### PR TITLE
docs(features): add Fusion, Sub-agent, and Advisor server-tool pages

### DIFF
--- a/content/docs/features/advisor.mdx
+++ b/content/docs/features/advisor.mdx
@@ -1,0 +1,99 @@
+---
+title: Advisor
+description: Consult a stronger model mid-task — the calling model asks a self-contained question and gets back advice to act on, without handing off the whole job.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+**Advisor** is a server tool: BitRouter runs it mid-generation instead of handing the call back to your client. When the calling model hits something it's unsure about, it asks a stronger advisor model a self-contained question and gets back advice to act on — without delegating the whole task. Use it to let a fast, cheap main model escalate just the hard sub-questions to a stronger model.
+
+## Quick start
+
+Enable the advisor by declaring `advisor` on the request `tools` array. The declaration pins the advisor model and instructions; at call time the model asks its question:
+
+<Tabs items={['Responses API', 'Anthropic Messages']}>
+<Tab value="Responses API">
+
+```bash
+curl https://api.bitrouter.ai/v1/responses \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-haiku-4.5",
+    "input": "Refactor this auth module. Ask the advisor before changing the token-rotation logic.",
+    "tools": [
+      {
+        "type": "advisor",
+        "model": "anthropic/claude-opus-4.8",
+        "instructions": "You are a senior security engineer. Be precise about auth edge cases."
+      }
+    ]
+  }'
+```
+
+</Tab>
+<Tab value="Anthropic Messages">
+
+```bash
+curl https://api.bitrouter.ai/v1/messages \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-haiku-4.5",
+    "max_tokens": 4096,
+    "messages": [
+      {"role": "user", "content": "Refactor this auth module. Ask the advisor before changing the token-rotation logic."}
+    ],
+    "tools": [
+      {
+        "type": "advisor",
+        "name": "advisor",
+        "model": "anthropic/claude-opus-4.8",
+        "instructions": "You are a senior security engineer. Be precise about auth edge cases."
+      }
+    ]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="warning">
+**Protocol support.** The `advisor` declaration works on the **OpenAI Responses API** (`/v1/responses`) and the **Anthropic Messages API** (`/v1/messages`), which both carry server tools on the wire. The **Chat Completions** `tools` array only accepts `{type:"function"}` entries and cannot carry the declaration.
+</Callout>
+
+## How it works
+
+When the calling model invokes the tool, it supplies:
+
+| Argument | Description |
+| --- | --- |
+| `prompt` | A clear, self-contained question for the advisor. |
+| `model` | Optional per-call override of the advisor model. |
+
+The advisor answers and its advice is returned to the calling model, which then continues the task. Unlike [Sub-agent](/docs/features/subagent), the advisor doesn't take over the work — it just answers a question.
+
+## Configuration
+
+Declared on the `tools`-array entry:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `model` | string | The advisor model. An absent value falls back to the per-call `model` arg, then the parent request model. |
+| `instructions` | string | System instructions for the advisor. |
+| `tools` | array | Provider server tools the advisor may use (e.g. web search), in provider-namespaced declaration form. |
+
+<Callout type="info">
+**Bounded by the server-tool loop.** An advisor turn runs inside a bounded loop — a default of 10 tool rounds, 30s per tool, and a 120s total budget per turn.
+</Callout>
+
+## On Cloud
+
+Advisor is enabled and managed on **BitRouter Cloud**, with per-run cost for the advisor calls visible in the request log. Self-hosters enable it with `server_tools.advisor: true`; it is then advertised per-request only when the caller declares it.
+
+## See also
+
+- [Sub-agent](/docs/features/subagent) — delegate a self-contained task instead of asking a question
+- [Fusion](/docs/features/fusion) — deliberate across a panel of models on one prompt
+- [Model variants](/docs/features/model-variants) — address a stronger variant of a model as the advisor

--- a/content/docs/features/advisor.zh.mdx
+++ b/content/docs/features/advisor.zh.mdx
@@ -1,0 +1,99 @@
+---
+title: Advisor
+description: 在任务中途咨询一个更强的模型——发起调用的模型提出一个自包含的问题并取回可据以行动的建议，而无需把整个任务交出去。
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+**Advisor** 是一个服务端工具（server tool）：BitRouter 在生成过程中自行执行它，而不是把调用交还给你的客户端。当发起调用的模型遇到拿不准的地方时，它会向一个更强的顾问模型提出一个自包含的问题，并取回可据以行动的建议——而不必委派整个任务。用它让一个快速、廉价的主模型，把那些难啃的子问题升级给更强的模型。
+
+## 快速示例
+
+在请求的 `tools` 数组上声明 `advisor` 即可启用顾问模型。声明会固定顾问模型与指令；在调用时由模型提出它的问题：
+
+<Tabs items={['Responses API', 'Anthropic Messages']}>
+<Tab value="Responses API">
+
+```bash
+curl https://api.bitrouter.ai/v1/responses \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-haiku-4.5",
+    "input": "重构这个 auth 模块。在改动 token 轮换逻辑之前先咨询 advisor。",
+    "tools": [
+      {
+        "type": "advisor",
+        "model": "anthropic/claude-opus-4.8",
+        "instructions": "你是一名资深安全工程师。对认证边界情况要表述精确。"
+      }
+    ]
+  }'
+```
+
+</Tab>
+<Tab value="Anthropic Messages">
+
+```bash
+curl https://api.bitrouter.ai/v1/messages \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-haiku-4.5",
+    "max_tokens": 4096,
+    "messages": [
+      {"role": "user", "content": "重构这个 auth 模块。在改动 token 轮换逻辑之前先咨询 advisor。"}
+    ],
+    "tools": [
+      {
+        "type": "advisor",
+        "name": "advisor",
+        "model": "anthropic/claude-opus-4.8",
+        "instructions": "你是一名资深安全工程师。对认证边界情况要表述精确。"
+      }
+    ]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="warning">
+**协议支持。** `advisor` 声明适用于 **OpenAI Responses API**（`/v1/responses`）与 **Anthropic Messages API**（`/v1/messages`），二者都能在传输层承载服务端工具。**Chat Completions** 的 `tools` 数组只接受 `{type:"function"}` 条目，无法承载该声明。
+</Callout>
+
+## 工作原理
+
+当发起调用的模型调用该工具时，它会提供：
+
+| 参数 | 说明 |
+| --- | --- |
+| `prompt` | 给顾问的一个清晰、自包含的问题。 |
+| `model` | 可选，按本次调用覆盖顾问模型。 |
+
+顾问作答，其建议返回给发起调用的模型，后者随即继续任务。与 [Sub-agent](/docs/features/subagent) 不同，顾问不会接管工作——它只回答一个问题。
+
+## 配置
+
+声明在 `tools` 数组的条目上：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `model` | 字符串 | 顾问模型。缺省时回退到本次调用的 `model` 参数，再回退到父请求模型。 |
+| `instructions` | 字符串 | 给顾问的系统指令。 |
+| `tools` | 数组 | 顾问可使用的供应商服务端工具（如网页搜索），以供应商命名空间的声明形式给出。 |
+
+<Callout type="info">
+**受服务端工具循环约束。** 一次 advisor 调用运行在一个有界循环中——默认 10 个工具轮次、单工具 30 秒、每轮总预算 120 秒。
+</Callout>
+
+## 在云端
+
+Advisor 在 **BitRouter Cloud** 上开箱即用并由平台托管，顾问调用的每次运行成本都可在请求日志中查看。自托管用户用 `server_tools.advisor: true` 启用；启用后，仅当调用方声明它时才会在该请求上对外公开。
+
+## 另见
+
+- [Sub-agent](/docs/features/subagent) —— 委派一个自包含的任务，而非提一个问题
+- [Fusion](/docs/features/fusion) —— 让一组模型对同一个提示词进行评议
+- [模型变体](/docs/features/model-variants) —— 用某个模型的更强变体作为顾问

--- a/content/docs/features/fusion.mdx
+++ b/content/docs/features/fusion.mdx
@@ -1,0 +1,95 @@
+---
+title: Fusion
+description: Multi-model deliberation — a panel of models answers in parallel, a judge compares their answers, and your model writes the final reply from structured analysis.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+**Fusion** is a server tool: BitRouter runs it mid-generation instead of handing the call back to your client. A **panel** of models answers your prompt in parallel, a **judge** model compares (not merges) their answers into structured analysis, and the calling model writes the final answer grounded in that analysis. Use it for hard, high-stakes questions where one model's blind spots are worth catching.
+
+## Quick start
+
+The simplest way to use Fusion is the `bitrouter/fusion` **model alias** — set it as your `model` and BitRouter expands it into a deliberation using your deployment's default panel and judge. This works on any protocol, including Chat Completions:
+
+<Tabs items={['Model alias (cURL)', 'Explicit panel (Responses)']}>
+<Tab value="Model alias (cURL)">
+
+```bash
+curl https://api.bitrouter.ai/v1/chat/completions \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bitrouter/fusion",
+    "messages": [
+      {"role": "user", "content": "Should we migrate our event pipeline from Kafka to a managed alternative? Trade-offs."}
+    ]
+  }'
+```
+
+The alias rewrites the request onto a default outer model, attaches the Fusion declaration, and nudges the model to call the tool once. You get back a single, deliberated answer.
+
+</Tab>
+<Tab value="Explicit panel (Responses)">
+
+Declare Fusion yourself to pick the exact panel, judge, and (optionally) a dedicated synthesizer. Fusion rides the request `tools` array as a server tool:
+
+```bash
+curl https://api.bitrouter.ai/v1/responses \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-opus-4.8",
+    "input": "Should we migrate our event pipeline from Kafka to a managed alternative?",
+    "tools": [
+      {
+        "type": "fusion",
+        "panel": [
+          {"model": "anthropic/claude-opus-4.8"},
+          {"model": "openai/gpt-5.5"},
+          {"model": "google/gemini-3-pro-preview"}
+        ],
+        "judge": {"model": "anthropic/claude-opus-4.8"}
+      }
+    ]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="warning">
+**Protocol support.** The explicit `tools`-array declaration works on the **OpenAI Responses API** (`/v1/responses`) and the **Anthropic Messages API** (`/v1/messages`), which both carry server tools on the wire. The **Chat Completions** `tools` array only accepts `{type:"function"}` entries, so declare Fusion there with the **`bitrouter/fusion` model alias** instead.
+</Callout>
+
+## How it works
+
+1. **Panel** — every model in the panel answers your prompt in parallel. Each member can be given provider web tools (e.g. web search) to ground its answer.
+2. **Judge** — the judge model compares the panel's answers and returns structured analysis: `consensus`, `contradictions`, `partial_coverage`, `unique_insights`, and `blind_spots`. The judge **compares, it does not merge** — it surfaces where the models agree and disagree rather than blending them into mush.
+3. **Synthesis** — the calling model (or a dedicated `synthesizer`) reads that analysis and writes the final answer.
+
+## Configuration
+
+Declared on the `tools`-array entry:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `panel` | array | One entry per model answering in parallel. Each is `{ "model": string, "tools"?: array }`, where `tools` are provider web tools forwarded to that member. Defaults to a single member on the request model. Capped at **8** members. |
+| `judge` | object | `{ "model": string }` — the model that compares the panel answers. Defaults to the request model. |
+| `synthesizer` | string | Optional dedicated model to write the final answer. When omitted, the calling model writes it from the returned analysis. |
+
+The deployment-wide defaults that the `bitrouter/fusion` alias expands to — panel, judge, synthesizer, and the web tools forwarded to every member — are set in the `server_tools.fusion` config section. An explicit declaration on a request overrides them.
+
+<Callout type="info">
+**Bounded by the server-tool loop.** Like all server tools, a Fusion turn runs inside a bounded loop — a default of 10 tool rounds, 30s per tool, and a 120s total budget per turn. A panel that exceeds the budget terminates with a truncation finish reason.
+</Callout>
+
+## On Cloud
+
+Fusion is enabled and managed on **BitRouter Cloud** — a curated default panel and judge back the `bitrouter/fusion` alias out of the box, with per-run cost and the full panel→judge→synthesis chain visible in the request log. Self-hosters enable it by adding a `server_tools.fusion` block to their config (its presence turns on both the `fusion` server tool and the `bitrouter/fusion` alias).
+
+## See also
+
+- [Sub-agent](/docs/features/subagent) — delegate a self-contained task to a single worker model
+- [Advisor](/docs/features/advisor) — consult one stronger model mid-task
+- [Provider selection](/docs/features/provider-selection) — control which provider serves each panel model

--- a/content/docs/features/fusion.zh.mdx
+++ b/content/docs/features/fusion.zh.mdx
@@ -1,0 +1,95 @@
+---
+title: Fusion
+description: 多模型协同评议——一组模型并行作答，由裁判模型比对各自的答案，再由你的模型基于结构化分析写出最终回复。
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+**Fusion** 是一个服务端工具（server tool）：BitRouter 在生成过程中自行执行它，而不是把调用交还给你的客户端。一组**面板（panel）**模型并行回答你的提示词，一个**裁判（judge）**模型把它们的答案比对（而非合并）成结构化分析，最后由发起调用的模型基于该分析写出最终答案。适用于那些高难度、高风险、单个模型的盲点值得被发现的问题。
+
+## 快速示例
+
+使用 Fusion 最简单的方式是 `bitrouter/fusion` **模型别名**——把它设为 `model`，BitRouter 就会用你部署的默认面板与裁判把请求展开为一次评议。该方式适用于任何协议，包括 Chat Completions：
+
+<Tabs items={['模型别名 (cURL)', '显式面板 (Responses)']}>
+<Tab value="模型别名 (cURL)">
+
+```bash
+curl https://api.bitrouter.ai/v1/chat/completions \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bitrouter/fusion",
+    "messages": [
+      {"role": "user", "content": "我们是否应该把事件管道从 Kafka 迁移到托管方案？请分析权衡。"}
+    ]
+  }'
+```
+
+别名会把请求改写到一个默认的外层模型上，附加 Fusion 声明，并提示模型调用一次该工具。你会得到一个经过评议的单一答案。
+
+</Tab>
+<Tab value="显式面板 (Responses)">
+
+自行声明 Fusion，即可精确指定面板、裁判，以及（可选的）专用合成器（synthesizer）。Fusion 以服务端工具的形式挂在请求的 `tools` 数组上：
+
+```bash
+curl https://api.bitrouter.ai/v1/responses \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-opus-4.8",
+    "input": "我们是否应该把事件管道从 Kafka 迁移到托管方案？",
+    "tools": [
+      {
+        "type": "fusion",
+        "panel": [
+          {"model": "anthropic/claude-opus-4.8"},
+          {"model": "openai/gpt-5.5"},
+          {"model": "google/gemini-3-pro-preview"}
+        ],
+        "judge": {"model": "anthropic/claude-opus-4.8"}
+      }
+    ]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="warning">
+**协议支持。** `tools` 数组的显式声明适用于 **OpenAI Responses API**（`/v1/responses`）与 **Anthropic Messages API**（`/v1/messages`），二者都能在传输层承载服务端工具。**Chat Completions** 的 `tools` 数组只接受 `{type:"function"}` 条目，因此在该协议下请改用 **`bitrouter/fusion` 模型别名** 来声明 Fusion。
+</Callout>
+
+## 工作原理
+
+1. **面板** —— 面板中的每个模型并行回答你的提示词。每个成员都可以配备供应商提供的网络工具（如网页搜索）来为其答案提供依据。
+2. **裁判** —— 裁判模型比对面板的各份答案，返回结构化分析：`consensus`（共识）、`contradictions`（矛盾）、`partial_coverage`（部分覆盖）、`unique_insights`（独特洞见）与 `blind_spots`（盲点）。裁判**只比对、不合并**——它呈现各模型在哪里一致、在哪里分歧，而不是把它们糅成一团。
+3. **合成** —— 发起调用的模型（或专用的 `synthesizer`）读取该分析，写出最终答案。
+
+## 配置
+
+声明在 `tools` 数组的条目上：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `panel` | 数组 | 每个并行作答的模型一项。每项为 `{ "model": string, "tools"?: array }`，其中 `tools` 是转发给该成员的供应商网络工具。默认为请求模型上的单成员面板。上限为 **8** 个成员。 |
+| `judge` | 对象 | `{ "model": string }` —— 比对面板答案的模型。默认为请求模型。 |
+| `synthesizer` | 字符串 | 可选的专用模型，用于写出最终答案。省略时，由发起调用的模型基于返回的分析来撰写。 |
+
+`bitrouter/fusion` 别名展开时所用的部署级默认值——面板、裁判、合成器，以及转发给每个成员的网络工具——在 `server_tools.fusion` 配置段中设置。请求上的显式声明会覆盖它们。
+
+<Callout type="info">
+**受服务端工具循环约束。** 与所有服务端工具一样，一次 Fusion 调用运行在一个有界循环中——默认 10 个工具轮次、单工具 30 秒、每轮总预算 120 秒。超出预算的面板会以截断（truncation）结束原因终止。
+</Callout>
+
+## 在云端
+
+Fusion 在 **BitRouter Cloud** 上开箱即用并由平台托管——一套精选的默认面板与裁判支撑着 `bitrouter/fusion` 别名，每次运行的成本以及完整的「面板→裁判→合成」调用链都可在请求日志中查看。自托管用户只需在配置中添加 `server_tools.fusion` 段即可启用（其存在会同时开启 `fusion` 服务端工具与 `bitrouter/fusion` 别名）。
+
+## 另见
+
+- [Sub-agent](/docs/features/subagent) —— 把一个自包含的任务委派给单个工作模型
+- [Advisor](/docs/features/advisor) —— 在任务中途咨询一个更强的模型
+- [供应商选择](/docs/features/provider-selection) —— 控制由哪个供应商承接每个面板模型

--- a/content/docs/features/meta.json
+++ b/content/docs/features/meta.json
@@ -2,5 +2,5 @@
   "title": "Features",
   "icon": "Boxes",
   "defaultOpen": false,
-  "pages": ["provider-selection", "model-fallback", "model-variants", "presets", "structured-outputs", "byok", "local-models", "guardrails", "observability", "mcp", "acp", "agentskills"]
+  "pages": ["provider-selection", "model-fallback", "model-variants", "presets", "structured-outputs", "fusion", "subagent", "advisor", "byok", "local-models", "guardrails", "observability", "mcp", "acp", "agentskills"]
 }

--- a/content/docs/features/subagent.mdx
+++ b/content/docs/features/subagent.mdx
@@ -1,0 +1,99 @@
+---
+title: Sub-agent
+description: Delegate a self-contained task to a focused worker model mid-generation — the worker sees only what you give it and returns its final result.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+**Sub-agent** is a server tool: BitRouter runs it mid-generation instead of handing the call back to your client. The calling model hands off a self-contained task — `task_name` and `task_description` — to a focused worker model (typically a cheaper or faster one), which works in isolation and returns only its final result. Use it to fan out grunt work without spending the main model's context on it.
+
+## Quick start
+
+Enable the worker by declaring `subagent` on the request `tools` array. The declaration pins the worker model and instructions; at call time the model fills in the task:
+
+<Tabs items={['Responses API', 'Anthropic Messages']}>
+<Tab value="Responses API">
+
+```bash
+curl https://api.bitrouter.ai/v1/responses \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-opus-4.8",
+    "input": "Summarize each of these 20 support tickets, then group them by theme.",
+    "tools": [
+      {
+        "type": "subagent",
+        "model": "anthropic/claude-haiku-4.5",
+        "instructions": "You are a concise summarizer. Return one sentence per ticket."
+      }
+    ]
+  }'
+```
+
+</Tab>
+<Tab value="Anthropic Messages">
+
+```bash
+curl https://api.bitrouter.ai/v1/messages \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-opus-4.8",
+    "max_tokens": 4096,
+    "messages": [
+      {"role": "user", "content": "Summarize each of these 20 support tickets, then group them by theme."}
+    ],
+    "tools": [
+      {
+        "type": "subagent",
+        "name": "subagent",
+        "model": "anthropic/claude-haiku-4.5",
+        "instructions": "You are a concise summarizer. Return one sentence per ticket."
+      }
+    ]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="warning">
+**Protocol support.** The `subagent` declaration works on the **OpenAI Responses API** (`/v1/responses`) and the **Anthropic Messages API** (`/v1/messages`), which both carry server tools on the wire. The **Chat Completions** `tools` array only accepts `{type:"function"}` entries and cannot carry the declaration.
+</Callout>
+
+## How it works
+
+When the calling model invokes the tool, it supplies:
+
+| Argument | Description |
+| --- | --- |
+| `task_name` | A short identifier for the task. |
+| `task_description` | The full, self-contained task: context, inputs, and expected output. |
+
+The worker model sees **only** the `task_description` — no other conversation context — runs the task, and its final result is returned to the calling model. Because the worker is isolated, the calling model must put everything the worker needs into the description.
+
+## Configuration
+
+Declared on the `tools`-array entry:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `model` | string | The worker model. Defaults to the parent request model. |
+| `instructions` | string | System instructions for the worker. |
+| `tools` | array | Provider server tools the worker may use (e.g. web search), in provider-namespaced declaration form. |
+
+<Callout type="info">
+**Bounded by the server-tool loop.** A sub-agent turn runs inside a bounded loop — a default of 10 tool rounds, 30s per tool, and a 120s total budget per turn.
+</Callout>
+
+## On Cloud
+
+Sub-agent is enabled and managed on **BitRouter Cloud**, with per-run cost for the worker calls visible in the request log. Self-hosters enable it with `server_tools.subagent: true`; it is then advertised per-request only when the caller declares it.
+
+## See also
+
+- [Advisor](/docs/features/advisor) — consult a stronger model for guidance instead of delegating a task
+- [Fusion](/docs/features/fusion) — deliberate across a panel of models on one prompt
+- [Provider selection](/docs/features/provider-selection) — control which provider serves the worker model

--- a/content/docs/features/subagent.zh.mdx
+++ b/content/docs/features/subagent.zh.mdx
@@ -1,0 +1,99 @@
+---
+title: Sub-agent
+description: 在生成过程中把一个自包含的任务委派给专注的工作模型——工作模型只看到你给它的内容，并返回最终结果。
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+**Sub-agent** 是一个服务端工具（server tool）：BitRouter 在生成过程中自行执行它，而不是把调用交还给你的客户端。发起调用的模型把一个自包含的任务——`task_name` 与 `task_description`——交给一个专注的工作模型（通常更便宜或更快），后者在隔离环境中完成任务并仅返回最终结果。用它把繁琐的体力活分发出去，而不占用主模型的上下文。
+
+## 快速示例
+
+在请求的 `tools` 数组上声明 `subagent` 即可启用工作模型。声明会固定工作模型与指令；在调用时由模型填入具体任务：
+
+<Tabs items={['Responses API', 'Anthropic Messages']}>
+<Tab value="Responses API">
+
+```bash
+curl https://api.bitrouter.ai/v1/responses \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-opus-4.8",
+    "input": "为这 20 张支持工单各写一句摘要，然后按主题分组。",
+    "tools": [
+      {
+        "type": "subagent",
+        "model": "anthropic/claude-haiku-4.5",
+        "instructions": "你是一个简洁的摘要器。每张工单返回一句话。"
+      }
+    ]
+  }'
+```
+
+</Tab>
+<Tab value="Anthropic Messages">
+
+```bash
+curl https://api.bitrouter.ai/v1/messages \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "anthropic/claude-opus-4.8",
+    "max_tokens": 4096,
+    "messages": [
+      {"role": "user", "content": "为这 20 张支持工单各写一句摘要，然后按主题分组。"}
+    ],
+    "tools": [
+      {
+        "type": "subagent",
+        "name": "subagent",
+        "model": "anthropic/claude-haiku-4.5",
+        "instructions": "你是一个简洁的摘要器。每张工单返回一句话。"
+      }
+    ]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="warning">
+**协议支持。** `subagent` 声明适用于 **OpenAI Responses API**（`/v1/responses`）与 **Anthropic Messages API**（`/v1/messages`），二者都能在传输层承载服务端工具。**Chat Completions** 的 `tools` 数组只接受 `{type:"function"}` 条目，无法承载该声明。
+</Callout>
+
+## 工作原理
+
+当发起调用的模型调用该工具时，它会提供：
+
+| 参数 | 说明 |
+| --- | --- |
+| `task_name` | 任务的简短标识。 |
+| `task_description` | 完整、自包含的任务：上下文、输入与期望输出。 |
+
+工作模型**只**看到 `task_description`——没有任何其他对话上下文——执行任务，其最终结果返回给发起调用的模型。由于工作模型是隔离的，发起调用的模型必须把工作模型所需的一切都写进描述里。
+
+## 配置
+
+声明在 `tools` 数组的条目上：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `model` | 字符串 | 工作模型。默认为父请求模型。 |
+| `instructions` | 字符串 | 给工作模型的系统指令。 |
+| `tools` | 数组 | 工作模型可使用的供应商服务端工具（如网页搜索），以供应商命名空间的声明形式给出。 |
+
+<Callout type="info">
+**受服务端工具循环约束。** 一次 sub-agent 调用运行在一个有界循环中——默认 10 个工具轮次、单工具 30 秒、每轮总预算 120 秒。
+</Callout>
+
+## 在云端
+
+Sub-agent 在 **BitRouter Cloud** 上开箱即用并由平台托管，工作模型调用的每次运行成本都可在请求日志中查看。自托管用户用 `server_tools.subagent: true` 启用；启用后，仅当调用方声明它时才会在该请求上对外公开。
+
+## 另见
+
+- [Advisor](/docs/features/advisor) —— 咨询一个更强的模型获取建议，而非委派整个任务
+- [Fusion](/docs/features/fusion) —— 让一组模型对同一个提示词进行评议
+- [供应商选择](/docs/features/provider-selection) —— 控制由哪个供应商承接工作模型


### PR DESCRIPTION
## What

Adds three new **Features** pages documenting BitRouter's built-in **server tools** — tools the router executes mid-generation rather than handing back to the client:

| Page | Tool | Summary |
|---|---|---|
| Fusion | `fusion` | Multi-model panel answers in parallel → judge compares (not merges) → caller writes the final answer. Also usable via the `bitrouter/fusion` model alias. |
| Sub-agent | `subagent` | Delegate a self-contained task (`task_name` / `task_description`) to an isolated worker model; only its final result returns. |
| Advisor | `advisor` | Consult a stronger model mid-task with a self-contained `prompt`; get advice back without handing off the whole job. |

Source: these tools live in `crates/bitrouter-sdk/src/language_model/server_tools/` (consolidated in #576, Fusion added in #574).

## Page contents

Each page is solid-but-focused: per-protocol quick start, how-it-works, a config-reference table, the server-tool loop bounds (10 rounds / 30s per tool / 120s per turn), and an **On Cloud** note mirroring the `guardrails`/`observability` pattern.

## Accuracy notes

- **Protocol-support caveat** on every page: declarations ride the `tools` array on the **OpenAI Responses** and **Anthropic Messages** APIs; **Chat Completions** can't carry them (Fusion still works there via the `bitrouter/fusion` alias).
- **Model slugs verified** against `.models-snapshot.json` — swapped two placeholders for real slugs (`openai/gpt-5.5`, `google/gemini-3-pro-preview`).

## Scope

- 6 new files: `fusion`, `subagent`, `advisor` × (`.mdx` + `.zh.mdx`)
- `meta.json` orders the trio right after `structured-outputs`
- All six routes verified locally (HTTP 200, clean compile, zh renders real Chinese)

🤖 Generated with [Claude Code](https://claude.com/claude-code)