### PR TITLE
feat(apis): add tools tab, detail pages, unify API base URL, fix midd…

### DIFF
--- a/app/[locale]/(home)/apis/[type]/[id]/page.tsx
+++ b/app/[locale]/(home)/apis/[type]/[id]/page.tsx
@@ -1,0 +1,39 @@
+import { setRequestLocale } from "next-intl/server";
+import { Footer } from "@/components/landing/sections/Footer";
+import { ApiDetailView } from "@/components/apis/api-detail-view";
+
+export default async function ApiDetailPage({
+  params,
+}: {
+  params: Promise<{ locale: string; type: string; id: string }>;
+}) {
+  const { locale, type, id } = await params;
+  setRequestLocale(locale);
+
+  if (type !== "models" && type !== "tools") {
+    return (
+      <div className="flex min-h-[calc(100vh-4rem)] flex-col">
+        <section className="mx-auto w-full max-w-7xl flex-1 px-4 pt-6 pb-4 sm:px-6">
+          <div className="text-center py-16">
+            <h1 className="text-2xl font-semibold mb-2">Invalid Type</h1>
+            <p className="text-muted-foreground">
+              The API type must be &quot;models&quot; or &quot;tools&quot;.
+            </p>
+          </div>
+        </section>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col">
+      <section className="mx-auto w-full max-w-7xl flex-1 px-4 pt-6 pb-4 sm:px-6">
+        <ApiDetailView />
+      </section>
+      <div className="shrink-0">
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/app/api/bitrouter/models/[id]/route.ts
+++ b/app/api/bitrouter/models/[id]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+const API_BASE = process.env.BITROUTER_API_BASE!;
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const decodedId = decodeURIComponent(id);
+
+    const res = await fetch(`${API_BASE}/models`, {
+      next: { revalidate: 300 },
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch models" },
+        { status: res.status },
+      );
+    }
+
+    const data = await res.json();
+    const model = data.data.find((m: { id: string }) => m.id === decodedId);
+
+    if (!model) {
+      return NextResponse.json(
+        { error: "Model not found" },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ data: model });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch model" },
+      { status: 502 },
+    );
+  }
+}

--- a/app/api/bitrouter/tools/[id]/route.ts
+++ b/app/api/bitrouter/tools/[id]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+const API_BASE = process.env.BITROUTER_API_BASE!;
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const decodedId = decodeURIComponent(id);
+
+    const res = await fetch(`${API_BASE}/tools`, {
+      next: { revalidate: 300 },
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch tools" },
+        { status: res.status },
+      );
+    }
+
+    const data = await res.json();
+    const tool = data.data.find((t: { id: string }) => t.id === decodedId);
+
+    if (!tool) {
+      return NextResponse.json(
+        { error: "Tool not found" },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ data: tool });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch tool" },
+      { status: 502 },
+    );
+  }
+}

--- a/app/api/bitrouter/tools/route.ts
+++ b/app/api/bitrouter/tools/route.ts
@@ -4,13 +4,13 @@ const API_BASE = process.env.BITROUTER_API_BASE!;
 
 export async function GET() {
   try {
-    const res = await fetch(`${API_BASE}/models`, {
-      next: { revalidate: 300 }, // cache 5 minutes
+    const res = await fetch(`${API_BASE}/tools`, {
+      next: { revalidate: 300 },
     });
 
     if (!res.ok) {
       return NextResponse.json(
-        { error: "Failed to fetch models" },
+        { error: "Failed to fetch tools" },
         { status: res.status },
       );
     }
@@ -19,7 +19,7 @@ export async function GET() {
     return NextResponse.json(data);
   } catch {
     return NextResponse.json(
-      { error: "Failed to fetch models" },
+      { error: "Failed to fetch tools" },
       { status: 502 },
     );
   }

--- a/app/api/bitrouter/volume/route.ts
+++ b/app/api/bitrouter/volume/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 
-// TODO: switch back to https://api.bitrouter.ai once custom domain SSL is resolved
-const API_BASE = "https://bitrouter-node-production.up.railway.app";
+const API_BASE = process.env.BITROUTER_API_BASE!;
 
 export async function GET() {
   const apiKey = process.env.BITROUTER_API_KEY;
@@ -14,7 +13,7 @@ export async function GET() {
   }
 
   try {
-    const res = await fetch(`${API_BASE}/v1/network/volume`, {
+    const res = await fetch(`${API_BASE}/network/volume`, {
       headers: { Authorization: `Bearer ${apiKey}` },
       next: { revalidate: 300 },
     });

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,7 +6,7 @@ export const maxDuration = 30;
 
 const bitrouter = createOpenAICompatible({
   name: "bitrouter",
-  baseURL: "https://api.bitrouter.ai/v1",
+  baseURL: process.env.BITROUTER_API_BASE!,
   apiKey: process.env.BITROUTER_API_KEY,
 });
 

--- a/components/apis/api-detail-view.tsx
+++ b/components/apis/api-detail-view.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+import Ai21 from "@lobehub/icons/es/Ai21";
+import Alibaba from "@lobehub/icons/es/Alibaba";
+import Anthropic from "@lobehub/icons/es/Anthropic";
+import Arcee from "@lobehub/icons/es/Arcee";
+import Baidu from "@lobehub/icons/es/Baidu";
+import ByteDance from "@lobehub/icons/es/ByteDance";
+import Cohere from "@lobehub/icons/es/Cohere";
+import DeepSeek from "@lobehub/icons/es/DeepSeek";
+import EssentialAI from "@lobehub/icons/es/EssentialAI";
+import Google from "@lobehub/icons/es/Google";
+import Inception from "@lobehub/icons/es/Inception";
+import Kwaipilot from "@lobehub/icons/es/Kwaipilot";
+import LongCat from "@lobehub/icons/es/LongCat";
+import Meta from "@lobehub/icons/es/Meta";
+import Minimax from "@lobehub/icons/es/Minimax";
+import Mistral from "@lobehub/icons/es/Mistral";
+import Moonshot from "@lobehub/icons/es/Moonshot";
+import Nova from "@lobehub/icons/es/Nova";
+import Nvidia from "@lobehub/icons/es/Nvidia";
+import OpenAI from "@lobehub/icons/es/OpenAI";
+import Qwen from "@lobehub/icons/es/Qwen";
+import Relace from "@lobehub/icons/es/Relace";
+import Stepfun from "@lobehub/icons/es/Stepfun";
+import Upstage from "@lobehub/icons/es/Upstage";
+import XAI from "@lobehub/icons/es/XAI";
+import XiaomiMiMo from "@lobehub/icons/es/XiaomiMiMo";
+import ZAI from "@lobehub/icons/es/ZAI";
+import type { ComponentType, SVGProps } from "react";
+
+type SvgIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+const PROVIDER_ICONS: Record<string, SvgIcon> = {
+  "ai21": Ai21,
+  "alibaba": Alibaba,
+  "anthropic": Anthropic,
+  "arcee-ai": Arcee,
+  "baidu": Baidu,
+  "bytedance-seed": ByteDance,
+  "cohere": Cohere,
+  "deepseek": DeepSeek,
+  "essentialai": EssentialAI,
+  "google": Google,
+  "inception": Inception,
+  "kwaipilot": Kwaipilot,
+  "meituan": LongCat,
+  "meta-llama": Meta,
+  "minimax": Minimax,
+  "mistralai": Mistral,
+  "moonshotai": Moonshot,
+  "amazon": Nova,
+  "nvidia": Nvidia,
+  "openai": OpenAI,
+  "qwen": Qwen,
+  "relace": Relace,
+  "stepfun": Stepfun,
+  "upstage": Upstage,
+  "x-ai": XAI,
+  "xiaomi": XiaomiMiMo,
+  "z-ai": ZAI,
+};
+
+function getProviderPrefix(modelId: string): string {
+  return modelId.includes("/") ? modelId.split("/")[0] : modelId.split("-")[0];
+}
+
+interface ModelData {
+  id: string;
+  name: string;
+  max_input_tokens: number;
+  max_output_tokens: number;
+  input_modalities?: string[];
+  output_modalities?: string[];
+  pricing: {
+    input_tokens: { no_cache: number };
+    output_tokens: { text: number };
+  };
+}
+
+interface ToolData {
+  id: string;
+  name: string;
+  description: string;
+  provider?: string;
+}
+
+export function ApiDetailView() {
+  const params = useParams();
+  const router = useRouter();
+  const type = params.type as string;
+  const id = params.id as string;
+
+  const [model, setModel] = useState<ModelData | null>(null);
+  const [tool, setTool] = useState<ToolData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedEndpoint, setCopiedEndpoint] = useState(false);
+  const [copiedCurl, setCopiedCurl] = useState(false);
+  const [copiedResponse, setCopiedResponse] = useState(false);
+
+  const decodedId = decodeURIComponent(id);
+
+  useEffect(() => {
+    if (type === "models") {
+      fetch(`/api/bitrouter/models/${encodeURIComponent(decodedId)}`)
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then((data: { data: ModelData }) => {
+          setModel(data.data);
+          setError(null);
+        })
+        .catch((err) => setError(err.message))
+        .finally(() => setLoading(false));
+    } else if (type === "tools") {
+      fetch(`/api/bitrouter/tools/${encodeURIComponent(decodedId)}`)
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then((data: { data: ToolData }) => {
+          setTool(data.data);
+          setError(null);
+        })
+        .catch((err) => setError(err.message))
+        .finally(() => setLoading(false));
+    }
+  }, [type, decodedId]);
+
+  const prefix = getProviderPrefix(decodedId);
+  const Icon = PROVIDER_ICONS[prefix];
+
+  const endpoint = `v1/chat/completions?model=${decodedId}`;
+  const curlExample = `curl https://your-endpoint.com/${endpoint} \\
+  -H "Authorization: Bearer $API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${decodedId}",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'`;
+
+  const responseExample = `{
+  "id": "chatcmpl-${Math.random().toString(36).substr(2, 9)}",
+  "object": "chat.completion",
+  "created": ${Date.now()},
+  "model": "${decodedId}",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hello! How can I help you today?"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 20,
+    "total_tokens": 30
+  }
+}`;
+
+  const copyToClipboard = (text: string, setCopied: (v: boolean) => void) => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <span className="text-sm text-muted-foreground animate-pulse">
+          Loading...
+        </span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-4">
+        <span className="text-sm text-red-400">{error}</span>
+        <Button variant="outline" size="sm" onClick={() => router.back()}>
+          Go Back
+        </Button>
+      </div>
+    );
+  }
+
+  const isTool = type === "tools";
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <Breadcrumb className="mb-6">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/apis">APIs</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={`/apis?tab=${type}`}>{type.charAt(0).toUpperCase() + type.slice(1)}</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage className="font-mono text-sm">{decodedId}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <Card className="mb-6">
+        <CardContent className="pt-6">
+          <div className="flex items-start gap-4">
+            <div className="shrink-0 w-12 h-12 rounded-lg bg-muted flex items-center justify-center">
+              {Icon ? (
+                <Icon className="w-6 h-6 text-muted-foreground" />
+              ) : (
+                <span className="text-lg font-semibold">
+                  {decodedId.charAt(0).toUpperCase()}
+                </span>
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <h1 className="text-xl font-semibold truncate">{decodedId}</h1>
+              <p className="text-sm text-muted-foreground mt-1">
+                {isTool
+                  ? tool?.description
+                  : model?.name || `Model by ${prefix}`}
+              </p>
+              <div className="flex flex-wrap gap-2 mt-3">
+                {!isTool &&
+                  model?.input_modalities?.map((modality) => (
+                    <Badge
+                      key={modality}
+                      variant="outline"
+                      className="text-xs font-normal"
+                    >
+                      {modality}
+                    </Badge>
+                  ))}
+                {isTool && tool?.provider && (
+                  <Badge variant="outline" className="text-xs font-normal">
+                    {tool.provider}
+                  </Badge>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {!isTool && model && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+          <Card>
+            <CardContent className="pt-4">
+              <p className="text-xs text-muted-foreground mb-1">Input Price</p>
+              <p className="text-lg font-semibold">
+                ${model.pricing?.input_tokens?.no_cache?.toFixed(2) ?? "—"}
+                <span className="text-xs font-normal text-muted-foreground">
+                  {" "}
+                  / 1M
+                </span>
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-4">
+              <p className="text-xs text-muted-foreground mb-1">Output Price</p>
+              <p className="text-lg font-semibold">
+                ${model.pricing?.output_tokens?.text?.toFixed(2) ?? "—"}
+                <span className="text-xs font-normal text-muted-foreground">
+                  {" "}
+                  / 1M
+                </span>
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-4">
+              <p className="text-xs text-muted-foreground mb-1">Max Input</p>
+              <p className="text-lg font-semibold">
+                {model.max_input_tokens > 0
+                  ? `${(model.max_input_tokens / 1000).toFixed(0)}k`
+                  : "—"}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-4">
+              <p className="text-xs text-muted-foreground mb-1">Max Output</p>
+              <p className="text-lg font-semibold">
+                {model.max_output_tokens > 0
+                  ? `${(model.max_output_tokens / 1000).toFixed(0)}k`
+                  : "—"}
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      <Card className="mb-6">
+        <CardContent className="pt-6">
+          <h2 className="text-sm font-medium mb-3">Endpoint</h2>
+          <div className="flex items-center gap-2 bg-muted rounded-md px-3 py-2">
+            <code className="flex-1 text-sm font-mono truncate">
+              {endpoint}
+            </code>
+            <button
+              onClick={() => copyToClipboard(endpoint, setCopiedEndpoint)}
+              className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+              title="Copy endpoint"
+            >
+              {copiedEndpoint ? (
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <polyline points="20 6 9 17 4 12" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              ) : (
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" strokeWidth="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" strokeWidth="2" />
+                </svg>
+              )}
+            </button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mb-6">
+        <CardContent className="pt-6">
+          <h2 className="text-sm font-medium mb-3">cURL Example</h2>
+          <div className="relative">
+            <pre className="bg-muted rounded-md px-3 py-3 text-xs font-mono overflow-x-auto whitespace-pre-wrap break-all">
+              {curlExample}
+            </pre>
+            <button
+              onClick={() => copyToClipboard(curlExample, setCopiedCurl)}
+              className="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition-colors bg-muted-foreground/10 hover:bg-muted-foreground/20 rounded p-1"
+              title="Copy cURL"
+            >
+              {copiedCurl ? (
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <polyline points="20 6 9 17 4 12" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              ) : (
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" strokeWidth="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" strokeWidth="2" />
+                </svg>
+              )}
+            </button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6">
+          <h2 className="text-sm font-medium mb-3">Response Format</h2>
+          <div className="relative">
+            <pre className="bg-muted rounded-md px-3 py-3 text-xs font-mono overflow-x-auto">
+              {responseExample}
+            </pre>
+            <button
+              onClick={() => copyToClipboard(responseExample, setCopiedResponse)}
+              className="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition-colors bg-muted-foreground/10 hover:bg-muted-foreground/20 rounded p-1"
+              title="Copy response"
+            >
+              {copiedResponse ? (
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <polyline points="20 6 9 17 4 12" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              ) : (
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" strokeWidth="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" strokeWidth="2" />
+                </svg>
+              )}
+            </button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/apis/apis-view.tsx
+++ b/components/apis/apis-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect, type ComponentType, type SVGProps } from "react";
+import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -74,7 +75,7 @@ function getProviderPrefix(modelId: string): string {
 
 type ApiTab = "models" | "tools" | "agents";
 // type TimeRange = "4w" | "12w" | "6m" | "1y";
-type SortKey = "volume" | "pricing" | "model";
+type SortKey = "volume" | "pricing" | "model" | "name";
 type SortDir = "asc" | "desc";
 
 interface ModelEntry {
@@ -109,6 +110,13 @@ interface ApiModelResponse {
     input_tokens: { no_cache: number };
     output_tokens: { text: number };
   };
+}
+
+interface ApiToolResponse {
+  id: string;
+  name: string;
+  description: string;
+  provider?: string;
 }
 
 // ── Provider colors (deterministic by model name) ────────
@@ -217,6 +225,20 @@ function sortModels(
   });
 }
 
+function sortTools(entries: ToolEntry[], key: SortKey, dir: SortDir): ToolEntry[] {
+  return [...entries].sort((a, b) => {
+    let cmp = 0;
+    switch (key) {
+      case "name":
+        cmp = a.name.localeCompare(b.name);
+        break;
+      default:
+        cmp = a.name.localeCompare(b.name);
+    }
+    return dir === "desc" ? -cmp : cmp;
+  });
+}
+
 // ── Data fetching hooks ──────────────────────────────────
 
 function useModels() {
@@ -252,6 +274,41 @@ function useModels() {
   return { models, loading, error };
 }
 
+interface ToolEntry {
+  id: string;
+  name: string;
+  description: string;
+  provider: string;
+}
+
+function useTools() {
+  const [tools, setTools] = useState<ToolEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/bitrouter/tools")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data: { data: ApiToolResponse[] }) => {
+        const entries: ToolEntry[] = data.data.map((t) => ({
+          id: t.id,
+          name: t.name,
+          description: t.description,
+          provider: t.provider ?? "custom",
+        }));
+        setTools(entries);
+        setError(null);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { tools, loading, error };
+}
+
 // function useVolume() {
 //   const [volume, setVolume] = useState<VolumeData | null>(null);
 //   const [loading, setLoading] = useState(true);
@@ -273,13 +330,14 @@ function useModels() {
 // ── Component ────────────────────────────────────────────
 
 export function ApisView() {
-  const [activeTab] = useState<ApiTab>("models");
+  const [activeTab, setActiveTab] = useState<ApiTab>("models");
   // const [timeRange, setTimeRange] = useState<TimeRange>("12w");
   const [search, setSearch] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("model");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
   const { models, loading: modelsLoading, error: modelsError } = useModels();
+  const { tools, loading: toolsLoading, error: toolsError } = useTools();
   // const { volume, loading: volumeLoading } = useVolume();
 
   // const hasVolumeData =
@@ -293,7 +351,7 @@ export function ApisView() {
   //   return volume.timeseries.slice(-weeks);
   // }, [timeRange, volume, hasVolumeData]);
 
-  const filtered = useMemo(() => {
+  const filteredModels = useMemo(() => {
     let list = models;
     if (search) {
       const q = search.toLowerCase();
@@ -306,12 +364,26 @@ export function ApisView() {
     return sortModels(list, sortKey, sortDir);
   }, [models, search, sortKey, sortDir]);
 
+  const filteredTools = useMemo(() => {
+    let list = tools;
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter(
+        (t) =>
+          t.name.toLowerCase().includes(q) ||
+          t.description.toLowerCase().includes(q) ||
+          t.provider.toLowerCase().includes(q),
+      );
+    }
+    return sortTools(list, sortKey, sortDir);
+  }, [tools, search, sortKey, sortDir]);
+
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
       setSortDir((d) => (d === "desc" ? "asc" : "desc"));
     } else {
       setSortKey(key);
-      setSortDir(key === "model" ? "asc" : "desc");
+      setSortDir(key === "model" || key === "name" ? "asc" : "desc");
     }
   };
 
@@ -323,17 +395,27 @@ export function ApisView() {
           <div className="flex flex-col gap-2 border-b border-border px-4 py-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-3">
               <div className="inline-flex border border-border rounded-md overflow-hidden">
-                <TabButton active={activeTab === "models"} disabled={false}>
+                <TabButton
+                  active={activeTab === "models"}
+                  disabled={false}
+                  onClick={() => {
+                    setActiveTab("models");
+                    setSearch("");
+                    setSortKey("model");
+                  }}
+                >
                   Models
                 </TabButton>
-                <TabButton active={false} disabled>
+                <TabButton
+                  active={activeTab === "tools"}
+                  disabled={false}
+                  onClick={() => {
+                    setActiveTab("tools");
+                    setSearch("");
+                    setSortKey("model");
+                  }}
+                >
                   Tools
-                  <Badge
-                    variant="outline"
-                    className="text-[9px] px-1.5 py-0 font-normal border-border ml-1.5"
-                  >
-                    soon
-                  </Badge>
                 </TabButton>
                 <TabButton active={false} disabled>
                   Agents
@@ -347,7 +429,11 @@ export function ApisView() {
               </div>
               <input
                 type="text"
-                placeholder="Search models or providers..."
+                placeholder={
+                  activeTab === "models"
+                    ? "Search models or providers..."
+                    : "Search tools..."
+                }
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className="bg-background border border-border rounded-md px-3 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-foreground/30 w-full sm:w-56 transition-colors"
@@ -355,7 +441,8 @@ export function ApisView() {
             </div>
             <div className="flex items-center gap-3">
               <span className="text-[11px] text-muted-foreground tabular-nums">
-                {models.length} models
+                {activeTab === "models" ? models.length : tools.length}{" "}
+                {activeTab === "models" ? "models" : "tools"}
               </span>
               {/* {hasVolumeData && (
                 <div className="inline-flex border border-border rounded-md overflow-hidden">
@@ -489,7 +576,7 @@ export function ApisView() {
                   </tr>
                 </thead>
                 <tbody>
-                  {filtered.map((entry, i) => (
+                  {filteredModels.map((entry, i) => (
                     <tr
                       key={entry.id}
                       className="border-b border-border/30 transition-colors hover:bg-muted/10"
@@ -511,7 +598,12 @@ export function ApisView() {
                               />
                             );
                           })()}
-                          <span className="font-medium">{entry.model}</span>
+                          <Link
+                            href={`/apis/models/${encodeURIComponent(entry.model)}`}
+                            className="font-medium hover:text-foreground/80 transition-colors"
+                          >
+                            {entry.model}
+                          </Link>
                           {entry.modalities.includes("image") && (
                             <Badge
                               variant="outline"
@@ -561,7 +653,7 @@ export function ApisView() {
                       </td>
                     </tr>
                   ))}
-                  {filtered.length === 0 && (
+                  {filteredModels.length === 0 && (
                     <tr>
                       <td
                         colSpan={5}
@@ -576,10 +668,98 @@ export function ApisView() {
             </div>
           )}
 
+          {/* Loading state */}
+          {toolsLoading && activeTab === "tools" && (
+            <div className="flex-1 flex items-center justify-center py-16">
+              <span className="text-xs text-muted-foreground animate-pulse">
+                Loading tools...
+              </span>
+            </div>
+          )}
+
+          {/* Error state */}
+          {toolsError && !toolsLoading && activeTab === "tools" && (
+            <div className="flex-1 flex items-center justify-center py-16">
+              <span className="text-xs text-red-400">
+                Failed to load tools: {toolsError}
+              </span>
+            </div>
+          )}
+
+          {/* Tools Table */}
+          {!toolsLoading && !toolsError && activeTab === "tools" && (
+            <div className="overflow-x-auto md:flex-1 md:min-h-0 md:overflow-y-auto">
+              <table className="w-full text-sm">
+                <thead className="md:sticky md:top-0 md:z-10 bg-card">
+                  <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                    <th className="px-4 py-2.5 font-medium w-8">#</th>
+                    <SortableHeader
+                      label="Tool"
+                      sortKey="name"
+                      activeSortKey={sortKey}
+                      sortDir={sortDir}
+                      onSort={handleSort}
+                      align="left"
+                    />
+                    <th className="px-4 py-2.5 font-medium text-left">
+                      Description
+                    </th>
+                    <th className="px-4 py-2.5 font-medium text-right">
+                      Provider
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredTools.map((entry, i) => (
+                    <tr
+                      key={entry.id}
+                      className="border-b border-border/30 transition-colors hover:bg-muted/10"
+                    >
+                      <td className="px-4 py-2.5 text-muted-foreground tabular-nums">
+                        {i + 1}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <Link
+                          href={`/apis/tools/${encodeURIComponent(entry.id)}`}
+                          className="font-medium hover:text-foreground/80 transition-colors"
+                        >
+                          {entry.name}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2.5 text-muted-foreground max-w-md truncate">
+                        {entry.description}
+                      </td>
+                      <td className="px-4 py-2.5 text-right">
+                        <Badge
+                          variant="outline"
+                          className="text-[10px] px-2 py-0 font-normal border-border"
+                        >
+                          {entry.provider}
+                        </Badge>
+                      </td>
+                    </tr>
+                  ))}
+                  {filteredTools.length === 0 && (
+                    <tr>
+                      <td
+                        colSpan={4}
+                        className="px-4 py-8 text-center text-muted-foreground text-xs"
+                      >
+                        No tools found.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+
           {/* Table footer */}
           <div className="shrink-0 flex items-center justify-between border-t border-border px-4 py-2.5">
             <span className="text-[11px] text-muted-foreground">
-              {filtered.length} of {models.length} models
+              {activeTab === "models"
+                ? `${filteredModels.length} of ${models.length} models`
+                : `${filteredTools.length} of ${tools.length} tools`}
               {search && ` · matching "${search}"`}
             </span>
             <span className="text-[11px] text-muted-foreground">
@@ -598,14 +778,17 @@ function TabButton({
   active,
   disabled,
   children,
+  onClick,
 }: {
   active: boolean;
   disabled: boolean;
   children: React.ReactNode;
+  onClick?: () => void;
 }) {
   return (
     <button
       disabled={disabled}
+      onClick={onClick}
       className={cn(
         "flex items-center px-4 py-2 text-xs border-r border-border last:border-r-0 transition-colors select-none",
         active && "bg-muted text-foreground font-medium",

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,0 +1,115 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<"nav"> & {
+    separator?: React.ReactNode
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />)
+Breadcrumb.displayName = "Breadcrumb"
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<"ol">
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
+      className
+    )}
+    {...props}
+  />
+))
+BreadcrumbList.displayName = "BreadcrumbList"
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<"li">
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn("inline-flex items-center gap-1.5", className)}
+    {...props}
+  />
+))
+BreadcrumbItem.displayName = "BreadcrumbItem"
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  )
+})
+BreadcrumbLink.displayName = "BreadcrumbLink"
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn("font-normal text-foreground", className)}
+    {...props}
+  />
+))
+BreadcrumbPage.displayName = "BreadcrumbPage"
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn("[&>svg]:h-3.5 [&>svg]:w-3.5", className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+)
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
+
+const BreadcrumbEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+)
+BreadcrumbEllipsis.displayName = "BreadcrumbEllipsis"
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/content/docs/overview/service-primitives.mdx
+++ b/content/docs/overview/service-primitives.mdx
@@ -2,7 +2,7 @@
 title: Models, Tools, & Agents
 ---
 
-Unlike common LLM aggregators that only unify models, BitRouter aggregates models, tools, and agents, allowing services to be composed and integrated in a highly flexible, agent-native manner.
+Unlike common LLM aggregators that only unify models, BitRouter aggregates **models**, **tools**, and **agents (coming soon)**, allowing services to be composed and integrated in a highly flexible, agent-native manner.
 
 ## Service Primitives
 
@@ -12,7 +12,7 @@ A single service can implement multiple primitives simultaneously.
 
 ### Models
 
-Model services provide LLM inference capabilities through OpenAI-compatible chat/completion endpoints.
+Model services provide LLM inference capabilities through OpenAI/Anthropic/Google-compatible endpoints (with openai-chat/completion as default)
 
 ```json
 // Request
@@ -79,36 +79,9 @@ Tool services expose functionality following the [MCP (Model Context Protocol)](
 }
 ```
 
-### Agents
+### Agents (coming soon)
 
-Agent services enable autonomous agent-to-agent communication following the [A2A (Agent2Agent)](https://a2a-protocol.org) standard via JSON-RPC 2.0 over HTTP.
-
-```json
-// Agent Card (capability discovery at /.well-known/agent.json)
-{
-  "name": "ResearchAgent",
-  "description": "Performs deep research and summarization",
-  "skills": [{ "id": "research_topic", "name": "Research Topic" }],
-  "protocolVersion": "0.3"
-}
-
-// Send task to agent
-POST /a2a
-{
-  "message": {
-    "messageId": "msg-123",
-    "role": "user",
-    "parts": [{ "text": "Research the latest advances in transformer architectures" }]
-  }
-}
-
-// Task response
-{
-  "id": "task-456",
-  "status": { "state": "completed" },
-  "artifacts": [{ "parts": [{ "text": "Summary: Recent advances include..." }] }]
-}
-```
+Agent services enable autonomous agent-to-agent communication following standards like the [A2A (Agent2Agent)](https://a2a-protocol.org) via JSON-RPC 2.0 over HTTP.
 
 ## Best Practices
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,5 +4,5 @@ import { routing } from "./i18n/routing";
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: ["/((?!api/|api$|_next|.*\\..*).*)"],
+  matcher: ["/((?!api/|api$|_next|[^/]*\\.[^/]*$).*)"],
 };


### PR DESCRIPTION
…leware

- Add tools tab with live data fetching and detail view pages
- Add model/tool detail pages with breadcrumb navigation
- Replace shadcn breadcrumb with official implementation (Slot support)
- Unify all API base URLs to BITROUTER_API_BASE env var
- Fix middleware matcher to allow dots in dynamic route params (e.g. gpt-4.1)
- Update service-primitives docs for current product state