### PR TITLE
fix: remove deleted MonoFooter from enterprise/pricing pages

### DIFF
--- a/components/enterprise/enterprise-page.tsx
+++ b/components/enterprise/enterprise-page.tsx
@@ -12,7 +12,6 @@ import posthog from "posthog-js";
 import { getCalApi } from "@calcom/embed-react";
 import "../landing/mono/mono.css";
 import "./enterprise.css";
-import { MonoFooter } from "../landing/mono/landing";
 
 /* Cal.com founder-call CTA, styled as a mono button. */
 function FounderCTA({
@@ -367,7 +366,6 @@ export function EnterprisePage() {
       <AuditCta />
       <EnterpriseCompare />
       <Faq />
-      <MonoFooter />
     </div>
   );
 }

--- a/components/pricing/pricing-page.tsx
+++ b/components/pricing/pricing-page.tsx
@@ -4,7 +4,7 @@
    sits alongside the landing/models/providers surfaces. Structure:
    compact header + three pricing columns (passthrough / subscription w/ tier
    tabs / outcome) → cost calculator (closed→open savings) → startup-credits
-   band → trimmed compare matrix → FAQ → MonoFooter.
+   band → trimmed compare matrix → FAQ.
 
    The outcome (enterprise) column is summarized here and hands off to
    /enterprise for the full budget-guarantee pitch. */
@@ -14,7 +14,6 @@ import Link from "next/link";
 import posthog from "posthog-js";
 import "../landing/mono/mono.css";
 import "./pricing.css";
-import { MonoFooter } from "../landing/mono/landing";
 import { CostCalculator } from "./cost-calculator";
 
 const SIGN_IN_URL = "https://cloud.bitrouter.ai";
@@ -404,7 +403,6 @@ export function PricingPage() {
       <StartupCredits />
       <Compare />
       <Faq />
-      <MonoFooter />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

`main` is failing to build (`next build`, Turbopack):

```
Export MonoFooter doesn't exist in target module
  components/enterprise/enterprise-page.tsx:15
  components/pricing/pricing-page.tsx:17
```

## Cause

PR #21 (pricing/enterprise mono redesign) added these two pages importing `MonoFooter` from `landing/mono/landing`. PR #22 (footer refactor) **deleted** that export — the old per-page `MonoFooter` was replaced by a single `SiteMonoFooter` mounted in the marketing layouts. The two landed independently and merged clean textually, but the combination breaks the build. It slipped through locally because a warm `.next` cache still had the old export (CI builds with "No build cache found").

## Fix

Both pages live under `app/(home)/`, so they already inherit `SiteMonoFooter` from `app/(home)/layout.tsx`. Removed their now-invalid inline `MonoFooter` import + `<MonoFooter />` render (same treatment models/providers/compare already got). No double footer, no missing export.

## Verification

Clean, cacheless production build (`rm -rf .next && next build`) — **✓ Compiled successfully, 320/320 pages**. No `MonoFooter` references remain anywhere except the new `SiteMonoFooter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)