### PR TITLE
ci: trigger Railway redeploy via API instead of empty deploy hook

### DIFF
--- a/.github/workflows/sync-docs-dispatch.yml
+++ b/.github/workflows/sync-docs-dispatch.yml
@@ -4,8 +4,10 @@
 #
 # Railway has no inbound "deploy hook" URL, so we call the GraphQL API's
 # serviceInstanceRedeploy mutation directly. Configure in this repo:
-#   secret RAILWAY_API_TOKEN       — Railway account/team API token
-#                                    (Account Settings -> Tokens)
+#   secret RAILWAY_TOKEN           — a Railway *project* token, scoped to the
+#                                    docs project+environment (Project Settings
+#                                    -> Tokens). Sent as the Project-Access-Token
+#                                    header (project tokens do NOT use Bearer).
 #   var    RAILWAY_SERVICE_ID      — the docs service id
 #   var    RAILWAY_ENVIRONMENT_ID  — the environment id to redeploy
 # The service/environment ids are in the Railway dashboard URL:
@@ -21,12 +23,12 @@ jobs:
     steps:
       - name: Trigger Railway redeploy
         env:
-          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
           RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
         run: |
-          if [ -z "$RAILWAY_API_TOKEN" ] || [ -z "$RAILWAY_SERVICE_ID" ] || [ -z "$RAILWAY_ENVIRONMENT_ID" ]; then
-            echo "::warning::Railway redeploy not configured (need RAILWAY_API_TOKEN secret + RAILWAY_SERVICE_ID/RAILWAY_ENVIRONMENT_ID vars); skipping."
+          if [ -z "$RAILWAY_TOKEN" ] || [ -z "$RAILWAY_SERVICE_ID" ] || [ -z "$RAILWAY_ENVIRONMENT_ID" ]; then
+            echo "::warning::Railway redeploy not configured (need RAILWAY_TOKEN secret + RAILWAY_SERVICE_ID/RAILWAY_ENVIRONMENT_ID vars); skipping."
             exit 0
           fi
           body="$(jq -n \
@@ -34,7 +36,7 @@ jobs:
             --arg s "$RAILWAY_SERVICE_ID" \
             '{query:"mutation serviceInstanceRedeploy($environmentId: String!, $serviceId: String!) { serviceInstanceRedeploy(environmentId: $environmentId, serviceId: $serviceId) }", variables:{environmentId:$e, serviceId:$s}}')"
           resp="$(curl -fsS -X POST https://backboard.railway.com/graphql/v2 \
-            -H "Authorization: Bearer $RAILWAY_API_TOKEN" \
+            -H "Project-Access-Token: $RAILWAY_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$body")"
           echo "$resp"

--- a/.github/workflows/sync-docs-dispatch.yml
+++ b/.github/workflows/sync-docs-dispatch.yml
@@ -1,7 +1,15 @@
 # .github/workflows/sync-docs-dispatch.yml
 # Receives a repository_dispatch from the bitrouter repo when docs change,
-# and triggers a Railway redeploy. The sender (in bitrouter CI) and the
-# RAILWAY_DEPLOY_HOOK secret are set up separately (Plan B).
+# and triggers a Railway redeploy of the docs service via the Railway API.
+#
+# Railway has no inbound "deploy hook" URL, so we call the GraphQL API's
+# serviceInstanceRedeploy mutation directly. Configure in this repo:
+#   secret RAILWAY_API_TOKEN       — Railway account/team API token
+#                                    (Account Settings -> Tokens)
+#   var    RAILWAY_SERVICE_ID      — the docs service id
+#   var    RAILWAY_ENVIRONMENT_ID  — the environment id to redeploy
+# The service/environment ids are in the Railway dashboard URL:
+#   railway.com/project/<projectId>/service/<SERVICE_ID>?environmentId=<ENVIRONMENT_ID>
 name: Rebuild docs on upstream change
 on:
   repository_dispatch:
@@ -12,4 +20,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Railway redeploy
-        run: curl -fsSL -X POST "${{ secrets.RAILWAY_DEPLOY_HOOK }}"
+        env:
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+          RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+        run: |
+          if [ -z "$RAILWAY_API_TOKEN" ] || [ -z "$RAILWAY_SERVICE_ID" ] || [ -z "$RAILWAY_ENVIRONMENT_ID" ]; then
+            echo "::warning::Railway redeploy not configured (need RAILWAY_API_TOKEN secret + RAILWAY_SERVICE_ID/RAILWAY_ENVIRONMENT_ID vars); skipping."
+            exit 0
+          fi
+          body="$(jq -n \
+            --arg e "$RAILWAY_ENVIRONMENT_ID" \
+            --arg s "$RAILWAY_SERVICE_ID" \
+            '{query:"mutation serviceInstanceRedeploy($environmentId: String!, $serviceId: String!) { serviceInstanceRedeploy(environmentId: $environmentId, serviceId: $serviceId) }", variables:{environmentId:$e, serviceId:$s}}')"
+          resp="$(curl -fsS -X POST https://backboard.railway.com/graphql/v2 \
+            -H "Authorization: Bearer $RAILWAY_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$body")"
+          echo "$resp"
+          if printf '%s' "$resp" | jq -e '.errors' >/dev/null 2>&1; then
+            echo "::error::Railway API returned errors"
+            exit 1
+          fi
+          echo "Railway redeploy triggered."


### PR DESCRIPTION
## Problem

The `Rebuild docs on upstream change` workflow (`sync-docs-dispatch.yml`) fails on every dispatch:

```
Run curl -fsSL -X POST ""
curl: (3) URL rejected: Malformed input to a URL function
Error: Process completed with exit code 3.
```

The step interpolated `${{ secrets.RAILWAY_DEPLOY_HOOK }}`, but that secret was **never set** ("Plan B" per the file's own comment). An unset secret expands to an empty string, so the command became `curl -X POST ""`.

The deeper issue: **Railway has no inbound "deploy hook" URL** (unlike Netlify/Vercel). Railway's built-in Webhooks feature is notification-only (outbound). The correct way to trigger a redeploy externally is the Railway GraphQL API.

## Fix

Rewrite the step to call the `serviceInstanceRedeploy` mutation directly, using an API token:

- **`secret RAILWAY_API_TOKEN`** — Railway account/team token (Account Settings → Tokens)
- **`var RAILWAY_SERVICE_ID`** — the docs service id
- **`var RAILWAY_ENVIRONMENT_ID`** — the environment id to redeploy

(service/environment ids are visible in the Railway dashboard URL.)

Robustness:
- If any of the three are unset, the step **warns and skips** (`exit 0`) instead of failing red.
- GraphQL-level errors (HTTP 200 with an `errors` array) now **fail loudly**, which the old `curl -f` couldn't catch.

## Follow-up (repo owner)

This PR makes the workflow correct, but the redeploy only actually fires once the secret + vars are set:

```sh
gh secret set RAILWAY_API_TOKEN     --repo bitrouter/bitrouter-docs --body "<railway-api-token>"
gh variable set RAILWAY_SERVICE_ID  --repo bitrouter/bitrouter-docs --body "<service-id>"
gh variable set RAILWAY_ENVIRONMENT_ID --repo bitrouter/bitrouter-docs --body "<environment-id>"
```

Endpoint/auth/mutation verified against the community [railway-deploy-hook](https://github.com/quansenB/railway-deploy-hook) function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)