### PR TITLE
fix(chat): point Ask AI at a live model id

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
   let searchCalls = 0;
 
   const result = streamText({
-    model: bitrouter("bitrouter-balanced"),
+    model: bitrouter("deepseek/deepseek-v4-pro"),
     system: SYSTEM_PROMPT,
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(4),
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
       posthog.capture({
         distinctId,
         event: "ai_chat_completion",
-        properties: { model: "bitrouter-balanced", search_calls: searchCalls },
+        properties: { model: "deepseek/deepseek-v4-pro", search_calls: searchCalls },
       });
     },
   });


### PR DESCRIPTION
## Problem

The **Ask AI** feature was broken. `app/api/chat/route.ts` hardcoded the model `bitrouter-balanced`, which the BitRouter API no longer serves — it returns `404 not found: unknown model: bitrouter-balanced`. Every Ask AI request therefore streamed `{"type":"error"}` / `finishReason: "error"` and produced no answer.

The name is a leftover alias (still referenced in `content/changelog/v0-4-0.mdx`); the live `/v1/models` catalog now only exposes `provider/model` ids, with no router/balanced alias.

## Fix

Swap the model to `deepseek/deepseek-v4-pro` (a current catalog id) and update the PostHog `ai_chat_completion` model label to match. Key, base URL, search tool, and streaming were all already correct — the model id was the only fault.

## Verification

Ran the dev server with a live key and hit `/api/chat` end-to-end:

- ✅ Full agentic loop: reasoning → `search` tool call → doc retrieval → cited answer
- ✅ `finishReason: "stop"` (was `"error"`)
- ✅ No `unknown model` / 404 in server logs

Sample Q&A ("How do I authenticate my API requests?") returned a correct, doc-grounded answer with a citation to the API Reference.

## Follow-up (not in this PR)

`content/changelog/v0-4-0.mdx` still advertises the dead `bitrouter-balanced` route — worth a separate docs cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)