### PR TITLE
fix(footer): update status page URL to status.bitrouter.ai

### DIFF
--- a/components/landing/footer-nav.ts
+++ b/components/landing/footer-nav.ts
@@ -39,7 +39,7 @@ const PRODUCTS: FooterLink[] = [
   { label: "Providers", href: "/providers" },
   { label: "Pricing", href: "/pricing" },
   { label: "Enterprise", href: "/enterprise" },
-  { label: "Status", href: "https://bitrouter.openstatus.dev", external: true },
+  { label: "Status", href: "https://status.bitrouter.ai", external: true },
 ];
 const DEVELOPERS: FooterLink[] = [
   { label: "API", href: "/docs/reference" },

--- a/components/landing/mono/site-mono-footer.tsx
+++ b/components/landing/mono/site-mono-footer.tsx
@@ -9,7 +9,7 @@ import { MonoThemeSwitch } from "./theme-switch";
 import "./mono.css";
 
 const FOUNDERS_CONTACT = "mailto:contact@bitrouter.ai";
-const STATUS_URL = "https://bitrouter.openstatus.dev";
+const STATUS_URL = "https://status.bitrouter.ai";
 
 /**
  * Site-wide mono-themed mega-footer. Config-driven (single source of truth in


### PR DESCRIPTION
## Summary
- Updated the footer "Status" link from `bitrouter.openstatus.dev` to `status.bitrouter.ai` in both the footer nav config and the mono footer component.

## Test plan
- [x] Grepped repo for remaining `openstatus` URL references (only style-comment mentions remain, no functional impact)