### PR TITLE
fix(sync): authenticate doc fetches and back off on rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+        env:
+          # Authenticates the docs/changelog sync fetches against GitHub
+          # (5000/hr) so they don't hit unauthenticated / raw.* rate limits.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -18,10 +18,35 @@ const REPO = process.env.BITROUTER_DOCS_REPO ?? DEFAULT_REPO;
 const REF = process.env.BITROUTER_DOCS_REF ?? DEFAULT_REF;
 const LOCAL = process.env.BITROUTER_REPO ?? "../bitrouter";
 
-function ghHeaders() {
-  const h = { Accept: "application/vnd.github+json", "User-Agent": "bitrouter-docs-sync" };
+function ghHeaders(accept = "application/vnd.github+json") {
+  const h = { Accept: accept, "User-Agent": "bitrouter-docs-sync" };
   if (process.env.GITHUB_TOKEN) h.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
   return h;
+}
+
+// Fetch with backoff on GitHub rate limiting (429, or 403 with the rate-limit
+// budget exhausted). Honors Retry-After / X-RateLimit-Reset when present.
+async function ghFetch(url, { accept } = {}, attempt = 0) {
+  const res = await fetch(url, { headers: ghHeaders(accept) });
+  const limited =
+    res.status === 429 ||
+    (res.status === 403 && res.headers.get("x-ratelimit-remaining") === "0");
+  if (limited && attempt < 5) {
+    const retryAfter = Number(res.headers.get("retry-after"));
+    const reset = Number(res.headers.get("x-ratelimit-reset"));
+    let waitMs = retryAfter
+      ? retryAfter * 1000
+      : reset
+        ? reset * 1000 - Date.now()
+        : 1000 * 2 ** attempt;
+    waitMs = Math.min(Math.max(waitMs, 1000), 60000) + 250;
+    console.warn(
+      `sync-docs: ${res.status} for ${url}; retry ${attempt + 1}/5 in ${Math.round(waitMs / 1000)}s`,
+    );
+    await new Promise((r) => setTimeout(r, waitMs));
+    return ghFetch(url, { accept }, attempt + 1);
+  }
+  return res;
 }
 
 // Returns a flat list of { path (relative to DOCS_ROOT), read() }.
@@ -42,17 +67,19 @@ async function acquire() {
   }
   console.log(`sync-docs: fetching ${REPO}@${REF}:${DOCS_ROOT} via GitHub`);
   const url = `https://api.github.com/repos/${REPO}/git/trees/${REF}?recursive=1`;
-  const res = await fetch(url, { headers: ghHeaders() });
+  const res = await ghFetch(url);
   if (!res.ok) throw new Error(`GitHub trees API ${res.status}`);
   const { tree } = await res.json();
   return tree
     .filter((n) => n.type === "blob" && n.path.startsWith(`${DOCS_ROOT}/`))
     .map((n) => ({
       path: relative(DOCS_ROOT, n.path),
+      // Read via the authenticated blob API (n.url) rather than
+      // raw.githubusercontent.com: the API honors GITHUB_TOKEN for a 5000/hr
+      // budget, while raw.* is throttled per-IP and 429s on shared runners.
       read: async () => {
-        const raw = `https://raw.githubusercontent.com/${REPO}/${REF}/${n.path}`;
-        const r = await fetch(raw, { headers: ghHeaders() });
-        if (!r.ok) throw new Error(`raw ${r.status} for ${n.path}`);
+        const r = await ghFetch(n.url, { accept: "application/vnd.github.raw" });
+        if (!r.ok) throw new Error(`blob ${r.status} for ${n.path}`);
         return r.text();
       },
     }));


### PR DESCRIPTION
## Problem

The docs build (`pnpm build` → `prebuild` → `sync-docs.mjs`) fails intermittently with:

```
sync-docs: fetching bitrouter/bitrouter@main:docs via GitHub
Error: raw 429 for docs/concepts/mcp.zh.md
```

Two compounding causes:

1. **No auth in CI** — `ci.yml` runs `pnpm build` with no `GITHUB_TOKEN` in env, so every fetch is unauthenticated.
2. **Fragile transport** — the script pulls each doc file individually from `raw.githubusercontent.com`, whose rate limit is **per-IP** and trips fast on shared Actions runners. Unauthenticated × N raw requests → 429.

This is pre-existing fragility; the recent get-started restructure merge (more files + a docs-changed dispatch) just made it trip reliably.

## Fix

- **Read blobs via the authenticated git blob API** (`n.url` from the tree response) with `Accept: application/vnd.github.raw`, instead of `raw.githubusercontent.com`. The API honors `GITHUB_TOKEN` for a 5000/hr budget and isn't subject to raw's per-IP throttle.
- **Add `ghFetch()`** with backoff on `429` (and `403` with the rate-limit budget exhausted), honoring `Retry-After` / `X-RateLimit-Reset`. Applied to both the tree call and each blob read.
- **Pass `GITHUB_TOKEN` to `pnpm build`** in CI. The automatic `secrets.GITHUB_TOKEN` can read the public `bitrouter` repo; `sync-changelog.mjs` (which also fetches) benefits too.

## Verification

Ran the rewritten `sync-docs.mjs` against `bitrouter@main` with a token:

```
sync-docs: wrote 111 file(s) into content/docs
```

Exit 0, **no 429s**. (It also emits the usual non-blocking "N stale translation(s)" warning, unchanged behavior.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)