### PR TITLE
docs(integrations): tier integrations, add Cline/Kilo/OpenHands, split local models

### DIFF
--- a/content/docs/features/local-models.mdx
+++ b/content/docs/features/local-models.mdx
@@ -1,10 +1,10 @@
 ---
 title: Local & private models
-description: Point BitRouter at your own local or private model server — Ollama, vLLM, LM Studio, llama.cpp, or any OpenAI-compatible endpoint. 100% free in local mode.
+description: Point BitRouter at your own local or private model server — Ollama, vLLM, LM Studio, Unsloth, or any OpenAI-compatible endpoint. 100% free in local mode.
 ---
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Run the open-source `bitrouter` binary against a model server on your own machine — Ollama, vLLM, LM Studio, llama.cpp, or any OpenAI-compatible endpoint — and the whole path stays on localhost. No cloud account, no per-token fee, no key leaving your box. This is **local mode**, and it's free.
+Run the open-source `bitrouter` binary against a model server on your own machine — Ollama, vLLM, LM Studio, Unsloth, or any OpenAI-compatible endpoint — and the whole path stays on localhost. No cloud account, no per-token fee, no key leaving your box. This is **local mode**, and it's free.
 
 ## Why route a local model through BitRouter
 
@@ -18,7 +18,7 @@ A bare local server gives you one model at one URL. Putting BitRouter in front o
 
 ### 1. OpenAI-compatible endpoint via the config file
 
-Most local servers (Ollama, vLLM, LM Studio, llama.cpp) expose an OpenAI-compatible `/v1` API. Declare them as a provider in `bitrouter.yaml` with an `api_base` pointing at the local URL:
+Most local servers (Ollama, vLLM, LM Studio, Unsloth) expose an OpenAI-compatible `/v1` API. Declare them as a provider in `bitrouter.yaml` with an `api_base` pointing at the local URL:
 
 ```yaml
 providers:
@@ -32,14 +32,14 @@ providers:
 
 `providers` is a map keyed by the provider id you choose (`ollama` here). `api_base` is the server's base URL; `api_protocol` is the wire format BitRouter speaks upstream — `chat_completions` for any OpenAI-compatible server. BitRouter already infers `chat_completions` for any non-Anthropic, non-Google host, so the `api_protocol` block is optional, but stating it keeps the intent explicit. Each entry under `models` is the model id the server serves.
 
-The full step-by-step — with Ollama, vLLM, LM Studio, and llama.cpp variants and the exact start commands — is in the [local model servers recipe](/docs/integrations/local-models).
+The full step-by-step — with Ollama, vLLM, LM Studio, and Unsloth variants and the exact start commands — is in the [local model servers recipe](/docs/integrations/local-models).
 
 ### 2. A registry-listed provider, auto-detected from the environment
 
 If your private endpoint is a provider already listed in the [registry](/docs/guides/register-as-a-provider), you don't need a config file at all. Set its key as `BITROUTER_<PROVIDER_ID>_API_KEY` and BitRouter detects it at startup — see [BYOK](/docs/features/byok) for the full env-var convention. This is the path for a private hosted deployment that ships a registry manifest, rather than a raw localhost server.
 
 <Callout type="info">
-**Local servers usually need no API key.** Ollama, vLLM, LM Studio, and llama.cpp accept anonymous requests on loopback by default, so you can leave `api_key` off the provider entry. Add one only if you've put auth in front of your server — `api_key: ${MY_LOCAL_KEY}` resolves from the environment at load time.
+**Local servers usually need no API key.** Ollama, vLLM, and LM Studio accept anonymous requests on loopback by default, so you can leave `api_key` off the provider entry. Add one only if you've put auth in front of your server — `api_key: ${MY_LOCAL_KEY}` resolves from the environment at load time. (Unsloth Studio is the exception: it mints an `sk-unsloth-…` key and requires it.)
 </Callout>
 
 ## Free, no cloud account

--- a/content/docs/features/local-models.zh.mdx
+++ b/content/docs/features/local-models.zh.mdx
@@ -1,10 +1,10 @@
 ---
 title: 本地与私有模型
-description: 让 BitRouter 指向你自己的本地或私有模型服务 —— Ollama、vLLM、LM Studio、llama.cpp，或任何 OpenAI 兼容端点。本地模式 100% 免费。
+description: 让 BitRouter 指向你自己的本地或私有模型服务 —— Ollama、vLLM、LM Studio、Unsloth，或任何 OpenAI 兼容端点。本地模式 100% 免费。
 ---
 import { Callout } from 'fumadocs-ui/components/callout';
 
-让开源的 `bitrouter` 二进制对接运行在你自己机器上的模型服务 —— Ollama、vLLM、LM Studio、llama.cpp，或任何 OpenAI 兼容端点 —— 整条链路都留在 localhost。无需云账户，无按 token 计费，密钥也不会离开你的机器。这就是**本地模式**，完全免费。
+让开源的 `bitrouter` 二进制对接运行在你自己机器上的模型服务 —— Ollama、vLLM、LM Studio、Unsloth，或任何 OpenAI 兼容端点 —— 整条链路都留在 localhost。无需云账户，无按 token 计费，密钥也不会离开你的机器。这就是**本地模式**，完全免费。
 
 ## 为什么要让本地模型走 BitRouter
 
@@ -18,7 +18,7 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 ### 1. 通过配置文件接入 OpenAI 兼容端点
 
-大多数本地服务（Ollama、vLLM、LM Studio、llama.cpp）都暴露一个 OpenAI 兼容的 `/v1` API。在 `bitrouter.yaml` 中把它们声明为一个 provider，`api_base` 指向本地 URL：
+大多数本地服务（Ollama、vLLM、LM Studio、Unsloth）都暴露一个 OpenAI 兼容的 `/v1` API。在 `bitrouter.yaml` 中把它们声明为一个 provider，`api_base` 指向本地 URL：
 
 ```yaml
 providers:
@@ -32,14 +32,14 @@ providers:
 
 `providers` 是一个以你自选的 provider id 为键的映射（这里是 `ollama`）。`api_base` 是服务的基础 URL；`api_protocol` 是 BitRouter 对上游使用的线格式 —— 任何 OpenAI 兼容服务都用 `chat_completions`。BitRouter 对任何非 Anthropic、非 Google 的主机已默认推断为 `chat_completions`，因此 `api_protocol` 块是可选的，但写明能让意图更清晰。`models` 下每一项是该服务提供的模型 id。
 
-完整的分步流程 —— 含 Ollama、vLLM、LM Studio 与 llama.cpp 的变体及确切启动命令 —— 见[本地模型服务食谱](/docs/integrations/local-models)。
+完整的分步流程 —— 含 Ollama、vLLM、LM Studio 与 Unsloth 的变体及确切启动命令 —— 见[本地模型服务食谱](/docs/integrations/local-models)。
 
 ### 2. 注册表中列出的 provider，从环境变量自动检测
 
 如果你的私有端点是[注册表](/docs/guides/register-as-a-provider)中已列出的 provider，你完全不需要配置文件。将其密钥设为 `BITROUTER_<PROVIDER_ID>_API_KEY`，BitRouter 会在启动时检测到它 —— 完整的环境变量约定见 [BYOK](/docs/features/byok)。这条路径适用于附带注册表清单的私有托管部署，而非裸的 localhost 服务。
 
 <Callout type="info">
-**本地服务通常无需 API 密钥。** Ollama、vLLM、LM Studio 与 llama.cpp 默认在回环地址上接受匿名请求，因此你可以在 provider 条目中省略 `api_key`。仅当你在服务前置了鉴权时才需要添加 —— `api_key: ${MY_LOCAL_KEY}` 会在加载时从环境变量解析。
+**本地服务通常无需 API 密钥。** Ollama、vLLM 与 LM Studio 默认在回环地址上接受匿名请求，因此你可以在 provider 条目中省略 `api_key`。仅当你在服务前置了鉴权时才需要添加 —— `api_key: ${MY_LOCAL_KEY}` 会在加载时从环境变量解析。（Unsloth Studio 例外：它会生成 `sk-unsloth-…` 密钥并要求带上。）
 </Callout>
 
 ## 免费，无需云账户

--- a/content/docs/integrations/cline.mdx
+++ b/content/docs/integrations/cline.mdx
@@ -1,0 +1,45 @@
+---
+title: Cline
+description: Route Cline through BitRouter via its OpenAI-compatible provider — every model in the registry, behind one endpoint.
+---
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Cline (VS Code / JetBrains) has an **OpenAI Compatible** provider that takes a base URL, an API key, and a model id. Point it at BitRouter and Cline routes across the whole [registry](/docs/concepts/models) instead of a single vendor.
+
+## Prerequisites
+
+- BitRouter running — local proxy at `http://127.0.0.1:4356`, or [BitRouter Cloud](/docs/get-started/quickstart) at `https://api.bitrouter.ai`.
+- Cline installed — search **"Cline"** in the Extensions panel, or:
+
+  ```bash
+  code --install-extension saoudrizwan.claude-dev
+  ```
+
+## Point Cline at BitRouter
+
+Open Cline's settings → **API Provider** → **OpenAI Compatible**, then fill in:
+
+- **Base URL** — `http://127.0.0.1:4356/v1`
+- **API Key** — any value for the local proxy; your BitRouter key for Cloud
+- **Model ID** — a registry id such as `openai/gpt-4o`
+
+<Callout type="info">
+Leave the base URL at the **host root + `/v1`** (not `/v1/chat/completions`) — Cline appends the route itself, and pulls the model list from `/v1/models` so you can select the id instead of typing it.
+</Callout>
+
+<Callout type="info">
+For **Cloud**, set the base URL to `https://api.bitrouter.ai/v1` and use your BitRouter key (from `bitrouter auth login` or the dashboard) as the API key.
+</Callout>
+
+## Pick a model
+
+The Model ID takes any registry id in `provider/model` form — `openai/gpt-4o`, `anthropic/claude-sonnet-4-6`, `google/gemini-2.5-pro` — optionally with a `:cost` or `:latency` variant. See [Models](/docs/concepts/models).
+
+## Verify
+
+Send a message in Cline and confirm a response. BitRouter's `bitrouter-served-by` response header tells you which provider actually answered.
+
+## Learn more
+
+- [Cline — OpenAI-compatible provider](https://docs.cline.bot/provider-config/openai-compatible)
+- [Model fallback](/docs/features/model-fallback) · [Provider selection](/docs/features/provider-selection)

--- a/content/docs/integrations/index.mdx
+++ b/content/docs/integrations/index.mdx
@@ -6,27 +6,34 @@ import { Cards, Card } from 'fumadocs-ui/components/card';
 
 Every recipe below is the same move: point a runtime at BitRouter's endpoint (local proxy at `http://127.0.0.1:4356`, or Cloud at `https://api.bitrouter.ai`) and address models by their `provider/model` id. From there you get the whole [registry](/docs/concepts/models), provider selection, and [fallback](/docs/features/model-fallback) underneath. New to BitRouter? Start with the [Quick Start](/docs/get-started/quickstart).
 
-## Coding agents
+## First-level integration
+
+Runtimes with first-class support for a custom endpoint — BitRouter slots in as a named provider or a base-URL override, and the agent speaks its native API.
 
 <Cards>
   <Card title="Claude Code" href="/docs/integrations/claude-code" description="Anthropic Messages via ANTHROPIC_BASE_URL" />
   <Card title="Codex" href="/docs/integrations/codex" description="Custom provider in ~/.codex/config.toml" />
-  <Card title="GitHub Copilot" href="/docs/integrations/github-copilot" description="BYOK OpenAI-compatible provider (chat)" />
   <Card title="OpenCode" href="/docs/integrations/opencode" description="Provider block in opencode.json" />
   <Card title="Pi" href="/docs/integrations/pi" description="Provider in ~/.pi/agent/models.json" />
+  <Card title="Hermes" href="/docs/integrations/hermes" description="Nous Research's self-improving agent" />
+  <Card title="OpenClaw" href="/docs/integrations/openclaw" description="Messaging gateway across many channels" />
 </Cards>
 
-## Gateways & agents
+## Second-level integration
+
+Runtimes that only expose a generic OpenAI-compatible "bring-your-own-key" slot. BitRouter rides in through that slot — same registry underneath.
 
 <Cards>
-  <Card title="OpenClaw" href="/docs/integrations/openclaw" description="Messaging gateway across many channels" />
-  <Card title="Hermes" href="/docs/integrations/hermes" description="Nous Research's self-improving agent" />
+  <Card title="Cline" href="/docs/integrations/cline" description="OpenAI Compatible provider (VS Code / JetBrains)" />
+  <Card title="Kilo Code" href="/docs/integrations/kilocode" description="OpenAI Compatible provider (VS Code / JetBrains)" />
+  <Card title="GitHub Copilot" href="/docs/integrations/github-copilot" description="BYOK OpenAI-compatible provider (chat)" />
+  <Card title="OpenHands" href="/docs/integrations/openhands" description="LiteLLM custom OpenAI-compatible endpoint" />
 </Cards>
 
 ## Bring your own setup
 
 <Cards>
-  <Card title="Local model servers" href="/docs/integrations/local-models" description="Ollama, vLLM, LM Studio, llama.cpp" />
+  <Card title="Local model servers" href="/docs/integrations/local-models" description="Ollama, vLLM, LM Studio, Unsloth" />
   <Card title="Migrate from LiteLLM" href="/docs/guides/migrate-from-litellm" description="Swap your gateway, keep your code" />
   <Card title="Migrate from OpenRouter" href="/docs/guides/migrate-from-openrouter" description="Change base URL and key" />
 </Cards>

--- a/content/docs/integrations/index.zh.mdx
+++ b/content/docs/integrations/index.zh.mdx
@@ -6,27 +6,34 @@ import { Cards, Card } from 'fumadocs-ui/components/card';
 
 下面每个指南做的都是同一件事：把运行时指向 BitRouter 的端点（本地代理 `http://127.0.0.1:4356`，或云端 `https://api.bitrouter.ai`），并用 `provider/model` 形式的模型 id 调用模型。这样即可获得完整的[模型注册表](/docs/concepts/models)、提供商优选与[失败回退](/docs/features/model-fallback)。初次使用？先看[快速开始](/docs/get-started/quickstart)。
 
-## 编程 Agent
+## 一级集成
+
+对自定义端点有原生支持的运行时——BitRouter 作为具名 provider 或 base URL 覆盖接入，Agent 仍走它原生的 API。
 
 <Cards>
   <Card title="Claude Code" href="/docs/integrations/claude-code" description="通过 ANTHROPIC_BASE_URL 走 Anthropic Messages" />
   <Card title="Codex" href="/docs/integrations/codex" description="在 ~/.codex/config.toml 中配置自定义 provider" />
-  <Card title="GitHub Copilot" href="/docs/integrations/github-copilot" description="BYOK OpenAI 兼容 provider（聊天）" />
   <Card title="OpenCode" href="/docs/integrations/opencode" description="在 opencode.json 中配置 provider" />
   <Card title="Pi" href="/docs/integrations/pi" description="在 ~/.pi/agent/models.json 中配置 provider" />
+  <Card title="Hermes" href="/docs/integrations/hermes" description="Nous Research 的自我改进 Agent" />
+  <Card title="OpenClaw" href="/docs/integrations/openclaw" description="跨多平台的消息网关" />
 </Cards>
 
-## 网关与 Agent
+## 二级集成
+
+只提供通用 OpenAI 兼容「自带密钥」入口的运行时。BitRouter 通过该入口接入——底层仍是同一套注册表。
 
 <Cards>
-  <Card title="OpenClaw" href="/docs/integrations/openclaw" description="跨多平台的消息网关" />
-  <Card title="Hermes" href="/docs/integrations/hermes" description="Nous Research 的自我改进 Agent" />
+  <Card title="Cline" href="/docs/integrations/cline" description="OpenAI Compatible provider（VS Code / JetBrains）" />
+  <Card title="Kilo Code" href="/docs/integrations/kilocode" description="OpenAI Compatible provider（VS Code / JetBrains）" />
+  <Card title="GitHub Copilot" href="/docs/integrations/github-copilot" description="BYOK OpenAI 兼容 provider（聊天）" />
+  <Card title="OpenHands" href="/docs/integrations/openhands" description="LiteLLM 自定义 OpenAI 兼容端点" />
 </Cards>
 
 ## 接入你自己的方案
 
 <Cards>
-  <Card title="本地模型服务" href="/docs/integrations/local-models" description="Ollama、vLLM、LM Studio、llama.cpp" />
+  <Card title="本地模型服务" href="/docs/integrations/local-models" description="Ollama、vLLM、LM Studio、Unsloth" />
   <Card title="从 LiteLLM 迁移" href="/docs/guides/migrate-from-litellm" description="替换网关，代码不变" />
   <Card title="从 OpenRouter 迁移" href="/docs/guides/migrate-from-openrouter" description="改 base URL 和密钥即可" />
 </Cards>

--- a/content/docs/integrations/kilocode.mdx
+++ b/content/docs/integrations/kilocode.mdx
@@ -1,0 +1,45 @@
+---
+title: Kilo Code
+description: Route Kilo Code through BitRouter via its OpenAI-compatible provider — every model in the registry, in one dropdown.
+---
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Kilo Code (VS Code / JetBrains) ships an **OpenAI Compatible** provider that takes a base URL, an API key, and a model id. Point it at BitRouter and the agent routes across the whole [registry](/docs/concepts/models) instead of a single vendor.
+
+## Prerequisites
+
+- BitRouter running — local proxy at `http://127.0.0.1:4356`, or [BitRouter Cloud](/docs/get-started/quickstart) at `https://api.bitrouter.ai`.
+- Kilo Code installed — search **"Kilo Code"** in the Extensions panel, or:
+
+  ```bash
+  code --install-extension kilocode.Kilo-Code
+  ```
+
+## Point Kilo Code at BitRouter
+
+Open the Kilo Code settings → **API Provider** dropdown → **OpenAI Compatible**, then fill in:
+
+- **Base URL** — `http://127.0.0.1:4356/v1`
+- **API Key** — any value for the local proxy; your BitRouter key for Cloud
+- **Model** — a registry id such as `openai/gpt-4o`
+
+<Callout type="info">
+Keep the `/v1` on the base URL and leave it at the **host root + `/v1`** — not `/v1/chat/completions`. Kilo appends the route itself, and it auto-fetches the model list from `/v1/models` once the URL is valid, so you can pick from the dropdown instead of typing the id.
+</Callout>
+
+<Callout type="info">
+For **Cloud**, set the base URL to `https://api.bitrouter.ai/v1` and use your BitRouter key (from `bitrouter auth login` or the dashboard) as the API key.
+</Callout>
+
+## Pick a model
+
+The model field takes any registry id in `provider/model` form — `openai/gpt-4o`, `anthropic/claude-sonnet-4-6`, `google/gemini-2.5-pro` — optionally with a `:cost` or `:latency` variant to bias provider selection. See [Models](/docs/concepts/models).
+
+## Verify
+
+Start a task in Kilo Code and confirm a response. BitRouter's `bitrouter-served-by` response header tells you which provider actually answered.
+
+## Learn more
+
+- [Kilo Code — OpenAI-compatible providers](https://kilo.ai/docs/ai-providers/openai-compatible)
+- [Model fallback](/docs/features/model-fallback) · [Provider selection](/docs/features/provider-selection)

--- a/content/docs/integrations/lm-studio.mdx
+++ b/content/docs/integrations/lm-studio.mdx
@@ -1,0 +1,49 @@
+---
+title: LM Studio
+description: Register a local LM Studio server as a BitRouter provider — OpenAI-compatible, GUI-driven, runs on localhost.
+---
+import { Callout } from 'fumadocs-ui/components/callout';
+
+[LM Studio](https://lmstudio.ai) is a desktop app for running models locally. Its built-in server exposes an OpenAI-compatible API at `http://localhost:1234/v1`, which BitRouter fronts as one provider block.
+
+## Prerequisites
+
+- BitRouter installed, with a `bitrouter.yaml` ([scaffold one](/docs/integrations/local-models#scaffold-a-config) with `bitrouter init`).
+- LM Studio's server running with a model loaded — from the app's **Developer** tab, or the CLI:
+
+  ```bash
+  lms server start                       # default port 1234
+  lms load llama-3.1-8b-instruct
+  ```
+
+## Add LM Studio to BitRouter
+
+```yaml
+# bitrouter.yaml
+providers:
+  lmstudio:
+    api_base: http://localhost:1234/v1
+    api_protocol:
+      - "*": chat_completions
+    models:
+      - id: llama-3.1-8b-instruct
+```
+
+The `models` id is the model identifier LM Studio shows for the loaded model. Confirm it with `lms ps` or by hitting `http://localhost:1234/v1/models`.
+
+<Callout type="info">
+**No API key.** LM Studio's local server accepts anonymous loopback requests, so the block has no `api_key`.
+</Callout>
+
+## Route to it
+
+```bash
+bitrouter route lmstudio:llama-3.1-8b-instruct
+```
+
+Then [start BitRouter and send a request](/docs/integrations/local-models#start-bitrouter-and-send-a-request).
+
+## Learn more
+
+- [LM Studio — OpenAI-compatible API](https://lmstudio.ai/docs/app/api/endpoints/openai)
+- [Model fallback](/docs/features/model-fallback) — fail over from LM Studio to a hosted model.

--- a/content/docs/integrations/local-models.mdx
+++ b/content/docs/integrations/local-models.mdx
@@ -1,15 +1,41 @@
 ---
-title: Local model servers
-description: Connect Ollama, vLLM, LM Studio, or llama.cpp to BitRouter — free, local, OpenAI-compatible.
+title: Overview
+description: Route Ollama, vLLM, LM Studio, or an Unsloth fine-tune through BitRouter — free, local, OpenAI-compatible.
 ---
+import { Cards, Card } from 'fumadocs-ui/components/card';
 import { Callout } from 'fumadocs-ui/components/callout';
-import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
-# Local model servers
+Run a model on your own machine and route it through BitRouter. Each of these servers exposes an OpenAI-compatible API, so adding one is a single provider block in `bitrouter.yaml` — and everything stays on localhost: no cloud account, no per-token fee.
 
-Run a model on your own machine and route it through BitRouter. Ollama, vLLM, LM Studio, and llama.cpp all expose an OpenAI-compatible API, so each one is a one-block addition to `bitrouter.yaml`. Everything stays on localhost — no cloud account, no per-token fee.
+<Cards>
+  <Card title="Ollama" href="/docs/integrations/ollama" description="Easiest local start · :11434 · no key" />
+  <Card title="vLLM" href="/docs/integrations/vllm" description="High-throughput GPU serving · :8000" />
+  <Card title="LM Studio" href="/docs/integrations/lm-studio" description="Desktop GUI runner · :1234 · no key" />
+  <Card title="Unsloth" href="/docs/integrations/unsloth" description="Serve your fine-tune via Unsloth Studio · :8000" />
+</Cards>
 
-## 1. Scaffold a config
+## How it works
+
+Every server below speaks the OpenAI wire format, so the integration is always the same shape — a provider entry in `bitrouter.yaml`:
+
+```yaml
+# bitrouter.yaml
+providers:
+  ollama:                              # an id you choose
+    api_base: http://localhost:11434/v1  # the server's OpenAI-compatible base URL
+    api_protocol:
+      - "*": chat_completions          # upstream wire format; inferred for any OpenAI-compatible host
+    models:
+      - id: llama3.1                   # a model id the server serves
+```
+
+`providers` is a map keyed by an id you pick; `api_base` is the server's base URL; `api_protocol` is the upstream wire format (`chat_completions` for every OpenAI-compatible server — also the inferred default, so the block is optional); each `models` entry is a model the server serves.
+
+<Callout type="info">
+**Most local servers need no API key.** Ollama, vLLM, and LM Studio accept anonymous loopback requests, so the block has no `api_key`. The exception is **Unsloth Studio**, which mints an `sk-unsloth-…` key and requires it on every request — its page covers the `api_key` field.
+</Callout>
+
+## Scaffold a config
 
 Generate a starter `bitrouter.yaml` (defaults to `./bitrouter.yaml`):
 
@@ -17,124 +43,17 @@ Generate a starter `bitrouter.yaml` (defaults to `./bitrouter.yaml`):
 bitrouter init
 ```
 
-This writes a commented config with `skip_auth: true`, ready for you to add a provider. Use `-c <path>` to write it elsewhere.
+This writes a commented config with `skip_auth: true`, ready for a provider block. Use `-c <path>` to write it elsewhere. Then follow your server's page to fill in the block.
 
-## 2. Add your local server
+## Start BitRouter and send a request
 
-Pick your runtime. Each tab shows the provider block to drop into `bitrouter.yaml`, the command to start the server, and how to route to the model. `providers` is a map keyed by an id you choose; `api_base` is the server's OpenAI-compatible base URL; `api_protocol` is the upstream wire format (`chat_completions` for every OpenAI-compatible server — it's also the inferred default, so you may omit the block); each `models` entry is a model id the server serves.
-
-<Tabs items={['Ollama', 'vLLM', 'LM Studio', 'llama.cpp']}>
-<Tab value="Ollama">
-
-```yaml
-# bitrouter.yaml
-providers:
-  ollama:
-    api_base: http://localhost:11434/v1
-    api_protocol:
-      - "*": chat_completions
-    models:
-      - id: llama3.1
-```
-
-```bash
-# Start Ollama and pull the model (default port 11434)
-ollama serve &
-ollama pull llama3.1
-```
-
-Route to it by provider-qualified id (`provider:model`) or by the bare model name:
-
-```bash
-bitrouter route ollama:llama3.1
-```
-
-</Tab>
-<Tab value="vLLM">
-
-```yaml
-# bitrouter.yaml
-providers:
-  vllm:
-    api_base: http://localhost:8000/v1
-    api_protocol:
-      - "*": chat_completions
-    models:
-      - id: meta-llama/Llama-3.1-8B-Instruct
-```
-
-```bash
-# Start vLLM's OpenAI-compatible server (default port 8000)
-vllm serve meta-llama/Llama-3.1-8B-Instruct
-```
-
-```bash
-bitrouter route vllm:meta-llama/Llama-3.1-8B-Instruct
-```
-
-</Tab>
-<Tab value="LM Studio">
-
-```yaml
-# bitrouter.yaml
-providers:
-  lmstudio:
-    api_base: http://localhost:1234/v1
-    api_protocol:
-      - "*": chat_completions
-    models:
-      - id: llama-3.1-8b-instruct
-```
-
-```bash
-# Start LM Studio's local server (default port 1234)
-lms server start
-lms load llama-3.1-8b-instruct
-```
-
-```bash
-bitrouter route lmstudio:llama-3.1-8b-instruct
-```
-
-</Tab>
-<Tab value="llama.cpp">
-
-```yaml
-# bitrouter.yaml
-providers:
-  llamacpp:
-    api_base: http://localhost:8080/v1
-    api_protocol:
-      - "*": chat_completions
-    models:
-      - id: llama-3.1-8b-instruct
-```
-
-```bash
-# Start llama.cpp's OpenAI-compatible server (default port 8080)
-llama-server -m ./models/llama-3.1-8b-instruct.gguf
-```
-
-```bash
-bitrouter route llamacpp:llama-3.1-8b-instruct
-```
-
-</Tab>
-</Tabs>
-
-<Callout type="info">
-**No API key needed.** Local servers accept anonymous requests on loopback by default, so the provider block has no `api_key`. Add `api_key: ${MY_LOCAL_KEY}` only if you've put auth in front of your server — it resolves from the environment at load time.
-</Callout>
-
-## 3. Start BitRouter and send a request
-
-Start the proxy — it listens on `127.0.0.1:4356` by default:
+Once your provider block is in place, start the proxy — it listens on `127.0.0.1:4356` by default:
 
 ```bash
 bitrouter
 ```
 
-Then hit the OpenAI-compatible endpoint with the model id from your config (swap in your provider id / model where shown):
+Then hit the OpenAI-compatible endpoint with the model id from your config (swap in your provider id / model):
 
 ```bash
 curl http://localhost:4356/v1/chat/completions \

--- a/content/docs/integrations/local-models.zh.mdx
+++ b/content/docs/integrations/local-models.zh.mdx
@@ -1,140 +1,59 @@
 ---
-title: 本地模型服务
-description: 将 Ollama、vLLM、LM Studio 或 llama.cpp 接入 BitRouter —— 免费、本地、OpenAI 兼容。
+title: 概览
+description: 将 Ollama、vLLM、LM Studio 或 Unsloth 微调模型接入 BitRouter —— 免费、本地、OpenAI 兼容。
 ---
+import { Cards, Card } from 'fumadocs-ui/components/card';
 import { Callout } from 'fumadocs-ui/components/callout';
-import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
-# 本地模型服务
+在自己的机器上跑模型，并通过 BitRouter 路由。下面这些服务都暴露 OpenAI 兼容 API，因此接入任意一个都只是 `bitrouter.yaml` 里的一段 provider 配置——而且一切都留在 localhost：无需云端账号，无每 token 费用。
 
-在自己的机器上运行模型，并让它走 BitRouter。Ollama、vLLM、LM Studio 与 llama.cpp 都暴露 OpenAI 兼容 API，因此每一个都是在 `bitrouter.yaml` 中加一个块的事。一切都留在 localhost —— 无需云账户，无按 token 计费。
+<Cards>
+  <Card title="Ollama" href="/docs/integrations/ollama" description="最易上手 · :11434 · 无需密钥" />
+  <Card title="vLLM" href="/docs/integrations/vllm" description="高吞吐 GPU 推理 · :8000" />
+  <Card title="LM Studio" href="/docs/integrations/lm-studio" description="桌面 GUI · :1234 · 无需密钥" />
+  <Card title="Unsloth" href="/docs/integrations/unsloth" description="用 Unsloth Studio 托管你的微调模型 · :8000" />
+</Cards>
 
-## 1. 生成配置
+## 工作原理
 
-生成一份起始 `bitrouter.yaml`（默认为 `./bitrouter.yaml`）：
+下面每个服务都讲 OpenAI 协议，因此接入形态始终一致——`bitrouter.yaml` 里的一段 provider 配置：
+
+```yaml
+# bitrouter.yaml
+providers:
+  ollama:                              # 你自己取的 id
+    api_base: http://localhost:11434/v1  # 服务的 OpenAI 兼容 base URL
+    api_protocol:
+      - "*": chat_completions          # 上游协议；对任意 OpenAI 兼容主机都会被自动推断
+    models:
+      - id: llama3.1                   # 该服务提供的模型 id
+```
+
+`providers` 是一个由你取 id 的映射；`api_base` 是服务的 base URL；`api_protocol` 是上游协议（任意 OpenAI 兼容服务都是 `chat_completions`，也是默认推断值，所以这段可省略）；`models` 下每一项是该服务提供的模型。
+
+<Callout type="info">
+**多数本地服务无需密钥。** Ollama、vLLM、LM Studio 在 loopback 上接受匿名请求，所以配置块里没有 `api_key`。例外是 **Unsloth Studio**——它会生成 `sk-unsloth-…` 密钥并要求每次请求都带上，详见其页面的 `api_key` 字段。
+</Callout>
+
+## 生成配置
+
+生成一份起步 `bitrouter.yaml`（默认写到 `./bitrouter.yaml`）：
 
 ```bash
 bitrouter init
 ```
 
-这会写出一份带注释、`skip_auth: true` 的配置，供你添加 provider。用 `-c <path>` 写到别处。
+它会写出一份带注释、`skip_auth: true` 的配置，随时可以加 provider。用 `-c <path>` 写到别处。然后按你所用服务的页面填好配置块。
 
-## 2. 添加你的本地服务
+## 启动 BitRouter 并发请求
 
-选择你的运行时。每个标签页展示要放进 `bitrouter.yaml` 的 provider 块、启动服务的命令，以及如何路由到该模型。`providers` 是一个以你自选 id 为键的映射；`api_base` 是服务的 OpenAI 兼容基础 URL；`api_protocol` 是上游线格式（任何 OpenAI 兼容服务都用 `chat_completions` —— 这也是推断的默认值，因此该块可省略）；`models` 下每一项是该服务提供的模型 id。
-
-<Tabs items={['Ollama', 'vLLM', 'LM Studio', 'llama.cpp']}>
-<Tab value="Ollama">
-
-```yaml
-# bitrouter.yaml
-providers:
-  ollama:
-    api_base: http://localhost:11434/v1
-    api_protocol:
-      - "*": chat_completions
-    models:
-      - id: llama3.1
-```
-
-```bash
-# 启动 Ollama 并拉取模型（默认端口 11434）
-ollama serve &
-ollama pull llama3.1
-```
-
-用 provider 限定 id（`provider:model`）或裸模型名路由：
-
-```bash
-bitrouter route ollama:llama3.1
-```
-
-</Tab>
-<Tab value="vLLM">
-
-```yaml
-# bitrouter.yaml
-providers:
-  vllm:
-    api_base: http://localhost:8000/v1
-    api_protocol:
-      - "*": chat_completions
-    models:
-      - id: meta-llama/Llama-3.1-8B-Instruct
-```
-
-```bash
-# 启动 vLLM 的 OpenAI 兼容服务（默认端口 8000）
-vllm serve meta-llama/Llama-3.1-8B-Instruct
-```
-
-```bash
-bitrouter route vllm:meta-llama/Llama-3.1-8B-Instruct
-```
-
-</Tab>
-<Tab value="LM Studio">
-
-```yaml
-# bitrouter.yaml
-providers:
-  lmstudio:
-    api_base: http://localhost:1234/v1
-    api_protocol:
-      - "*": chat_completions
-    models:
-      - id: llama-3.1-8b-instruct
-```
-
-```bash
-# 启动 LM Studio 的本地服务（默认端口 1234）
-lms server start
-lms load llama-3.1-8b-instruct
-```
-
-```bash
-bitrouter route lmstudio:llama-3.1-8b-instruct
-```
-
-</Tab>
-<Tab value="llama.cpp">
-
-```yaml
-# bitrouter.yaml
-providers:
-  llamacpp:
-    api_base: http://localhost:8080/v1
-    api_protocol:
-      - "*": chat_completions
-    models:
-      - id: llama-3.1-8b-instruct
-```
-
-```bash
-# 启动 llama.cpp 的 OpenAI 兼容服务（默认端口 8080）
-llama-server -m ./models/llama-3.1-8b-instruct.gguf
-```
-
-```bash
-bitrouter route llamacpp:llama-3.1-8b-instruct
-```
-
-</Tab>
-</Tabs>
-
-<Callout type="info">
-**无需 API 密钥。** 本地服务默认在回环地址上接受匿名请求，因此 provider 块不含 `api_key`。仅当你在服务前置了鉴权时才添加 `api_key: ${MY_LOCAL_KEY}` —— 它会在加载时从环境变量解析。
-</Callout>
-
-## 3. 启动 BitRouter 并发送请求
-
-启动代理 —— 默认监听 `127.0.0.1:4356`：
+配置块就绪后，启动代理——默认监听 `127.0.0.1:4356`：
 
 ```bash
 bitrouter
 ```
 
-然后用配置中的模型 id 访问 OpenAI 兼容端点（按需替换为你的 provider id / 模型）：
+然后用配置里的模型 id 访问 OpenAI 兼容端点（把 provider id / 模型替换成你的）：
 
 ```bash
 curl http://localhost:4356/v1/chat/completions \
@@ -145,10 +64,10 @@ curl http://localhost:4356/v1/chat/completions \
   }'
 ```
 
-裸模型名（`llama3.1`）同样有效 —— BitRouter 会将其自动级联到声明了该模型的活跃 provider。provider 限定的 `ollama:llama3.1` 形式则把请求固定到该确切 provider。
+裸模型名（`llama3.1`）也可用——BitRouter 会自动级联到声明了它的活跃 provider。`ollama:llama3.1` 这种带 provider 前缀的形式则把请求固定到该 provider。
 
 <Callout type="info">
-**混用本地与托管。** 声明一个[虚拟模型](/docs/features/model-fallback)，其 endpoints 先列你的本地 provider、再列一个托管 provider：请求在本地硬件上免费运行，并在出错或过载时回退到托管模型 —— 单一模型名，自动故障转移。
+**混用本地与托管。** 声明一个[虚拟模型](/docs/features/model-fallback)，其端点列表先放本地 provider、再放托管的：请求先免费跑在本地硬件上，出错或过载时自动回退到托管模型——一个模型名，自动切换。
 </Callout>
 
-要了解背后的概念 —— 为何前置本地服务，以及注册表检测这一替代方式 —— 见[本地与私有模型](/docs/features/local-models)。
+背后的概念——为什么要在本地服务前面套一层、以及注册表自动探测这条替代路径——见[本地与私有模型](/docs/features/local-models)。

--- a/content/docs/integrations/meta.json
+++ b/content/docs/integrations/meta.json
@@ -2,5 +2,25 @@
   "title": "Integrations",
   "icon": "Blocks",
   "defaultOpen": false,
-  "pages": ["index", "claude-code", "codex", "github-copilot", "hermes", "openclaw", "opencode", "pi", "local-models"]
+  "pages": [
+    "index",
+    "---First-level integration---",
+    "claude-code",
+    "codex",
+    "opencode",
+    "pi",
+    "hermes",
+    "openclaw",
+    "---Second-level integration---",
+    "cline",
+    "kilocode",
+    "github-copilot",
+    "openhands",
+    "---Local model servers---",
+    "local-models",
+    "ollama",
+    "vllm",
+    "lm-studio",
+    "unsloth"
+  ]
 }

--- a/content/docs/integrations/ollama.mdx
+++ b/content/docs/integrations/ollama.mdx
@@ -1,0 +1,49 @@
+---
+title: Ollama
+description: Register a local Ollama server as a BitRouter provider — OpenAI-compatible, no key, runs on localhost.
+---
+import { Callout } from 'fumadocs-ui/components/callout';
+
+[Ollama](https://ollama.com) is the easiest way to run open models locally. It serves an OpenAI-compatible API at `http://localhost:11434/v1`, so it drops into `bitrouter.yaml` as one provider block.
+
+## Prerequisites
+
+- BitRouter installed, with a `bitrouter.yaml` ([scaffold one](/docs/integrations/local-models#scaffold-a-config) with `bitrouter init`).
+- Ollama running, with a model pulled:
+
+  ```bash
+  ollama serve &          # default port 11434
+  ollama pull llama3.1
+  ```
+
+## Add Ollama to BitRouter
+
+```yaml
+# bitrouter.yaml
+providers:
+  ollama:
+    api_base: http://localhost:11434/v1
+    api_protocol:
+      - "*": chat_completions
+    models:
+      - id: llama3.1
+```
+
+Each `models` entry is a name you've pulled with `ollama pull`. List what's available with `ollama list`.
+
+<Callout type="info">
+**No API key.** Ollama accepts anonymous loopback requests, so the block has no `api_key`. (Its own SDK examples pass a dummy `"ollama"` key only because the OpenAI client library demands a non-empty string — BitRouter doesn't.)
+</Callout>
+
+## Route to it
+
+```bash
+bitrouter route ollama:llama3.1
+```
+
+Then [start BitRouter and send a request](/docs/integrations/local-models#start-bitrouter-and-send-a-request). Use the provider-qualified id `ollama:llama3.1` to pin the request, or the bare `llama3.1` to let BitRouter cascade.
+
+## Learn more
+
+- [Ollama — OpenAI compatibility](https://docs.ollama.com/api/openai-compatibility)
+- [Model fallback](/docs/features/model-fallback) — fail over from local Ollama to a hosted model.

--- a/content/docs/integrations/openhands.mdx
+++ b/content/docs/integrations/openhands.mdx
@@ -1,0 +1,65 @@
+---
+title: OpenHands
+description: Route OpenHands through BitRouter via its LiteLLM-backed custom LLM provider.
+---
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+OpenHands talks to models through LiteLLM, which has a generic OpenAI-compatible passthrough. Configure that passthrough to hit BitRouter and OpenHands routes across the whole [registry](/docs/concepts/models).
+
+## Prerequisites
+
+- BitRouter running — local proxy at `http://127.0.0.1:4356`, or [BitRouter Cloud](/docs/get-started/quickstart) at `https://api.bitrouter.ai`.
+- OpenHands installed:
+
+  ```bash
+  pip install openhands-ai
+  ```
+
+<Callout type="warn">
+**Mind the double `openai/` prefix.** LiteLLM uses a leading `openai/` to mean "this is an OpenAI-compatible endpoint", and sends everything after it as the model name. Because BitRouter ids already carry a provider prefix, the model string becomes `openai/` + `openai/gpt-4o` → **`openai/openai/gpt-4o`**. The first segment is for LiteLLM; the rest is the registry id BitRouter receives.
+</Callout>
+
+## Point OpenHands at BitRouter
+
+<Tabs items={['Settings UI', 'config.toml']}>
+<Tab value="Settings UI">
+
+In OpenHands, open **Settings → LLM → Advanced** and set:
+
+- **Custom Model** — `openai/openai/gpt-4o`
+- **Base URL** — `http://127.0.0.1:4356/v1`
+- **API Key** — any value for the local proxy; your BitRouter key for Cloud
+
+</Tab>
+<Tab value="config.toml">
+
+Add an `[llm]` section to `config.toml` in your working directory:
+
+```toml
+[llm]
+model = "openai/openai/gpt-4o"
+base_url = "http://127.0.0.1:4356/v1"
+api_key = "local-placeholder"   # any value for the local proxy
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="info">
+For **Cloud**, set the base URL to `https://api.bitrouter.ai/v1` and use your BitRouter key (from `bitrouter auth login` or the dashboard) as the API key.
+</Callout>
+
+## Pick a model
+
+After the leading `openai/`, use any registry id in `provider/model` form — `openai/openai/gpt-4o`, `openai/anthropic/claude-sonnet-4-6`, `openai/google/gemini-2.5-pro` — optionally with a `:cost` or `:latency` variant on the registry id. See [Models](/docs/concepts/models).
+
+## Verify
+
+Run a task in OpenHands and confirm a response. BitRouter's `bitrouter-served-by` response header tells you which provider actually answered.
+
+## Learn more
+
+- [OpenHands — LLM configuration](https://docs.openhands.dev/openhands/usage/llms/openai-llms)
+- [LiteLLM — OpenAI-compatible endpoints](https://docs.litellm.ai/docs/providers/openai_compatible)
+- [Model fallback](/docs/features/model-fallback) · [Provider selection](/docs/features/provider-selection)

--- a/content/docs/integrations/unsloth.mdx
+++ b/content/docs/integrations/unsloth.mdx
@@ -1,0 +1,66 @@
+---
+title: Unsloth
+description: Serve a model with Unsloth Studio and register its OpenAI-compatible endpoint as a BitRouter provider.
+---
+import { Callout } from 'fumadocs-ui/components/callout';
+
+[Unsloth](https://unsloth.ai) is best known for fast fine-tuning, and **Unsloth Studio** also serves models locally behind an OpenAI-compatible API — handy for routing a model you just fine-tuned, or any Unsloth GGUF. The server exposes `/v1/chat/completions` (and an Anthropic `/v1/messages` surface), which BitRouter fronts as one provider block.
+
+## Prerequisites
+
+- BitRouter installed, with a `bitrouter.yaml` ([scaffold one](/docs/integrations/local-models#scaffold-a-config) with `bitrouter init`).
+- Unsloth Studio serving a model:
+
+  ```bash
+  unsloth run --model unsloth/gemma-3-27b-it-GGUF:UD-Q4_K_XL
+  ```
+
+  This starts the server, opens the Studio UI, and **prints your endpoint URL and `sk-unsloth-…` API key** — note both. The port is typically `8000` or `8888`.
+
+## Add Unsloth to BitRouter
+
+```yaml
+# bitrouter.yaml
+providers:
+  unsloth:
+    api_base: http://localhost:8000/v1     # use the port Studio printed
+    api_protocol:
+      - "*": chat_completions
+    api_key: ${UNSLOTH_API_KEY}
+    models:
+      - id: unsloth/gemma-3-27b-it-GGUF
+```
+
+<Callout type="warn">
+**Unsloth requires a key.** Unlike Ollama / vLLM / LM Studio, Unsloth Studio authenticates every request with an `Authorization: Bearer sk-unsloth-…` header. Export the key it printed and reference it in the block:
+
+```bash
+export UNSLOTH_API_KEY=sk-unsloth-xxxxxxxxxxxx
+```
+
+`api_key` resolves from the environment at load time.
+</Callout>
+
+Confirm the exact model id the server reports — it's what goes under `models`:
+
+```bash
+curl http://localhost:8000/v1/models -H "Authorization: Bearer $UNSLOTH_API_KEY"
+```
+
+<Callout type="info">
+**Port clash with vLLM.** Unsloth Studio and vLLM both default to `:8000`. If you run both, point `api_base` at whichever port Studio actually printed.
+</Callout>
+
+## Route to it
+
+```bash
+bitrouter route unsloth:unsloth/gemma-3-27b-it-GGUF
+```
+
+Then [start BitRouter and send a request](/docs/integrations/local-models#start-bitrouter-and-send-a-request).
+
+## Learn more
+
+- [Unsloth — API endpoint guide](https://unsloth.ai/docs/basics/api)
+- [Unsloth — llama-server & OpenAI endpoint](https://unsloth.ai/docs/basics/inference-and-deployment/llama-server-and-openai-endpoint)
+- [Model fallback](/docs/features/model-fallback) · [Provider selection](/docs/features/provider-selection)

--- a/content/docs/integrations/vllm.mdx
+++ b/content/docs/integrations/vllm.mdx
@@ -1,0 +1,52 @@
+---
+title: vLLM
+description: Register a local vLLM server as a BitRouter provider — high-throughput GPU serving behind an OpenAI-compatible API.
+---
+import { Callout } from 'fumadocs-ui/components/callout';
+
+[vLLM](https://docs.vllm.ai) is a high-throughput inference engine for serving models on your own GPUs. Its `vllm serve` command exposes an OpenAI-compatible API at `http://localhost:8000/v1`, which BitRouter fronts as one provider block.
+
+## Prerequisites
+
+- BitRouter installed, with a `bitrouter.yaml` ([scaffold one](/docs/integrations/local-models#scaffold-a-config) with `bitrouter init`).
+- vLLM serving a model:
+
+  ```bash
+  vllm serve meta-llama/Llama-3.1-8B-Instruct    # default port 8000
+  ```
+
+## Add vLLM to BitRouter
+
+```yaml
+# bitrouter.yaml
+providers:
+  vllm:
+    api_base: http://localhost:8000/v1
+    api_protocol:
+      - "*": chat_completions
+    models:
+      - id: meta-llama/Llama-3.1-8B-Instruct
+```
+
+The `models` id must match the name vLLM serves. By default that's the full Hugging Face repo id; pass `--served-model-name my-model` to `vllm serve` to alias it to something shorter, then use that alias here.
+
+<Callout type="info">
+**Optional auth.** vLLM is keyless by default. If you launched it with `--api-key <token>` (or `VLLM_API_KEY`), add `api_key: ${VLLM_API_KEY}` to the provider block — it resolves from the environment at load time.
+</Callout>
+
+<Callout type="warn">
+**Port clash with Unsloth.** vLLM and Unsloth Studio both default to `:8000`. If you run both, start one on another port (`vllm serve … --port 8001`) and update `api_base`.
+</Callout>
+
+## Route to it
+
+```bash
+bitrouter route vllm:meta-llama/Llama-3.1-8B-Instruct
+```
+
+Then [start BitRouter and send a request](/docs/integrations/local-models#start-bitrouter-and-send-a-request).
+
+## Learn more
+
+- [vLLM — OpenAI-compatible server](https://docs.vllm.ai/en/stable/serving/openai_compatible_server/)
+- [Model fallback](/docs/features/model-fallback) · [Provider selection](/docs/features/provider-selection)


### PR DESCRIPTION
## What

Restructures the **Integrations** section and expands coverage.

### Two tiers + a local-models group (sidebar)
- **First-level integration** — Claude Code, Codex, OpenCode, Pi, Hermes, OpenClaw *(native provider / base-URL override)*
- **Second-level integration** — Cline, Kilo Code, GitHub Copilot, OpenHands *(generic OpenAI-compatible BYOK slot)*
- **Local model servers** — Overview + one page per server

### New / re-added pages
- `cline.mdx`, `openhands.mdx` (new), `kilocode.mdx` (re-added)
- OpenHands page documents the LiteLLM **double `openai/` prefix** gotcha (`openai/openai/gpt-4o`)

### Local model servers
- Split the single tabbed page into **Overview** + flat per-server pages: `ollama`, `vllm`, `lm-studio`, `unsloth`
- **Dropped llama.cpp** everywhere (incl. the `features/local-models` concept page prose)
- **Unsloth** is now a server in its own right via Unsloth Studio — its required `sk-unsloth-…` key and the **:8000 port clash with vLLM** are called out

## Compatibility
- `/docs/integrations/local-models` is preserved (now the Overview page), so existing inbound links and `#scaffold-a-config` / `#start-bitrouter-and-send-a-request` deep anchors keep working.

## Verification
- `pnpm build` passes; all new routes return 200 on the local dev server; old sub-folder URLs correctly 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)