### PR TITLE
Fix models API 404 by adding /v1/ prefix to endpoint path

### DIFF
--- a/app/api/bitrouter/models/[id]/route.ts
+++ b/app/api/bitrouter/models/[id]/route.ts
@@ -10,7 +10,7 @@ export async function GET(
     const { id } = await params;
     const decodedId = decodeURIComponent(id);
 
-    const res = await fetch(`${API_BASE}/models`, {
+    const res = await fetch(`${API_BASE}/v1/models`, {
       next: { revalidate: 300 },
     });
 

--- a/app/api/bitrouter/models/route.ts
+++ b/app/api/bitrouter/models/route.ts
@@ -4,7 +4,7 @@ const API_BASE = "https://api.bitrouter.ai";
 
 export async function GET() {
   try {
-    const res = await fetch(`${API_BASE}/models`, {
+    const res = await fetch(`${API_BASE}/v1/models`, {
       next: { revalidate: 300 }, // cache 5 minutes
     });
 


### PR DESCRIPTION
The API routes were fetching from /models instead of /v1/models on api.bitrouter.ai, causing 404 errors.

https://claude.ai/code/session_01KhKnRT9ELDHa8Ybwvbtzrq