### PR TITLE
fix(docs): raise API playground request timeout to 120s

### DIFF
--- a/components/docs/api-page.client.tsx
+++ b/components/docs/api-page.client.tsx
@@ -4,7 +4,13 @@ import { defineClientConfig } from "fumadocs-openapi/ui/client";
 export default defineClientConfig({
   playground: {
     fetchOptions: {
+      // Route requests through our same-origin proxy — the upstream
+      // `api.bitrouter.ai` sends no CORS headers, so a direct browser fetch
+      // fails with `[TypeError] Failed to fetch`. See app/api/openapi-proxy.
       proxyUrl: "/api/openapi-proxy",
+      // Fumadocs defaults this to 10s; real chat-completion / reasoning calls
+      // exceed that and surface as `[TimeoutError] signal timed out`. Seconds.
+      requestTimeout: 120,
     },
   },
 });


### PR DESCRIPTION
## Summary

Investigated the API reference playground's `Client side error: [TypeError] Failed to fetch`.

**Root cause of that error:** the upstream `api.bitrouter.ai` sends no CORS headers, so a *direct* browser fetch throws `[TypeError] Failed to fetch`. The docs already mitigate this with a same-origin proxy at `/api/openapi-proxy` (`createOpenAPI({ proxyUrl })` + `createProxy()` route + client `fetchOptions.proxyUrl`), which I verified is **correctly configured and live in production** (`bitrouter.ai/api/openapi-proxy?url=…/ping` → 200; playground routes GET+POST through it and returns real responses). A live "Failed to fetch" is therefore a **stale cached client bundle** from before the proxy deployed — this redeploy busts that cache.

**What this changes:** bumps the Fumadocs playground `requestTimeout` from its 10s default to **120s**. Real chat-completion / reasoning calls exceed 10s and surface as `[TimeoutError] signal timed out` ([fumadocs#2803](https://github.com/fuma-nama/fumadocs/discussions/2803)). Also adds comments documenting why the proxy exists so the config isn't accidentally removed.

## Verification
- Local dev: Send on GET `/ping` and POST `/v1/chat/completions` both route through `/api/openapi-proxy` and return real responses (no regression from the config change).
- Confirmed prod proxy endpoint returns 200 and the prod page payload references `openapi-proxy`.

## Out of scope (needs the console/cloud repo)
`cloud.bitrouter.ai/api/auth/get-session` returns no `Access-Control-Allow-Origin`, so the header's cross-origin session check logs `ERR_FAILED`. The correct fix is CORS on the console backend (`Access-Control-Allow-Origin: https://bitrouter.ai` + `Access-Control-Allow-Credentials: true`), not a docs-side band-aid — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)