### PR TITLE
seo: expand sitemap, dedupe JSON-LD, broaden crawler allow-list

### DIFF
--- a/app/(home)/careers/page.tsx
+++ b/app/(home)/careers/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function CareersPage() {
-  redirect("/about");
-}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,22 +1,59 @@
 import type { MetadataRoute } from "next";
 
+// Crawler policy. Everything public is open; only the app's POST/JSON API
+// routes are withheld (except /api/docs/* — the markdown + llms-full feeds we
+// *want* crawlers and agents to ingest).
+const ALLOW = ["/", "/docs/", "/api/docs/"];
+const DISALLOW = ["/api/"];
+
+// AI answer engines + search crawlers we explicitly welcome (GEO/SEO). All are
+// already covered by `*`, but listing them records intent and keeps them open
+// if the `*` group is ever tightened. Grouped by operator for maintainability.
+const AI_AND_SEARCH_BOTS = [
+  // OpenAI
+  "GPTBot", // training
+  "OAI-SearchBot", // ChatGPT search index
+  "ChatGPT-User", // live fetch when a user asks ChatGPT about a page
+  // Anthropic
+  "ClaudeBot", // training
+  "anthropic-ai",
+  "Claude-User", // live fetch for Claude
+  "Claude-SearchBot",
+  // Google / Bing search + AI
+  "Googlebot",
+  "Google-Extended", // Gemini / Vertex grounding
+  "Bingbot",
+  // Perplexity
+  "PerplexityBot",
+  "Perplexity-User",
+  // Others
+  "Amazonbot",
+  "Applebot",
+  "Applebot-Extended",
+  "cohere-ai",
+  "CCBot", // Common Crawl — feeds many open models
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
         userAgent: "*",
-        allow: ["/", "/docs/", "/api/docs/"],
-        disallow: ["/api/"],
+        allow: ALLOW,
+        disallow: DISALLOW,
       },
       {
-        userAgent: [
-          "GPTBot",
-          "ClaudeBot",
-          "anthropic-ai",
-          "PerplexityBot",
-          "Google-Extended",
-        ],
-        allow: ["/"],
+        userAgent: AI_AND_SEARCH_BOTS,
+        allow: ALLOW,
+        disallow: DISALLOW,
+      },
+      // Stripe's merchant/compliance crawler. Not an SEO/GEO bot — this keeps
+      // Stripe's account-review crawl unthrottled. See:
+      // https://docs.stripe.com/stripebot-crawler
+      {
+        userAgent: "Stripebot",
+        allow: ALLOW,
+        disallow: DISALLOW,
       },
     ],
     sitemap: "https://bitrouter.ai/sitemap.xml",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,13 @@
 import type { MetadataRoute } from "next";
 import { execSync } from "child_process";
-import { source } from "@/lib/source";
+import {
+  source,
+  blogSource,
+  legalSource,
+  getChangelogItems,
+} from "@/lib/source";
+import { fetchModels } from "@/lib/models-server";
+import { fetchProviders } from "@/lib/providers-server";
 
 export const dynamic = "force-static";
 
@@ -17,69 +24,117 @@ function getGitLastModified(filePath: string): Date {
   }
 }
 
+type Entry = MetadataRoute.Sitemap[number];
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // ── Docs (EN + ZH), git-dated per source file ──
   const docPages = source.getPages().flatMap((page) => {
     const mdxPath = `content/docs/${page.slugs.join("/")}.mdx`;
-    const lastModified = getGitLastModified(mdxPath);
-
-    const entries = [
+    const entries: Entry[] = [
       {
         url: `${BASE_URL}${page.url}`,
-        lastModified,
-        changeFrequency: "weekly" as const,
+        lastModified: getGitLastModified(mdxPath),
+        changeFrequency: "weekly",
         priority: 0.7,
       },
     ];
     const zhPage = source.getPage(page.slugs, "zh");
     if (zhPage) {
-      const zhMdxPath = `content/docs/${page.slugs.join("/")}.zh.mdx`;
       entries.push({
         url: `${BASE_URL}${zhPage.url}`,
-        lastModified: getGitLastModified(zhMdxPath),
-        changeFrequency: "weekly" as const,
+        lastModified: getGitLastModified(
+          `content/docs/${page.slugs.join("/")}.zh.mdx`,
+        ),
+        changeFrequency: "weekly",
         priority: 0.5,
       });
     }
     return entries;
   });
 
+  // ── Programmatic model + provider pages (data fetched at build) ──
+  const [models, providers] = await Promise.all([
+    fetchModels(),
+    fetchProviders(),
+  ]);
+  const modelPages: Entry[] = models.map((m) => ({
+    url: `${BASE_URL}/models/${m.id}`,
+    changeFrequency: "weekly",
+    priority: 0.6,
+  }));
+  const providerPages: Entry[] = providers.map((p) => ({
+    url: `${BASE_URL}/providers/${p.slug}`,
+    changeFrequency: "weekly",
+    priority: 0.6,
+  }));
+
+  // ── Blog posts (English-only; auto-populates as posts land) ──
+  const blogPages: Entry[] = blogSource.getPages("en").map((page) => ({
+    url: `${BASE_URL}${page.url}`,
+    lastModified: page.data.lastModified
+      ? new Date(page.data.lastModified)
+      : undefined,
+    changeFrequency: "monthly",
+    priority: 0.6,
+  }));
+
+  // ── Changelog posts ──
+  const changelogPages: Entry[] = getChangelogItems("en").map((item) => ({
+    url: `${BASE_URL}${item.url}`,
+    lastModified: item.date ? new Date(item.date) : undefined,
+    changeFrequency: "monthly",
+    priority: 0.5,
+  }));
+
+  // ── Legal pages (English-only) ──
+  const legalPages: Entry[] = legalSource.getPages("en").map((page) => ({
+    url: `${BASE_URL}${page.url}`,
+    lastModified: page.data.lastModified
+      ? new Date(page.data.lastModified)
+      : undefined,
+    changeFrequency: "yearly",
+    priority: 0.3,
+  }));
+
+  // ── Static marketing/index pages, git-dated by their source file ──
+  const staticPages: Entry[] = (
+    [
+      { url: BASE_URL, file: "app/(home)/page.tsx", priority: 1.0, changeFrequency: "weekly" },
+      { url: `${BASE_URL}/models`, file: "app/(home)/models/page.tsx", priority: 0.9, changeFrequency: "weekly" },
+      { url: `${BASE_URL}/providers`, file: "app/(home)/providers/page.tsx", priority: 0.8, changeFrequency: "weekly" },
+      { url: `${BASE_URL}/pricing`, file: "app/(home)/pricing/page.tsx", priority: 0.8, changeFrequency: "monthly" },
+      { url: `${BASE_URL}/compare/bitrouter-vs-openrouter`, file: "app/(home)/compare/bitrouter-vs-openrouter/page.tsx", priority: 0.9, changeFrequency: "monthly" },
+      { url: `${BASE_URL}/compare/bitrouter-vs-litellm`, file: "app/(home)/compare/bitrouter-vs-litellm/page.tsx", priority: 0.9, changeFrequency: "monthly" },
+      { url: `${BASE_URL}/compare/bitrouter-vs-portkey`, file: "app/(home)/compare/bitrouter-vs-portkey/page.tsx", priority: 0.9, changeFrequency: "monthly" },
+      { url: `${BASE_URL}/enterprise`, file: "app/(home)/enterprise/page.tsx", priority: 0.6, changeFrequency: "monthly" },
+      { url: `${BASE_URL}/about`, file: "app/(home)/about/page.tsx", priority: 0.5, changeFrequency: "monthly" },
+      { url: `${BASE_URL}/brand`, file: "app/(home)/brand/page.tsx", priority: 0.4, changeFrequency: "yearly" },
+      { url: `${BASE_URL}/blog`, file: "app/blog/(index)/page.tsx", priority: 0.6, changeFrequency: "weekly" },
+      { url: `${BASE_URL}/changelog`, file: "app/changelog/(index)/page.tsx", priority: 0.6, changeFrequency: "weekly" },
+    ] as const
+  ).map(({ url, file, priority, changeFrequency }) => ({
+    url,
+    lastModified: getGitLastModified(file),
+    changeFrequency: changeFrequency as Entry["changeFrequency"],
+    priority,
+  }));
+
+  // ── Chinese landing (site pages are EN-only except this entry point) ──
+  const zhLanding: Entry = {
+    url: `${BASE_URL}/zh`,
+    lastModified: getGitLastModified("app/(home)/page.tsx"),
+    changeFrequency: "monthly",
+    priority: 0.5,
+  };
+
   return [
-    {
-      url: BASE_URL,
-      lastModified: getGitLastModified("app/(home)/page.tsx"),
-      changeFrequency: "weekly",
-      priority: 1.0,
-    },
-    {
-      url: `${BASE_URL}/pricing`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/compare/bitrouter-vs-openrouter`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/compare/bitrouter-vs-litellm`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/compare/bitrouter-vs-portkey`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/zh`,
-      lastModified: getGitLastModified("app/(home)/page.tsx"),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
+    ...staticPages,
+    zhLanding,
+    ...modelPages,
+    ...providerPages,
+    ...blogPages,
+    ...changelogPages,
+    ...legalPages,
     ...docPages,
   ];
 }

--- a/components/site-providers.tsx
+++ b/components/site-providers.tsx
@@ -8,48 +8,16 @@ import {
 } from "@/components/ai/search";
 import { MessageCircleIcon } from "lucide-react";
 
-const BASE_URL = "https://bitrouter.ai";
-
 // Providers for the English-only site surface (landing, models, providers,
 // brand, careers, enterprise, legal, blog). next-intl is pinned to `en` so the
 // existing translated components keep working without a rewrite. No fumadocs
 // `i18n` prop on purpose — that keeps the language toggle out of the header
 // (the only i18n surface, docs, lives under [locale] with its own provider).
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@graph": [
-    {
-      "@type": "Organization",
-      name: "BitRouter",
-      url: BASE_URL,
-      logo: `${BASE_URL}/logo.svg`,
-      description:
-        "Agent-native LLM router that optimizes your agent with every run. Zero harness changes — reliable, traceable, secure, and cost-effective.",
-      sameAs: ["https://github.com/AIMOverse", "https://x.com/AIMOverse"],
-    },
-    {
-      "@type": "WebSite",
-      name: "BitRouter",
-      url: BASE_URL,
-      description:
-        "Agent-native LLM router. Zero harness changes — every model call reliable, traceable, secure, and cost-effective. Open-sourced, Cloud opt-in.",
-      inLanguage: "en",
-    },
-    {
-      "@type": "SoftwareApplication",
-      name: "BitRouter",
-      applicationCategory: "DeveloperApplication",
-      operatingSystem: "Any",
-      url: BASE_URL,
-      offers: {
-        "@type": "Offer",
-        price: "0",
-        priceCurrency: "USD",
-        description: "Free to self-host. Cloud opt-in with pay-as-you-go pricing.",
-      },
-    },
-  ],
-};
+//
+// NOTE: the Organization/WebSite/SoftwareApplication JSON-LD graph lives once
+// in the root layout (app/layout.tsx) so it ships on every page. Do not re-emit
+// it here — a second copy created conflicting entity descriptions on the
+// (home)/blog/changelog surfaces that nest this provider inside the root layout.
 
 export async function SiteProviders({
   children,
@@ -70,10 +38,6 @@ export async function SiteProviders({
     >
       <NextIntlClientProvider locale="en" messages={messages}>
         <AISearch>
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-          />
           {children}
           <AISearchPanel />
           <AISearchTrigger


### PR DESCRIPTION
## Why

Goal: improve SEO/GEO (AI-citation) discoverability. Audit found the site was already crawlable, but several indexable surfaces were invisible to the sitemap and there was conflicting structured data. (Triggered by reviewing Stripe's [stripebot-crawler](https://docs.stripe.com/stripebot-crawler) docs — note: Stripebot is a merchant/compliance crawler, **not** an SEO/GEO bot; it's handled here only for Stripe account health.)

## Changes

**Sitemap ([app/sitemap.ts](app/sitemap.ts)) — main win.** Added entries that had canonical metadata but were missing from the sitemap:
- `/models` + every model detail page (`/models/{id}`)
- `/providers` + every provider page (`/providers/{slug}`)
- `/blog` + posts (auto-populates as posts land), `/changelog` + posts, `/legal/*`
- `/about`, `/enterprise`, `/brand`
- Static-page `lastModified` now uses git dates instead of `new Date()` (no per-build churn).

**JSON-LD dedupe ([components/site-providers.tsx](components/site-providers.tsx)).** Removed the duplicate `Organization`/`WebSite`/`SoftwareApplication` graph that conflicted with the root-layout graph on home/blog/changelog. Root layout is now the single source of truth.

**robots.txt ([app/robots.ts](app/robots.ts)).** Broadened the explicit AI/search allow-list 5 → 17 agents (added `OAI-SearchBot`, `ChatGPT-User`, `Claude-User`/`-SearchBot`, `Perplexity-User`, `Googlebot`, `Bingbot`, `Applebot(-Extended)`, `Amazonbot`, `cohere-ai`, `CCBot`), grouped by operator with comments. Added an explicit `Stripebot` group.

**Cleanup.** Deleted dead `app/(home)/careers/page.tsx` (next.config 308 already redirects `/careers → /about`).

## Notes
- The bots were never blocked — this makes intent explicit and, more importantly, makes hundreds of model/provider/content pages discoverable via the sitemap.
- robots.txt has no standard `llms.txt` directive, so none was added; `/llms.txt` is already discoverable at the conventional path.

## Verification
- `tsc --noEmit`: 0 errors project-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)