### PR TITLE
Serve /install.sh and /install.ps1 as plain-text installer scripts

### DIFF
--- a/app/install.ps1/route.ts
+++ b/app/install.ps1/route.ts
@@ -1,0 +1,21 @@
+const INSTALLER_URL =
+  "https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.ps1";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const res = await fetch(INSTALLER_URL, { redirect: "follow" });
+  if (!res.ok) {
+    return new Response(`Failed to fetch installer: ${res.status}`, {
+      status: 502,
+    });
+  }
+  const body = await res.text();
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=300, s-maxage=300",
+    },
+  });
+}

--- a/app/install.ps1/route.ts
+++ b/app/install.ps1/route.ts
@@ -1,13 +1,12 @@
 const INSTALLER_URL =
   "https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.ps1";
 
-export const dynamic = "force-dynamic";
-
 export async function GET() {
   const res = await fetch(INSTALLER_URL, { redirect: "follow" });
   if (!res.ok) {
     return new Response(`Failed to fetch installer: ${res.status}`, {
       status: 502,
+      headers: { "Cache-Control": "no-store" },
     });
   }
   const body = await res.text();
@@ -15,7 +14,8 @@ export async function GET() {
     status: 200,
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
-      "Cache-Control": "public, max-age=300, s-maxage=300",
+      "Cache-Control":
+        "public, max-age=300, s-maxage=600, stale-while-revalidate=86400",
     },
   });
 }

--- a/app/install.sh/route.ts
+++ b/app/install.sh/route.ts
@@ -1,13 +1,12 @@
 const INSTALLER_URL =
   "https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.sh";
 
-export const dynamic = "force-dynamic";
-
 export async function GET() {
   const res = await fetch(INSTALLER_URL, { redirect: "follow" });
   if (!res.ok) {
     return new Response(`Failed to fetch installer: ${res.status}`, {
       status: 502,
+      headers: { "Cache-Control": "no-store" },
     });
   }
   const body = await res.text();
@@ -15,7 +14,8 @@ export async function GET() {
     status: 200,
     headers: {
       "Content-Type": "text/x-shellscript; charset=utf-8",
-      "Cache-Control": "public, max-age=300, s-maxage=300",
+      "Cache-Control":
+        "public, max-age=300, s-maxage=600, stale-while-revalidate=86400",
     },
   });
 }

--- a/app/install.sh/route.ts
+++ b/app/install.sh/route.ts
@@ -1,0 +1,21 @@
+const INSTALLER_URL =
+  "https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.sh";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const res = await fetch(INSTALLER_URL, { redirect: "follow" });
+  if (!res.ok) {
+    return new Response(`Failed to fetch installer: ${res.status}`, {
+      status: 502,
+    });
+  }
+  const body = await res.text();
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/x-shellscript; charset=utf-8",
+      "Cache-Control": "public, max-age=300, s-maxage=300",
+    },
+  });
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ const nextConfig: NextConfig = {
       { source: "/docs", destination: "/docs/overview", permanent: false },
       { source: "/zh/docs", destination: "/zh/docs/overview", permanent: false },
       { source: "/install.sh", destination: "https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.sh", permanent: false },
+      { source: "/install.ps1", destination: "https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.ps1", permanent: false },
       { source: "/apis", destination: "/llms", permanent: true },
       { source: "/apis/models/:id*", destination: "/llms/:id*", permanent: true },
     ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,8 +10,6 @@ const nextConfig: NextConfig = {
     return [
       { source: "/docs", destination: "/docs/overview", permanent: false },
       { source: "/zh/docs", destination: "/zh/docs/overview", permanent: false },
-      { source: "/install.sh", destination: "https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.sh", permanent: false },
-      { source: "/install.ps1", destination: "https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.ps1", permanent: false },
       { source: "/apis", destination: "/llms", permanent: true },
       { source: "/apis/models/:id*", destination: "/llms/:id*", permanent: true },
     ];


### PR DESCRIPTION
Replaces the previous redirect-based approach for `/install.sh` and `/install.ps1` with Next.js route handlers that fetch the latest installer from the `bitrouter/bitrouter` GitHub release and return the script body directly as text.

This way `curl https://bitrouter.ai/install.sh | sh` works as expected, instead of curl printing `Redirecting...`.

- `app/install.sh/route.ts` → fetches `bitrouter-installer.sh`, returns `text/x-shellscript`
- `app/install.ps1/route.ts` → fetches `bitrouter-installer.ps1`, returns `text/plain`
- Removed the corresponding `/install.*` redirects from `next.config.ts`
- Both still resolve via GitHub's `releases/latest/download/...` URL, so they always serve the newest release
- Responses are cached for 5 minutes (`max-age=300`)