### PR TITLE
Models: capability radars, cards/table + model pages, routed-usage ranking hero

### DIFF
--- a/app/(home)/models/[...slug]/page.tsx
+++ b/app/(home)/models/[...slug]/page.tsx
@@ -1,31 +1,38 @@
-import { getTranslations, setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, ArrowUpRight } from "lucide-react";
 import type { Metadata } from "next";
-import { RuledSectionLabel } from "@/components/ruled-section-label";
-import { Button } from "@/components/ui/button";
+import "@/components/landing/mono/mono.css";
 import { ProviderIcon } from "@/components/models/provider-icon";
 import { CopyIdButton } from "@/components/models/copy-id-button";
 import { CopySnippet } from "@/components/models/copy-snippet";
-import { fetchModelById } from "@/lib/models-server";
-import { modelDisplayName, providerFromId } from "@/lib/models-filter";
-import { formatPricePerMillionTokens } from "@/lib/model-pricing";
+import { CapabilityRadar } from "@/components/models/capability-radar";
+import { AxisBars } from "@/components/models/axis-bars";
+import { ModelCallTerminal } from "@/components/models/model-call-terminal";
+import { fetchModelById, fetchModels } from "@/lib/models-server";
+import {
+  modelDisplayName,
+  providerFromId,
+  isOpenSourceModel,
+} from "@/lib/models-filter";
+import { formatCompactPricePerMillionTokens } from "@/lib/model-pricing";
+import {
+  capabilityAxes,
+  modelTier,
+  routerUsage,
+  formatCtx,
+  modTag,
+} from "@/lib/model-capability";
+import { type Model } from "@/lib/models-types";
 
+const SIGN_IN_URL = "https://cloud.bitrouter.ai";
 const API_BASE_URL = "https://api.bitrouter.ai/v1";
 const OPENAI_CHAT_COMPLETIONS_URL = `${API_BASE_URL}/chat/completions`;
 const ANTHROPIC_MESSAGES_URL = `${API_BASE_URL}/messages`;
 
-type Props = {
-  params: Promise<{ slug: string[] }>;
-};
+type Props = { params: Promise<{ slug: string[] }> };
 
-function formatTokens(tokens: number): string {
-  if (!tokens) return "—";
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
-  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
-  return String(tokens);
-}
+const provDisplay = (p: string) => p.charAt(0).toUpperCase() + p.slice(1);
 
 function openaiSnippet(modelId: string): string {
   return `curl ${OPENAI_CHAT_COMPLETIONS_URL} \\
@@ -36,7 +43,6 @@ function openaiSnippet(modelId: string): string {
     "messages": [{"role": "user", "content": "Hello"}]
   }'`;
 }
-
 function anthropicSnippet(modelId: string): string {
   return `curl ${ANTHROPIC_MESSAGES_URL} \\
   -H "x-api-key: $BITROUTER_API_KEY" \\
@@ -49,169 +55,203 @@ function anthropicSnippet(modelId: string): string {
   }'`;
 }
 
+/* Sibling models for the "similar models" row — same provider first, topped up
+   with same-tier models so there are always a few links. */
+function pickSimilar(model: Model, all: Model[]): Model[] {
+  const provider = providerFromId(model.id);
+  const tier = modelTier(model);
+  const sameProvider = all.filter(
+    (m) => m.id !== model.id && providerFromId(m.id) === provider,
+  );
+  const out = [...sameProvider];
+  if (out.length < 4) {
+    const sameTier = all.filter(
+      (m) =>
+        m.id !== model.id &&
+        providerFromId(m.id) !== provider &&
+        modelTier(m) === tier,
+    );
+    out.push(...sameTier);
+  }
+  return out.slice(0, 4);
+}
+
 export default async function ModelDetailPage({ params }: Props) {
   const { slug } = await params;
   setRequestLocale("en");
-  const t = await getTranslations("ModelDetail");
 
   const modelId = slug.join("/");
-  const model = await fetchModelById(modelId);
+  const [model, all] = await Promise.all([fetchModelById(modelId), fetchModels()]);
   if (!model) notFound();
 
   const provider = providerFromId(model.id);
-  const friendlyName = model.name && model.name !== model.id
-    ? model.name
-    : modelDisplayName(model);
+  const oss = isOpenSourceModel(model);
+  const tier = modelTier(model);
+  const friendlyName =
+    model.name && model.name !== model.id ? model.name : modelDisplayName(model);
+  const fin = formatCompactPricePerMillionTokens(model.pricing.input);
+  const fout = formatCompactPricePerMillionTokens(model.pricing.output);
+  const { axes, sources } = capabilityAxes(model);
+  const usage = routerUsage(model);
+  const similar = pickSimilar(model, all);
 
   return (
-    <article className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 sm:py-14">
-      <Link
-        href="/models"
-        className="mb-8 inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-widest text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <ArrowLeft className="size-3" />
-        {t("back")}
-      </Link>
+    <div className="br-mono">
+      <article className="wrap mp">
+        <Link href="/models" className="mp-back">
+          ← all models
+        </Link>
 
-      {/* ── Header ─────────────────────────────────────── */}
-      <div className="flex flex-col gap-6 border-b border-border pb-8 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <ProviderIcon provider={provider} size={14} className="text-foreground" />
-            <span className="font-mono text-[11px] uppercase tracking-widest">
-              {provider}
+        <header className="mp-head">
+          <div>
+            <span className="mp-prov">
+              <ProviderIcon provider={provider} size={14} className="mrow-ico" />
+              {provDisplay(provider)}
+            </span>
+            <h1 className="h-display mp-title">{friendlyName}</h1>
+            <div className="mp-idrow">
+              <code className="mp-id">{model.id}</code>
+              <CopyIdButton id={model.id} />
+              {oss && <span className="oss-badge">oss</span>}
+            </div>
+            <div className="mp-tierline">
+              {tier}
+              {oss ? " · open" : ""} · {formatCtx(model.maxInputTokens)} ctx · {fin} in
+              · {fout} out
+            </div>
+          </div>
+          <a href={SIGN_IN_URL} className="btn btn-primary">
+            Get API key →
+          </a>
+        </header>
+
+        <div className="mp-grid">
+          <section className="mp-card">
+            <div className="mp-card-h">
+              capability shape <span className="mp-est">~ estimated · mock</span>
+            </div>
+            <div className="mp-shape">
+              <CapabilityRadar
+                values={axes}
+                size={168}
+                showLabels
+                title={`${model.id} capability shape`}
+              />
+              <AxisBars values={axes} sources={sources} />
+            </div>
+          </section>
+
+          <section className="mp-card">
+            <div className="mp-card-h">
+              how the router uses this model <span className="mp-est">mock</span>
+            </div>
+            <div className="rusage">
+              {usage.policies.map((p) => (
+                <div className="rpolicy" key={p.key}>
+                  <span className="rpolicy-mark">{p.mark}</span>
+                  <span className="rpolicy-k">{p.label}</span>
+                  <span className="rpolicy-note">{p.note}</span>
+                  <span className="rpolicy-bar">
+                    <i style={{ width: `${Math.round(p.weight * 100)}%` }} />
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div className="rusage-foot rusage-role">
+              role <b>{usage.role}</b> · {usage.shareNote}
+            </div>
+          </section>
+        </div>
+
+        <div className="mp-sec-h">pricing &amp; limits</div>
+        <div className="mp-stats">
+          <div className="mp-stat">
+            <span className="mp-stat-k">input</span>
+            <span className="mp-stat-v">{fin} / 1M</span>
+          </div>
+          <div className="mp-stat">
+            <span className="mp-stat-k">output</span>
+            <span className="mp-stat-v">{fout} / 1M</span>
+          </div>
+          <div className="mp-stat">
+            <span className="mp-stat-k">context</span>
+            <span className="mp-stat-v">{formatCtx(model.maxInputTokens)} tokens</span>
+          </div>
+          <div className="mp-stat">
+            <span className="mp-stat-k">modality</span>
+            <span className="mp-stat-v">
+              {model.modalities.map(modTag).join(" · ") || "TXT"}
             </span>
           </div>
-          <h1 className="mt-3 text-2xl font-medium tracking-tight sm:text-3xl">
-            {friendlyName}
-          </h1>
-          <div className="mt-3 flex items-center gap-2">
-            <code className="min-w-0 truncate border border-border bg-background px-2 py-1 font-mono text-[12px] text-foreground/90">
-              {model.id}
-            </code>
-            <CopyIdButton id={model.id} />
+          {model.pricing.cacheRead !== undefined && (
+            <div className="mp-stat">
+              <span className="mp-stat-k">cache read</span>
+              <span className="mp-stat-v">
+                {formatCompactPricePerMillionTokens(model.pricing.cacheRead)} / 1M
+              </span>
+            </div>
+          )}
+          {model.pricing.cacheWrite !== undefined && (
+            <div className="mp-stat">
+              <span className="mp-stat-k">cache write</span>
+              <span className="mp-stat-v">
+                {formatCompactPricePerMillionTokens(model.pricing.cacheWrite)} / 1M
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="mp-sec-h">try it</div>
+        <ModelCallTerminal id={model.id} provider={provider} fin={fin} fout={fout} />
+
+        {similar.length > 0 && (
+          <>
+            <div className="mp-sec-h">similar models</div>
+            <div className="mp-similar">
+              {similar.map((s) => (
+                <Link key={s.id} href={`/models/${s.id}`}>
+                  {s.id}
+                </Link>
+              ))}
+            </div>
+          </>
+        )}
+
+        <div className="mp-sec-h">quickstart</div>
+        <div className="mp-snippet">
+          <div className="mp-snippet-h">
+            <span className="mp-snippet-lbl">OpenAI-compatible</span>
+            <CopySnippet value={openaiSnippet(model.id)} />
           </div>
+          <pre>
+            <code>{openaiSnippet(model.id)}</code>
+          </pre>
         </div>
-
-        <a
-          href="https://cloud.bitrouter.ai"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="shrink-0"
-        >
-          <Button size="sm">
-            {t("ctaApiKey")} <ArrowUpRight className="ml-1 size-3" />
-          </Button>
-        </a>
-      </div>
-
-      {/* ── Overview ───────────────────────────────────── */}
-      <section className="mt-10">
-        <RuledSectionLabel label={t("overviewLabel")} counter="01" />
-        <div className="mt-4 grid grid-cols-2 gap-px border border-border bg-border sm:grid-cols-4">
-          <Stat
-            label={t("statContext")}
-            value={formatTokens(model.maxInputTokens)}
-          />
-          <Stat
-            label={t("statInput")}
-            value={formatPricePerMillionTokens(model.pricing.input)}
-          />
-          <Stat
-            label={t("statOutput")}
-            value={formatPricePerMillionTokens(model.pricing.output)}
-          />
-          <Stat
-            label={t("statModalities")}
-            value={model.modalities.join(", ") || "text"}
-          />
+        <div className="mp-snippet">
+          <div className="mp-snippet-h">
+            <span className="mp-snippet-lbl">Anthropic-compatible</span>
+            <CopySnippet value={anthropicSnippet(model.id)} />
+          </div>
+          <pre>
+            <code>{anthropicSnippet(model.id)}</code>
+          </pre>
         </div>
-      </section>
-
-      {/* ── Quickstart ─────────────────────────────────── */}
-      <section className="mt-12">
-        <RuledSectionLabel label={t("quickstartLabel")} counter="02" />
-        <p className="mt-3 text-sm text-muted-foreground">
-          {t("quickstartBody")}
-        </p>
-
-        <div className="mt-5 space-y-4">
-          <SnippetCard
-            label={t("snippetOpenAI")}
-            endpoint={OPENAI_CHAT_COMPLETIONS_URL}
-            code={openaiSnippet(model.id)}
-          />
-          <SnippetCard
-            label={t("snippetAnthropic")}
-            endpoint={ANTHROPIC_MESSAGES_URL}
-            code={anthropicSnippet(model.id)}
-          />
-        </div>
-      </section>
-    </article>
-  );
-}
-
-function Stat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="bg-background px-4 py-4">
-      <div className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
-        {label}
-      </div>
-      <div className="mt-1 font-mono text-sm tabular-nums text-foreground">
-        {value}
-      </div>
-    </div>
-  );
-}
-
-function SnippetCard({
-  label,
-  endpoint,
-  code,
-}: {
-  label: string;
-  endpoint: string;
-  code: string;
-}) {
-  return (
-    <div className="border border-border bg-background">
-      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-3 py-2">
-        <div className="min-w-0 flex-1">
-          <p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
-            {label}
-          </p>
-          <code className="block truncate font-mono text-[11px] text-foreground/85">
-            {endpoint}
-          </code>
-        </div>
-        <CopySnippet value={code} />
-      </div>
-      <pre className="overflow-x-auto px-3 py-3 font-mono text-[12px] leading-relaxed text-foreground/90">
-        <code>{code}</code>
-      </pre>
+      </article>
     </div>
   );
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
-  const t = await getTranslations({ locale: "en", namespace: "ModelDetail" });
   const modelId = slug.join("/");
   const model = await fetchModelById(modelId);
-  if (!model) {
-    return { title: t("notFound") };
-  }
-  const friendlyName = model.name && model.name !== model.id
-    ? model.name
-    : modelDisplayName(model);
+  if (!model) return { title: "Model not found — BitRouter" };
+  const friendlyName =
+    model.name && model.name !== model.id ? model.name : modelDisplayName(model);
+  const fin = formatCompactPricePerMillionTokens(model.pricing.input);
+  const fout = formatCompactPricePerMillionTokens(model.pricing.output);
   return {
     title: `${friendlyName} — BitRouter`,
-    description: t("metaDescription", {
-      id: model.id,
-      input: formatPricePerMillionTokens(model.pricing.input),
-      output: formatPricePerMillionTokens(model.pricing.output),
-      context: formatTokens(model.maxInputTokens),
-    }),
+    description: `${model.id} on BitRouter: ${fin} in / ${fout} out per 1M tokens, ${formatCtx(model.maxInputTokens)} context. See its capability shape across intelligence, coding, agentic, cost, speed and reliability, and how the router routes to it.`,
   };
 }

--- a/components/landing/mono/mono.css
+++ b/components/landing/mono/mono.css
@@ -1796,31 +1796,41 @@
    Page header (Models)
    ============================================================ */
 .br-mono .page-head {
-  padding: 56px 0 44px;
+  padding: 28px 0 24px;
   border-bottom: 1px solid var(--line);
 }
 .br-mono .page-head .eyebrow {
-  margin-bottom: 18px;
+  margin-bottom: 10px;
 }
 .br-mono .page-head-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
-  gap: 52px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 40px;
   align-items: center;
 }
+.br-mono .page-head-copy {
+  min-width: 0;
+}
 .br-mono .page-title {
-  font-size: clamp(40px, 6vw, 72px);
-  margin-bottom: 18px;
+  font-size: clamp(26px, 3.2vw, 40px);
+  margin-bottom: 8px;
 }
 .br-mono .page-lead {
   color: var(--fg-dim);
-  font-size: 15px;
-  line-height: 1.62;
-  max-width: 52ch;
+  font-size: 13.5px;
+  line-height: 1.55;
+  max-width: 48ch;
   margin: 0;
 }
+.br-mono .page-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
 .br-mono .page-reg-cta {
-  margin: 12px 0 0;
+  margin: 0;
   font-size: 12.5px;
   color: var(--muted);
   font-family: var(--mono);
@@ -1835,15 +1845,169 @@
   color: var(--fg);
 }
 .br-mono .page-term {
-  height: 312px;
+  height: auto;
+  align-self: stretch;
 }
 @media (max-width: 940px) {
   .br-mono .page-head-grid {
     grid-template-columns: 1fr;
-    gap: 32px;
+    gap: 22px;
   }
   .br-mono .page-title {
-    font-size: clamp(40px, 13vw, 64px);
+    font-size: clamp(26px, 8vw, 36px);
+  }
+}
+
+/* ---------- Top-models ranking hero ---------- */
+.br-mono .rank-topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+.br-mono .rank-intro {
+  min-width: 0;
+}
+.br-mono .rank-sample {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--muted);
+  border: 1px solid var(--line-2);
+  border-radius: 100px;
+  padding: 2px 9px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+.br-mono .rank-sample::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--term-warn);
+}
+.br-mono .rank-grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 34px;
+  align-items: start;
+}
+.br-mono .rank-panel {
+  min-width: 0;
+}
+.br-mono .rank-panel-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin-bottom: 14px;
+}
+.br-mono .rank-panel-rt {
+  color: var(--ghost);
+}
+
+/* usage chart (shadcn Chart / Recharts) */
+.br-mono .usage-chart {
+  width: 100%;
+  height: 200px;
+  aspect-ratio: auto !important;
+}
+/* theme the Recharts grid + axis lines to match the mono system */
+.br-mono .usage-chart .recharts-cartesian-grid line {
+  stroke: var(--line);
+}
+.br-mono .usage-chart .recharts-cartesian-axis-tick text {
+  fill: var(--faint) !important;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.br-mono .usage-empty {
+  height: 184px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+/* rank list */
+.br-mono .ranklist {
+  display: flex;
+  flex-direction: column;
+}
+.br-mono .rankrow {
+  display: grid;
+  grid-template-columns: 16px 8px 16px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 12.5px;
+  font-family: var(--mono);
+  color: var(--fg-dim);
+}
+.br-mono .rankrow:last-child {
+  border-bottom: none;
+}
+.br-mono .rankrow:hover .rankrow-id {
+  color: #fff;
+}
+.br-mono .rankrow-n {
+  color: var(--faint);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.br-mono .rankrow-sw {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+.br-mono .rankrow-id {
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.br-mono .rankrow-share {
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+}
+.br-mono .rankrow-delta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 3px;
+  min-width: 46px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.br-mono .rankrow-delta.up {
+  color: var(--term-ok);
+}
+.br-mono .rankrow-delta.down {
+  color: var(--term-warn);
+}
+.br-mono .ranklist-foot {
+  margin-top: 12px;
+  font-size: 11.5px;
+  color: var(--faint);
+}
+.br-mono .mcat-eyebrow {
+  margin-bottom: 16px;
+}
+@media (max-width: 940px) {
+  .br-mono .rank-grid {
+    grid-template-columns: 1fr;
+    gap: 14px;
   }
 }
 
@@ -2188,6 +2352,476 @@
   }
   .br-mono .mrow-detail {
     grid-template-columns: 1fr;
+  }
+}
+
+/* ============================================================
+   Capability radar · cards/table view · model page
+   ============================================================ */
+
+/* view switch */
+.br-mono .viewsw {
+  display: flex;
+  gap: 0;
+}
+.br-mono .viewsw-opt {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--muted);
+  background: var(--panel-2);
+  border: 1px solid var(--line-2);
+  padding: 7px 11px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.br-mono .viewsw-opt:first-child {
+  border-radius: 6px 0 0 6px;
+}
+.br-mono .viewsw-opt:last-child {
+  border-radius: 0 6px 6px 0;
+  border-left: none;
+}
+.br-mono .viewsw-opt:hover {
+  color: var(--fg-dim);
+}
+.br-mono .viewsw-opt.on {
+  color: #000;
+  background: var(--fg);
+  border-color: var(--fg);
+}
+
+/* radar (shadcn Chart / Recharts) */
+.br-mono .caprad-chart {
+  aspect-ratio: auto !important;
+}
+.br-mono .caprad-chart .recharts-polar-grid path {
+  stroke: var(--line-2);
+}
+.br-mono .caprad-chart .recharts-polar-grid line {
+  stroke: var(--line);
+}
+.br-mono .caprad-chart .recharts-polar-angle-axis-tick text {
+  fill: var(--faint) !important;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.02em;
+}
+
+/* cards grid */
+.br-mono .mcards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 14px;
+}
+.br-mono .mcard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  background: var(--panel);
+  padding: 16px 18px;
+  transition: border-color 0.15s, background 0.15s;
+}
+.br-mono .mcard:hover {
+  border-color: var(--line-bright);
+  background: var(--panel-2);
+}
+.br-mono .mcard-facts {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  min-width: 0;
+}
+.br-mono .mcard-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.br-mono .mcard-id {
+  color: var(--fg);
+  font-size: 13.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.br-mono .mcard-tier {
+  font-size: 11.5px;
+  color: var(--muted);
+}
+.br-mono .mcard-price {
+  display: flex;
+  gap: 14px;
+  font-size: 13px;
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+}
+.br-mono .mcard-price i {
+  font-style: normal;
+  color: var(--faint);
+  margin-right: 4px;
+}
+.br-mono .mcard-meta {
+  font-size: 11.5px;
+  color: var(--muted);
+}
+.br-mono .mcard-est {
+  font-size: 10.5px;
+  color: var(--faint);
+}
+.br-mono .mcard-vis {
+  flex: 0 0 auto;
+}
+
+/* capability table — own classes, isolated from .mrow mobile rules */
+.br-mono .mtable-scroll {
+  overflow-x: auto;
+}
+.br-mono .mtable.captable {
+  min-width: 720px;
+}
+.br-mono .captable-row {
+  display: grid;
+  grid-template-columns:
+    minmax(170px, 2fr) 52px 64px 64px 44px 44px 44px 44px 44px minmax(60px, 0.9fr);
+  align-items: center;
+  gap: 10px;
+}
+.br-mono .captable-head {
+  padding: 12px 18px;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--faint);
+  border-bottom: 1px solid var(--line);
+  background: var(--panel-2);
+}
+.br-mono .captable-head .ar {
+  text-align: right;
+}
+.br-mono .captable-body > a {
+  border-bottom: 1px solid var(--line);
+}
+.br-mono .captable-body > a:last-child {
+  border-bottom: none;
+}
+.br-mono a.captable-rowlink {
+  padding: 12px 18px;
+  font-family: var(--mono);
+  color: var(--fg-dim);
+  font-size: 13px;
+  transition: background 0.12s;
+}
+.br-mono a.captable-rowlink:hover {
+  background: var(--panel-2);
+}
+.br-mono .captable-num,
+.br-mono .captable-ax {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.br-mono .captable-num {
+  color: var(--fg-dim);
+}
+.br-mono .captable-ctx {
+  color: var(--muted);
+}
+.br-mono .captable-ax {
+  color: var(--fg-dim);
+}
+.br-mono .captable-ax.est {
+  color: var(--faint);
+}
+.br-mono .captable-mod {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+/* ---------- model detail page ---------- */
+.br-mono .mp {
+  padding: 40px 0 72px;
+}
+.br-mono .mp-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 28px;
+}
+.br-mono .mp-back:hover {
+  color: var(--fg);
+}
+.br-mono .mp-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 26px;
+  flex-wrap: wrap;
+}
+.br-mono .mp-prov {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.br-mono .mp-title {
+  font-size: clamp(28px, 4vw, 44px);
+  margin: 12px 0;
+}
+.br-mono .mp-idrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.br-mono .mp-id {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--fg-dim);
+  border: 1px solid var(--line-2);
+  background: var(--panel-2);
+  border-radius: 5px;
+  padding: 3px 8px;
+}
+.br-mono .mp-tierline {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.br-mono .mp-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-top: 26px;
+}
+.br-mono .mp-card {
+  border: 1px solid var(--line-2);
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--panel), var(--bg));
+  padding: 20px;
+}
+.br-mono .mp-card-h {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin-bottom: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.br-mono .mp-est {
+  font-size: 10.5px;
+  color: var(--faint);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.br-mono .mp-shape {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+.br-mono .mp-shape .axbars {
+  flex: 1;
+}
+
+/* axis bars */
+.br-mono .axbars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.br-mono .axbar {
+  display: grid;
+  grid-template-columns: 84px 1fr 30px;
+  align-items: center;
+  gap: 10px;
+}
+.br-mono .axbar-k {
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+.br-mono .axbar-est {
+  color: var(--faint);
+  font-style: normal;
+  margin-left: 3px;
+}
+.br-mono .axbar-track {
+  height: 6px;
+  background: var(--line-2);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.br-mono .axbar-track > i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+.br-mono .axbar-v {
+  font-size: 12px;
+  color: var(--muted);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* router usage */
+.br-mono .rusage {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+.br-mono .rpolicy {
+  display: grid;
+  grid-template-columns: 16px 74px 1fr 70px;
+  align-items: center;
+  gap: 10px;
+  font-size: 12.5px;
+}
+.br-mono .rpolicy-mark {
+  color: var(--accent);
+}
+.br-mono .rpolicy-k {
+  color: var(--fg);
+}
+.br-mono .rpolicy-note {
+  color: var(--muted);
+  font-size: 11.5px;
+}
+.br-mono .rpolicy-bar {
+  width: 70px;
+  height: 6px;
+  background: var(--line-2);
+  border-radius: 3px;
+  overflow: hidden;
+  justify-self: end;
+}
+.br-mono .rpolicy-bar > i {
+  display: block;
+  height: 100%;
+  background: var(--fg-dim);
+}
+.br-mono .rusage-foot {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--muted);
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+}
+.br-mono .rusage-role b {
+  color: var(--fg);
+  font-weight: 500;
+}
+
+/* pricing stats + sections */
+.br-mono .mp-sec-h {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 34px 0 14px;
+}
+.br-mono .mp-stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.br-mono .mp-stat {
+  background: var(--panel);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.br-mono .mp-stat-k {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.br-mono .mp-stat-v {
+  font-size: 14px;
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+}
+.br-mono .mp-term {
+  height: 200px;
+}
+.br-mono .mp-similar {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.br-mono .mp-similar a {
+  font-size: 12.5px;
+  color: var(--fg-dim);
+  border: 1px solid var(--line-2);
+  border-radius: 100px;
+  padding: 5px 12px;
+}
+.br-mono .mp-similar a:hover {
+  color: var(--fg);
+  border-color: var(--line-bright);
+}
+.br-mono .mp-snippet {
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  background: var(--panel);
+  overflow: hidden;
+}
+.br-mono .mp-snippet + .mp-snippet {
+  margin-top: 14px;
+}
+.br-mono .mp-snippet-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 13px;
+  border-bottom: 1px solid var(--line);
+}
+.br-mono .mp-snippet-lbl {
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.br-mono .mp-snippet pre {
+  margin: 0;
+  padding: 13px;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--fg-dim);
+  overflow-x: auto;
+}
+@media (max-width: 820px) {
+  .br-mono .mp-grid {
+    grid-template-columns: 1fr;
+  }
+  .br-mono .mp-shape {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .br-mono .mp-shape .caprad {
+    align-self: center;
   }
 }
 

--- a/components/models/axis-bars.tsx
+++ b/components/models/axis-bars.tsx
@@ -1,0 +1,34 @@
+/* AxisBars — the six capability axes as horizontal 0–100 bars, beside the
+   radar on the model page. Mock axes get a `~` estimated marker. */
+
+import * as React from "react";
+import { AXES, AXIS_META, type AxisSet, type SourceSet } from "@/lib/model-capability";
+
+export function AxisBars({
+  values,
+  sources,
+}: {
+  values: AxisSet;
+  sources?: SourceSet;
+}) {
+  return (
+    <div className="axbars">
+      {AXES.map((ax) => (
+        <div className="axbar" key={ax}>
+          <span className="axbar-k">
+            {AXIS_META[ax].label}
+            {sources && sources[ax] === "mock" && (
+              <i className="axbar-est" title="estimated">
+                ~
+              </i>
+            )}
+          </span>
+          <span className="axbar-track">
+            <i style={{ width: `${values[ax]}%` }} />
+          </span>
+          <span className="axbar-v">{values[ax]}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/models/capability-radar.tsx
+++ b/components/models/capability-radar.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+/* CapabilityRadar — a model's six-axis shape, on the shadcn Chart (Recharts
+   RadarChart) so it matches the usage chart and gets hover tooltips. Rendered
+   both in the cards grid (many instances) and on the model page (one large
+   instance); kept lightweight — no animation, no dots. */
+
+import * as React from "react";
+import { PolarAngleAxis, PolarGrid, Radar, RadarChart } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { AXES, AXIS_META, type AxisSet } from "@/lib/model-capability";
+
+const chartConfig = {
+  value: { label: "score", color: "var(--accent)" },
+} satisfies ChartConfig;
+
+export function CapabilityRadar({
+  values,
+  size = 120,
+  showLabels = false,
+  title,
+  className = "",
+}: {
+  values: AxisSet;
+  size?: number;
+  showLabels?: boolean;
+  title?: string;
+  className?: string;
+}) {
+  const data = AXES.map((ax) => ({
+    axis: AXIS_META[ax].short,
+    value: values[ax],
+  }));
+
+  return (
+    <ChartContainer
+      config={chartConfig}
+      className={"caprad-chart " + className}
+      style={{ width: size, height: size }}
+      aria-label={title ?? "capability radar"}
+    >
+      <RadarChart data={data} outerRadius={showLabels ? "68%" : "88%"}>
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <PolarGrid />
+        {showLabels && <PolarAngleAxis dataKey="axis" />}
+        <Radar
+          dataKey="value"
+          fill="var(--color-value)"
+          fillOpacity={0.2}
+          stroke="var(--color-value)"
+          strokeWidth={1.5}
+          isAnimationActive={false}
+        />
+      </RadarChart>
+    </ChartContainer>
+  );
+}

--- a/components/models/model-call-terminal.tsx
+++ b/components/models/model-call-terminal.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+/* Client island for the model page's animated `bitrouter chat` terminal —
+   the Terminal takes a program *function*, which can't cross the server→client
+   boundary, so it's built here from plain string props. */
+
+import * as React from "react";
+import { Terminal, Ok, Dim, Faint } from "../landing/mono/terminal";
+
+export function ModelCallTerminal({
+  id,
+  provider,
+  fin,
+  fout,
+}: {
+  id: string;
+  provider: string;
+  fin: string;
+  fout: string;
+}) {
+  const program = React.useCallback(
+    () => [
+      ["type", `bitrouter chat --model ${id}`, { prefix: "$", cps: 60, after: 360 }],
+      [
+        "print",
+        <span>
+          <Dim>POST</Dim> api.bitrouter.ai/v1/chat <Faint>· 1 key</Faint>
+        </span>,
+        220,
+      ],
+      [
+        "spin",
+        `routing → ${provider}`,
+        950,
+        <span>
+          <Ok>✓</Ok> <span className="lbl">{id}</span>{" "}
+          <Faint>
+            · {fin} / {fout}
+          </Faint>
+        </span>,
+      ],
+      [
+        "print",
+        <span>
+          <Dim>stream</Dim> <span className="caret accent" />
+        </span>,
+        600,
+      ],
+      ["loop", 1800],
+    ],
+    [id, provider, fin, fout],
+  );
+
+  return (
+    <Terminal
+      title={`call · ${id}`}
+      accentPrompt={false}
+      className="mp-term"
+      program={program as never}
+    />
+  );
+}

--- a/components/models/model-card.tsx
+++ b/components/models/model-card.tsx
@@ -1,0 +1,66 @@
+/* ModelCard — cards-view tile: facts on the left, capability radar on the
+   right. The whole card links to the model's page. Pure component (no hooks). */
+
+import * as React from "react";
+import Link from "next/link";
+import { ProviderIcon } from "./provider-icon";
+import { CapabilityRadar } from "./capability-radar";
+import {
+  capabilityAxes,
+  modelTier,
+  formatCtx,
+  modTag,
+} from "@/lib/model-capability";
+import { providerFromId, isOpenSourceModel } from "@/lib/models-filter";
+import { formatCompactPricePerMillionTokens } from "@/lib/model-pricing";
+import { type Model } from "@/lib/models-data";
+
+export function ModelCard({ m }: { m: Model }) {
+  const prov = providerFromId(m.id);
+  const oss = isOpenSourceModel(m);
+  const tier = modelTier(m);
+  const { axes, sources } = capabilityAxes(m);
+  const estimated = (Object.keys(sources) as (keyof typeof sources)[])
+    .filter((k) => sources[k] === "mock")
+    .length;
+
+  return (
+    <Link href={`/models/${m.id}`} className="mcard">
+      <div className="mcard-facts">
+        <div className="mcard-head">
+          <ProviderIcon provider={prov} size={15} className="mrow-ico" />
+          <span className="mcard-id">{m.id}</span>
+          {oss && <span className="oss-badge">oss</span>}
+        </div>
+        <div className="mcard-tier">
+          {tier}
+          {oss ? " · open" : ""}
+        </div>
+        <div className="mcard-price">
+          <span>
+            <i>in</i>
+            {formatCompactPricePerMillionTokens(m.pricing.input)}
+          </span>
+          <span>
+            <i>out</i>
+            {formatCompactPricePerMillionTokens(m.pricing.output)}
+          </span>
+        </div>
+        <div className="mcard-meta">
+          {formatCtx(m.maxInputTokens)} ctx · {m.modalities.map(modTag).join(" · ")}
+        </div>
+        {estimated > 0 && (
+          <div className="mcard-est">~ agentic · reliability estimated</div>
+        )}
+      </div>
+      <div className="mcard-vis">
+        <CapabilityRadar
+          values={axes}
+          size={132}
+          showLabels
+          title={`${m.id} capability shape`}
+        />
+      </div>
+    </Link>
+  );
+}

--- a/components/models/mono-models-page.tsx
+++ b/components/models/mono-models-page.tsx
@@ -2,12 +2,14 @@
 
 /* Models catalog — mono/dev redesign. Unified catalog shell: global
    FilterSidebar (left) + mono content (animated `models ls` terminal, search,
-   sort, dense mono table with expandable per-model call terminal), on the live
-   model data. Shares its layout with the Providers page. */
+   sort, and a cards ⇄ table view of the live model data). Cards show each
+   model's capability radar; the table shows the same axes as sortable columns.
+   Rows/cards link to the per-model page (no inline expand). Shares its layout
+   with the Providers page. */
 
 import * as React from "react";
+import Link from "next/link";
 import "../landing/mono/mono.css";
-import { Terminal, Ok, Dim, Faint } from "../landing/mono/terminal";
 import { primeModelsCache, useModels, type Model } from "@/lib/models-data";
 import {
   CONTEXT_BUCKETS,
@@ -17,7 +19,19 @@ import {
   isOpenSourceModel,
 } from "@/lib/models-filter";
 import { formatCompactPricePerMillionTokens } from "@/lib/model-pricing";
+import {
+  AXES,
+  capabilityAxes,
+  formatCtx,
+  modTag,
+  type Axis,
+  type AxisSet,
+} from "@/lib/model-capability";
+import { mockUsage, WEEKS_SPAN } from "@/lib/model-usage";
 import { ProviderIcon } from "./provider-icon";
+import { ModelCard } from "./model-card";
+import { UsageChart } from "./usage-chart";
+import { RankList } from "./rank-list";
 import {
   FilterSidebar,
   FilterSheetTrigger,
@@ -27,8 +41,6 @@ import {
   type FilterGroupDef,
   type FilterState,
 } from "@/components/ui/filter-sidebar";
-
-const SIGN_IN_URL = "https://cloud.bitrouter.ai";
 
 const FILTER_LABELS = {
   title: "Filters",
@@ -58,249 +70,51 @@ const PROV_LABEL: Record<string, string> = {
 const provLabel = (key: string) =>
   PROV_LABEL[key] ?? key.charAt(0).toUpperCase() + key.slice(1);
 
-const MOD_TAG: Record<string, string> = {
-  text: "TXT",
-  image: "IMG",
-  audio: "AUD",
-  video: "VID",
-  embedding: "EMB",
-  "function-calling": "FN",
-  tools: "FN",
-};
-const modTag = (m: string) =>
-  MOD_TAG[m.toLowerCase()] ?? m.slice(0, 3).toUpperCase();
-
-const TIERS: Record<string, string> = {
-  frontier: "frontier",
-  balanced: "balanced",
-  fast: "fast",
-  reasoning: "reasoning",
-};
-
-function tierOf(m: Model): keyof typeof TIERS {
-  const id = m.id.toLowerCase();
-  if (/(^|\/)(o1|o3|o4)|r1|reason|think|qwq/.test(id)) return "reasoning";
-  const intel = m.benchmarks?.intelligenceIndex;
-  if (intel != null) {
-    if (intel >= 55) return "frontier";
-    if (intel >= 40) return "balanced";
-    return "fast";
-  }
-  const p = m.pricing.input;
-  if (p >= 10) return "frontier";
-  if (p >= 2) return "balanced";
-  return "fast";
-}
-
-function formatCtx(tokens: number): string {
-  if (!tokens) return "—";
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(0)}M`;
-  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
-  return String(tokens);
-}
-
-function ttftMs(m: Model): number | null {
-  const t = m.benchmarks?.timeToFirstToken;
-  return t != null ? Math.round(t * 1000) : null;
-}
-const formatP50 = (m: Model) => {
-  const v = ttftMs(m);
-  return v != null ? `${v}ms` : "—";
-};
-
-/* ── header terminal (demo program from the design) ── */
-function modelsLsProgram() {
-  return [
-    [
-      "type",
-      "bitrouter models ls --filter oss --sort price",
-      { prefix: "$", cps: 50, after: 420 },
-    ],
-    [
-      "print",
-      <span className="fnt">MODEL                          IN/1M   OUT/1M</span>,
-      180,
-    ],
-    [
-      "print",
-      <span>
-        <span className="lbl">qwen/qwen-3.7</span>{" "}
-        <Faint>                </Faint>
-        <Dim>$0.07    $0.28</Dim>
-      </span>,
-      90,
-    ],
-    [
-      "print",
-      <span>
-        <span className="lbl">deepseek/deepseek-v4-pro</span>{" "}
-        <Faint>     </Faint>
-        <Dim>$0.20    $0.80</Dim>
-      </span>,
-      90,
-    ],
-    [
-      "print",
-      <span>
-        <span className="lbl">moonshot/kimi-k2.6</span>{" "}
-        <Faint>          </Faint>
-        <Dim>$0.15    $2.50</Dim>
-      </span>,
-      90,
-    ],
-    [
-      "print",
-      <span>
-        <span className="lbl">anthropic/claude-opus-4.8</span>{" "}
-        <Faint>    </Faint>
-        <Dim>$15.0   $75.0</Dim>
-      </span>,
-      90,
-    ],
-    [
-      "print",
-      <span>
-        <Faint>… 180+ open-source · zero markup</Faint>
-      </span>,
-      360,
-    ],
-    [
-      "spin",
-      "resolving alias code/balanced",
-      1100,
-      <span>
-        <Ok>✓</Ok> <Dim>alias →</Dim>{" "}
-        <span className="lbl">deepseek/deepseek-v4-pro</span>{" "}
-        <Faint>· 287ms</Faint>
-      </span>,
-    ],
-    ["loop", 2200],
-  ];
-}
-
-/* ── one table row + expandable detail ── */
-function ModelRow({
-  m,
-  open,
-  onToggle,
-}: {
-  m: Model;
-  open: boolean;
-  onToggle: () => void;
-}) {
-  const tier = tierOf(m);
+/* ── one table row (links to the model page) ── */
+function CapRow({ m, axes }: { m: Model; axes: AxisSet }) {
   const prov = providerFromId(m.id);
   const oss = isOpenSourceModel(m);
   const fin = formatCompactPricePerMillionTokens(m.pricing.input);
   const fout = formatCompactPricePerMillionTokens(m.pricing.output);
   return (
-    <div className={"mrow-wrap" + (open ? " open" : "")}>
-      <button className="mrow" onClick={onToggle}>
-        <span className="mrow-id">
-          <span className="mrow-caret">{open ? "▾" : "▸"}</span>
-          <ProviderIcon provider={prov} size={15} className="mrow-ico" />
-          <span className="mrow-id-text">{m.id}</span>
-          {oss && <span className="oss-badge">oss</span>}
-        </span>
-        <span className="mrow-ctx">{formatCtx(m.maxInputTokens)}</span>
-        <span className="mrow-num">{fin}</span>
-        <span className="mrow-num">{fout}</span>
-        <span className="mrow-mod">
-          {m.modalities.map((x) => (
-            <i key={x} className="mtag">
-              {modTag(x)}
-            </i>
-          ))}
-        </span>
-      </button>
-      {open && (
-        <div className="mrow-detail">
-          <div className="mdetail-grid">
-            <div>
-              <span className="mdetail-k">provider</span>
-              <span className="mdetail-v mdetail-prov">
-                <ProviderIcon provider={prov} size={14} className="mrow-ico" />
-                {provLabel(prov)}
-              </span>
-            </div>
-            <div>
-              <span className="mdetail-k">context</span>
-              <span className="mdetail-v">
-                {formatCtx(m.maxInputTokens)} tokens
-              </span>
-            </div>
-            <div>
-              <span className="mdetail-k">input</span>
-              <span className="mdetail-v">{fin} / 1M</span>
-            </div>
-            <div>
-              <span className="mdetail-k">output</span>
-              <span className="mdetail-v">{fout} / 1M</span>
-            </div>
-            <div>
-              <span className="mdetail-k">modality</span>
-              <span className="mdetail-v">
-                {m.modalities.map(modTag).join(" · ") || "—"}
-              </span>
-            </div>
-            <div>
-              <span className="mdetail-k">p50 ttft</span>
-              <span className="mdetail-v">{formatP50(m)}</span>
-            </div>
-          </div>
-          <Terminal
-            title={"call · " + m.id}
-            accentPrompt={false}
-            className="mdetail-term"
-            program={
-              (() => [
-                [
-                  "type",
-                  "bitrouter chat --model " + m.id,
-                  { prefix: "$", cps: 60, after: 360 },
-                ],
-                [
-                  "print",
-                  <span>
-                    <Dim>POST</Dim> api.bitrouter.ai/v1/chat{" "}
-                    <Faint>· 1 key</Faint>
-                  </span>,
-                  220,
-                ],
-                [
-                  "spin",
-                  "routing → " + prov,
-                  950,
-                  <span>
-                    <Ok>✓</Ok> <span className="lbl">{m.id}</span>{" "}
-                    <Faint>
-                      · {formatP50(m)} · {fin}/{fout}
-                    </Faint>
-                  </span>,
-                ],
-                [
-                  "print",
-                  <span>
-                    <Dim>stream</Dim> <span className="caret accent" />
-                  </span>,
-                  600,
-                ],
-                ["loop", 1800],
-              ]) as never
-            }
-          />
-        </div>
-      )}
-    </div>
+    <Link href={`/models/${m.id}`} className="captable-row captable-rowlink">
+      <span className="mrow-id">
+        <ProviderIcon provider={prov} size={15} className="mrow-ico" />
+        <span className="mrow-id-text">{m.id}</span>
+        {oss && <span className="oss-badge">oss</span>}
+      </span>
+      <span className="captable-ctx">{formatCtx(m.maxInputTokens)}</span>
+      <span className="captable-num">{fin}</span>
+      <span className="captable-num">{fout}</span>
+      <span className="captable-ax">{axes.intelligence}</span>
+      <span className="captable-ax">{axes.coding}</span>
+      <span className="captable-ax est">{axes.agentic}</span>
+      <span className="captable-ax">{axes.speed}</span>
+      <span className="captable-ax est">{axes.reliability}</span>
+      <span className="captable-mod">
+        {m.modalities.map((x) => (
+          <i key={x} className="mtag">
+            {modTag(x)}
+          </i>
+        ))}
+      </span>
+    </Link>
   );
 }
 
 const SORTS: [string, string][] = [
-  ["in", "input $"],
-  ["out", "output $"],
-  ["p50", "latency"],
+  ["in", "in $"],
+  ["out", "out $"],
+  ["intelligence", "int"],
+  ["coding", "code"],
+  ["agentic", "agentic"],
+  ["speed", "speed"],
+  ["reliability", "reliability"],
   ["id", "name"],
 ];
+const AXIS_KEYS = new Set<string>(AXES);
+
+type ViewMode = "cards" | "table";
 
 function ModelsCatalog() {
   const { models, isLoading, error } = useModels();
@@ -308,7 +122,48 @@ function ModelsCatalog() {
   const [sort, setSort] = React.useState("in");
   const [filters, setFilters] = React.useState<FilterState>({});
   const [ossOnly, setOssOnly] = React.useState(false);
-  const [open, setOpen] = React.useState<string | null>(null);
+  const [view, setView] = React.useState<ViewMode>("cards");
+
+  // View: URL (?view=) wins on load, else last localStorage choice, else cards.
+  React.useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const fromUrl = params.get("view");
+    let ls: string | null = null;
+    try {
+      ls = localStorage.getItem("br-models-view");
+    } catch {
+      ls = null;
+    }
+    const pick =
+      fromUrl === "table" || fromUrl === "cards"
+        ? fromUrl
+        : ls === "table" || ls === "cards"
+          ? ls
+          : "cards";
+    setView(pick as ViewMode);
+  }, []);
+
+  const changeView = (v: ViewMode) => {
+    setView(v);
+    try {
+      localStorage.setItem("br-models-view", v);
+    } catch {
+      /* ignore */
+    }
+    const params = new URLSearchParams(window.location.search);
+    params.set("view", v);
+    window.history.replaceState(null, "", `${window.location.pathname}?${params.toString()}`);
+  };
+
+  // Deterministic capability shapes, memoized per model id.
+  const caps = React.useMemo(() => {
+    const map = new Map<string, AxisSet>();
+    for (const m of models) map.set(m.id, capabilityAxes(m).axes);
+    return map;
+  }, [models]);
+
+  // Mock "what the router routed to" usage series for the ranking hero.
+  const usage = React.useMemo(() => mockUsage(models), [models]);
 
   const groups = React.useMemo<FilterGroupDef[]>(() => {
     const providerCounts = new Map<string, number>();
@@ -360,14 +215,19 @@ function ModelsCatalog() {
         return false;
       return modelMatchesFilters(m, f);
     });
+
+    if (AXIS_KEYS.has(sort)) {
+      const ax = sort as Axis;
+      // higher capability first
+      return [...r].sort((a, b) => (caps.get(b.id)?.[ax] ?? 0) - (caps.get(a.id)?.[ax] ?? 0));
+    }
     const cmp: Record<string, (a: Model, b: Model) => number> = {
       id: (a, b) => a.id.localeCompare(b.id),
       in: (a, b) => a.pricing.input - b.pricing.input,
       out: (a, b) => a.pricing.output - b.pricing.output,
-      p50: (a, b) => (ttftMs(a) ?? 1e9) - (ttftMs(b) ?? 1e9),
     };
-    return [...r].sort(cmp[sort]);
-  }, [models, q, sort, filters, ossOnly]);
+    return [...r].sort(cmp[sort] ?? cmp.in);
+  }, [models, q, sort, filters, ossOnly, caps]);
 
   const activeCount = countActive(filters);
   const panelProps = {
@@ -383,44 +243,40 @@ function ModelsCatalog() {
   return (
     <>
       <section className="page-head wrap">
-        <div className="page-head-grid">
-          <div>
+        <div className="rank-topbar">
+          <div className="rank-intro">
             <div className="eyebrow">
-              <span className="idx">//</span> Registry
+              <span className="idx">//</span> Top models
             </div>
-            <h1 className="h-display page-title">Models.</h1>
+            <h1 className="h-display page-title">Top models.</h1>
             <p className="page-lead">
-              {models.length > 0 ? models.length : "200+"} models behind one
-              key. Open-source models at a fraction of frontier prices — zero
-              markup — pair with your Claude Code or Codex subscription to cut
-              costs on every run without changing a line of code.
-            </p>
-            <div className="hero-actions">
-              <a href={SIGN_IN_URL} className="btn btn-primary">
-                Get API key →
-              </a>
-            </div>
-            <p className="page-reg-cta">
-              To register as a model or harness provider,{" "}
-              <a
-                href="https://github.com/bitrouter/provider-registry"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                open a PR at github.com/bitrouter/provider-registry
-              </a>
+              What the router actually picked — share of routed calls across
+              BitRouter.<span className="rank-sample">sample data</span>
             </p>
           </div>
-          <Terminal
-            title="bitrouter — models"
-            accentPrompt={false}
-            className="page-term"
-            program={modelsLsProgram as never}
-          />
+        </div>
+        <div className="rank-grid">
+          <div className="rank-panel">
+            <div className="rank-panel-h">
+              routed calls / day
+              <span className="rank-panel-rt">last {WEEKS_SPAN} weeks</span>
+            </div>
+            <UsageChart days={usage.days} series={usage.series} />
+          </div>
+          <div className="rank-panel">
+            <div className="rank-panel-h">
+              ranked · this week
+              <span className="rank-panel-rt">share ▲▼ wk</span>
+            </div>
+            <RankList ranked={usage.ranked} total={models.length} />
+          </div>
         </div>
       </section>
 
       <section className="wrap mcat">
+        <div className="eyebrow mcat-eyebrow">
+          <span className="idx">//</span> All models
+        </div>
         <div className="catalog-row">
           <FilterSidebar {...panelProps} />
           <div className="catalog-body">
@@ -449,6 +305,22 @@ function ModelsCatalog() {
                 activeCount={activeCount}
                 triggerLabel="Filters"
               />
+              <div className="viewsw" role="group" aria-label="View mode">
+                <button
+                  className={"viewsw-opt" + (view === "cards" ? " on" : "")}
+                  aria-pressed={view === "cards"}
+                  onClick={() => changeView("cards")}
+                >
+                  ▦ cards
+                </button>
+                <button
+                  className={"viewsw-opt" + (view === "table" ? " on" : "")}
+                  aria-pressed={view === "table"}
+                  onClick={() => changeView("table")}
+                >
+                  ▤ table
+                </button>
+              </div>
               <div className="sortsel">
                 <span className="sortsel-lbl">sort</span>
                 {SORTS.map(([k, l]) => (
@@ -463,34 +335,51 @@ function ModelsCatalog() {
               </div>
             </div>
 
-            <div className="mtable">
-              <div className="mhead">
-                <span>model</span>
-                <span>ctx</span>
-                <span className="ar">in /1M</span>
-                <span className="ar">out /1M</span>
-                <span>modality</span>
-              </div>
-              {error ? (
+            {error ? (
+              <div className="mtable">
                 <div className="mempty">failed to load models — {error}</div>
-              ) : isLoading && models.length === 0 ? (
+              </div>
+            ) : isLoading && models.length === 0 ? (
+              <div className="mtable">
                 <div className="mempty">loading models…</div>
-              ) : (
-                rows.map((m) => (
-                  <ModelRow
-                    key={m.id}
-                    m={m}
-                    open={open === m.id}
-                    onToggle={() => setOpen(open === m.id ? null : m.id)}
-                  />
-                ))
-              )}
-              {!isLoading && !error && rows.length === 0 && (
+              </div>
+            ) : rows.length === 0 ? (
+              <div className="mtable">
                 <div className="mempty">no models match “{q}”</div>
-              )}
-            </div>
+              </div>
+            ) : view === "cards" ? (
+              <div className="mcards">
+                {rows.map((m) => (
+                  <ModelCard key={m.id} m={m} />
+                ))}
+              </div>
+            ) : (
+              <div className="mtable-scroll">
+                <div className="mtable captable">
+                  <div className="captable-head captable-row">
+                    <span>model</span>
+                    <span>ctx</span>
+                    <span className="ar">in /1M</span>
+                    <span className="ar">out /1M</span>
+                    <span className="ar">int</span>
+                    <span className="ar">code</span>
+                    <span className="ar">agnt</span>
+                    <span className="ar">spd</span>
+                    <span className="ar">rel</span>
+                    <span>modality</span>
+                  </div>
+                  <div className="captable-body">
+                    {rows.map((m) => (
+                      <CapRow key={m.id} m={m} axes={caps.get(m.id)!} />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+
             <div className="mcat-foot">
-              {rows.length} of {models.length} shown · zero markup on every model
+              {rows.length} of {models.length} shown · axes 0–100 · agentic +
+              reliability estimated · zero markup on every model
             </div>
           </div>
         </div>

--- a/components/models/rank-list.tsx
+++ b/components/models/rank-list.tsx
@@ -1,0 +1,38 @@
+/* RankList — the right-hand "ranked · this week" panel. Each row links to the
+   model page and shows rank · color swatch · provider · id · share % · WoW
+   delta (the ▲▼ that gives the "trending" feel). */
+
+import * as React from "react";
+import Link from "next/link";
+import { ProviderIcon } from "./provider-icon";
+import { type RankedRow } from "@/lib/model-usage";
+
+export function RankList({ ranked, total }: { ranked: RankedRow[]; total: number }) {
+  if (!ranked.length) {
+    return <div className="usage-empty">no routed traffic yet</div>;
+  }
+  return (
+    <>
+      <div className="ranklist">
+        {ranked.map((r) => {
+          const up = r.delta >= 0;
+          return (
+            <Link href={`/models/${r.id}`} className="rankrow" key={r.id}>
+              <span className="rankrow-n">{r.rank}</span>
+              <span className="rankrow-sw" style={{ background: r.color }} />
+              <ProviderIcon provider={r.provider} size={14} className="mrow-ico" />
+              <span className="rankrow-id">{r.id}</span>
+              <span className="rankrow-share">{r.share.toFixed(0)}%</span>
+              <span className={"rankrow-delta " + (up ? "up" : "down")}>
+                {up ? "▲" : "▼"} {Math.abs(r.delta).toFixed(1)}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+      <div className="ranklist-foot">
+        top {ranked.length} of {total} routed models · share of calls
+      </div>
+    </>
+  );
+}

--- a/components/models/usage-chart.tsx
+++ b/components/models/usage-chart.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/* UsageChart — one thin stacked bar per day of routed-call volume, one segment
+   per top model + a muted "other" tail. Built on the shadcn Chart (Recharts)
+   for hover tooltips. Series keys are sanitized (s0…s7, other) so the
+   `--color-*` CSS vars are valid; the tooltip label maps back to the real id.
+   X-axis shows a label every 7 days (weekly) over the daily bars. */
+
+import * as React from "react";
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { type UsageSeries } from "@/lib/model-usage";
+
+export function UsageChart({
+  days,
+  series,
+}: {
+  days: string[];
+  series: UsageSeries[];
+}) {
+  if (!days.length || !series.length) {
+    return <div className="usage-empty">no routed traffic yet</div>;
+  }
+
+  const keyed = series.map((se, i) => ({
+    ...se,
+    ck: se.id === null ? "other" : `s${i}`,
+  }));
+
+  const config: ChartConfig = {};
+  for (const se of keyed) {
+    config[se.ck] = { label: se.id ?? "other", color: se.color };
+  }
+
+  const data = days.map((d, di) => {
+    const row: Record<string, string | number> = { day: d };
+    for (const se of keyed) row[se.ck] = Math.round(se.values[di]);
+    return row;
+  });
+
+  return (
+    <ChartContainer config={config} className="usage-chart">
+      <BarChart data={data} margin={{ left: 0, right: 0, top: 4, bottom: 0 }} barCategoryGap={1}>
+        <CartesianGrid vertical={false} strokeDasharray="2 4" />
+        <XAxis
+          dataKey="day"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={10}
+          interval={6}
+        />
+        <ChartTooltip
+          cursor={{ fillOpacity: 0.08 }}
+          content={<ChartTooltipContent indicator="dot" />}
+        />
+        {keyed.map((se, i) => (
+          <Bar
+            key={se.ck}
+            dataKey={se.ck}
+            stackId="a"
+            fill={`var(--color-${se.ck})`}
+            isAnimationActive={false}
+            // round the top of the column (its topmost "other" segment) to match
+            // the rounded tracks/pills used elsewhere on the page
+            radius={i === keyed.length - 1 ? [2, 2, 0, 0] : 0}
+          />
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
+
+import { cn } from "@/lib/utils";
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const;
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  );
+};
+
+type ChartContextProps = {
+  config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+function useChart() {
+  const context = React.useContext(ChartContext);
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />");
+  }
+  return context;
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig;
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"];
+}) {
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className,
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, cfg]) => cfg.theme || cfg.color,
+  );
+
+  if (!colorConfig.length) {
+    return null;
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
+  })
+  .join("\n")}
+}
+`,
+          )
+          .join("\n"),
+      }}
+    />
+  );
+};
+
+const ChartTooltip = RechartsPrimitive.Tooltip;
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<"div"> & {
+  active?: boolean;
+  // recharts v3 no longer surfaces payload/label on Tooltip's public props, so
+  // we type the render-prop shape ourselves.
+  payload?: any[];
+  label?: unknown;
+  labelFormatter?: (label: unknown, payload: any[]) => React.ReactNode;
+  labelClassName?: string;
+  formatter?: (
+    value: unknown,
+    name: unknown,
+    item: any,
+    index: number,
+    payload: unknown,
+  ) => React.ReactNode;
+  color?: string;
+  hideLabel?: boolean;
+  hideIndicator?: boolean;
+  indicator?: "line" | "dot" | "dashed";
+  nameKey?: string;
+  labelKey?: string;
+}) {
+  const { config } = useChart();
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null;
+    }
+
+    const [item] = payload;
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label;
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      );
+    }
+
+    if (!value) {
+      return null;
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ]);
+
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot";
+
+  return (
+    <div
+      className={cn(
+        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+        className,
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload.map((item, index) => {
+          const key = `${nameKey || item.name || item.dataKey || "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+          const indicatorColor = color || item.payload?.fill || item.color;
+
+          return (
+            <div
+              key={item.dataKey}
+              className={cn(
+                "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
+                indicator === "dot" && "items-center",
+              )}
+            >
+              {formatter && item?.value !== undefined && item.name ? (
+                formatter(item.value, item.name, item, index, item.payload)
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <div
+                        className={cn(
+                          "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                          {
+                            "h-2.5 w-2.5": indicator === "dot",
+                            "w-1": indicator === "line",
+                            "w-0 border-[1.5px] border-dashed bg-transparent":
+                              indicator === "dashed",
+                            "my-0.5": nestLabel && indicator === "dashed",
+                          },
+                        )}
+                        style={
+                          {
+                            "--color-bg": indicatorColor,
+                            "--color-border": indicatorColor,
+                          } as React.CSSProperties
+                        }
+                      />
+                    )
+                  )}
+                  <div
+                    className={cn(
+                      "flex flex-1 justify-between leading-none",
+                      nestLabel ? "items-end" : "items-center",
+                    )}
+                  >
+                    <div className="grid gap-1.5">
+                      {nestLabel ? tooltipLabel : null}
+                      <span className="text-muted-foreground">
+                        {itemConfig?.label || item.name}
+                      </span>
+                    </div>
+                    {item.value !== undefined && (
+                      <span className="text-foreground font-mono font-medium tabular-nums">
+                        {item.value.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const ChartLegend = RechartsPrimitive.Legend;
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> & {
+  payload?: any[];
+  verticalAlign?: "top" | "bottom";
+  hideIcon?: boolean;
+  nameKey?: string;
+}) {
+  const { config } = useChart();
+
+  if (!payload?.length) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className,
+      )}
+    >
+      {payload.map((item) => {
+        const key = `${nameKey || item.dataKey || "value"}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
+
+        return (
+          <div
+            key={item.value}
+            className={cn(
+              "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3",
+            )}
+          >
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{ backgroundColor: item.color }}
+              />
+            )}
+            {itemConfig?.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string,
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string;
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config];
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+};

--- a/docs/superpowers/specs/2026-07-13-models-radar-capability-design.md
+++ b/docs/superpowers/specs/2026-07-13-models-radar-capability-design.md
@@ -1,0 +1,325 @@
+# Models page — capability radar + cards/table + model pages
+
+**Date:** 2026-07-13
+**Status:** Draft for review
+**Scope:** Frames 2, 3, 4 of the models-page refactor. Frame 1 (the live-router hero) is **deferred** — see [Deferred](#deferred).
+
+---
+
+## 1. Goal
+
+Reframe `/models` from a flat price catalog into a **capability surface**: every model is shown as a
+capability *shape*, and that same shape is what the router matches a call against. Two ways to read the
+same data:
+
+- **Cards view** — each model's capability shown as a radar (its "fingerprint").
+- **Table view** — the radar's axes shown as sortable numeric columns.
+
+Clicking any model opens a **dedicated model page** (a real route, not an inline expand), which shows the
+full shape plus *how the router uses this model*.
+
+This session is **UI/UX + mock data only**. No telemetry, no live routing. The data model is wired so the
+mock → real swap is a single function later.
+
+Core value-prop tie-in: the capability shape is the substrate the context-aware router reasons over. This
+page is the "what the router sees" reference; the routing *decision* itself is the deferred hero.
+
+### Non-goals
+- Frame 1 live-router hero (deferred).
+- Any real routing telemetry, traffic shares, or "% of calls" that isn't clearly labelled mock.
+- Changing the filter sidebar, search, or the underlying `useModels` data flow.
+- A new radar charting dependency — the radar is hand-rolled SVG (see §3).
+
+---
+
+## 2. The shared capability model
+
+One vocabulary of **six axes** drives the card radar, the table columns, and the model page. Six axes = a
+clean hexagon and it's the largest set that stays legible at card size (~150px). The axes are chosen to
+reflect BitRouter's moat, **not** to mirror Artificial Analysis's benchmark breakdown — three describe
+capability, three describe what the model costs to run in production.
+
+| Axis | Meaning | Source now | Normalize to 0–100 |
+|---|---|---|---|
+| `intelligence` | general capability | **real** — `intelligenceIndex` (0–100) | passthrough |
+| `coding` | coding ability | **real** — `codingIndex` (0–100) | passthrough |
+| `agentic` | tool-use / multi-step | **mock** — no field yet | deterministic mock (§2.1) |
+| `cost` | **affordability** (cheaper = higher) | **real** — `pricing.input` | inverse log-scale: cheap → 100 |
+| `speed` | output throughput | **real** — `outputTokensPerSecond` | log-scale 5–300 tok/s → 0–100 |
+| `reliability` | uptime / failover success | **mock** — BitRouter telemetry later | deterministic mock (§2.1) |
+
+Design notes:
+- **Not the AA axes.** Academic benchmarks (math, GPQA, MMLU) are dropped. `intelligence` is the one axis
+  that overlaps AA's headline index; it's kept as a familiar anchor. `agentic` and `reliability` are axes
+  AA structurally can't publish — `reliability` especially, since only a router in the request path sees
+  provider health and failover. That axis is the moat, drawn.
+- **`cost` is plotted as affordability, never raw price.** On a radar, outward = better on every axis or
+  the shape lies. So the `cost` spoke plots inverse-normalized price (cheap = outward); the raw `$` price
+  still appears as plain fields. (This supersedes the earlier draft's "cost is never an axis" — it enters
+  as affordability, distinct from the price fields.)
+- **Correlation is intentional.** The three capability axes (`intelligence`/`coding`/`agentic`) move
+  together, so models differ most on the operational axes (`cost`/`speed`/`reliability`). The resulting
+  silhouette is a **value-frontier signature**: open models render fat on cost/speed/reliability with
+  respectable capability; frontier models render lean on cost, spiky on capability. That open→frontier
+  gradient is the pitch, drawn automatically.
+- `speed` (throughput) and latency (`timeToFirstToken`) are different. The radar uses `speed`; `p50 ttft`
+  stays a plain field.
+- **Axis order is fixed everywhere**, clockwise from top: `intelligence, coding, agentic, cost, speed,
+  reliability` — capability axes grouped on one side, operational on the other, so the value seesaw reads.
+  Reordering changes the silhouette, so the order is a constant, never per-model.
+- **Data backing:** 4 of 6 axes are real today (`intelligence`, `coding`, `cost`, `speed`); `agentic` and
+  `reliability` are mock-first this session. `reliability`'s real source is BitRouter's own routing
+  telemetry — which is exactly why it can't be copied from a benchmark site.
+
+### 2.1 `lib/model-capability.ts` (new)
+
+Single source of truth for axes + normalization + the mock fallback.
+
+```ts
+export const AXES = ["intelligence", "coding", "agentic", "cost", "speed", "reliability"] as const;
+export type Axis = (typeof AXES)[number];
+export type AxisSet = Record<Axis, number>;              // each 0..100
+export type SourceSet = Record<Axis, "real" | "mock">;   // per-axis provenance
+
+export function capabilityAxes(m: Model): { axes: AxisSet; sources: SourceSet };
+```
+
+- Per-axis provenance: `intelligence`/`coding`/`speed` are `real` when `m.benchmarks` has them, and `cost`
+  is always `real` (derived from `pricing.input`); `agentic`/`reliability` are always `mock` for now.
+- **Real axes with missing data** (dev has no `AA_API_KEY`, or a model AA doesn't cover) fall back to a
+  **deterministic** mock seeded by a hash of `m.id` (stable across renders/reloads), biased by
+  `pricing.input` and `maxInputTokens` so pricier/larger models look stronger — plausible, not random —
+  and marked `mock`.
+- Any axis whose source is `mock` is tagged in the UI (a small `~ estimated`), so we never imply a number
+  we don't have. Real axes are attributed to Artificial Analysis; `reliability`/`agentic` to BitRouter.
+
+---
+
+## 3. Radar component
+
+`components/models/capability-radar.tsx` (new) — pure inline SVG, no dependency.
+
+```ts
+type Props = {
+  values: AxisSet;
+  size?: number;              // px, default 120
+  variant?: "filled" | "outline";
+  showLabels?: boolean;       // axis labels around the ring
+  className?: string;
+  title?: string;             // <title> for a11y, e.g. "qwen/qwen-3.7 capability shape"
+};
+```
+
+- Renders 3 concentric hex grid rings + 6 spokes + the value polygon.
+- Colors via `currentColor` / mono tokens (`--line`, `--mono`, `--accent`) so it themes with `.br-mono`.
+  No `<style>` color blocks.
+- `role="img"` + `<title>`/`<desc>`; the numeric values are also exposed in adjacent text (card
+  footer / table cells), so the chart is never the *only* representation of the data.
+- **Two visual jobs, one component, deliberately distinct treatments:**
+  - Card + model page = a model's *fixed* shape → `variant="filled"`, quiet, single polygon.
+  - (Reserved) hero decision = the *deciding* verb → not this component; deferred with Frame 1.
+
+---
+
+## 4. Frame 2 — Cards view
+
+Grid of model cards; each card is a link to `/models/{id}`. **Each card is a two-column split: facts on
+the left, radar on the right** — the radar is the visual anchor and a row of cards gets a clean vertical
+rhythm of radars down the right edge.
+
+```
+[▦ cards] [▤ table]                                          sort: in$ ▾
+
+┌─ one card · facts left, radar right ─────────────────┐   grid: auto-fit
+│ ◈ qwen/qwen-3.7          oss     intelligence         │   3-up desktop,
+│ fast · open                        ·▲·                │   2-up tablet,
+│                            relia·⟋  ▨▨  ⟍·coding      │   1-up mobile
+│ in   $0.07 / 1M                ⟍ ▨████▨ ⟋             │
+│ out  $0.28 / 1M            speed·⟍  ▨▨  ⟋·agentic     │   ▨ filled shape
+│ ctx  256K · TXT                    ·▼·                │   ~ = estimated axes
+│ ~ agentic·reliability est         cost               │
+└───────────────────────────────────────────────────────┘
+whole card → <a href="/models/{id}">  · no expand · no terminal in card
+```
+
+**Card anatomy — a flex/grid split (`1fr | auto`):**
+
+*Left column (facts, top → bottom):*
+1. Header: provider icon + `m.id` (truncating) + `oss` badge if open-source.
+2. Tier + tier class (`fast · open` / `balanced · open` / `frontier`) — reuse `tierOf()`.
+3. Price: `in` / `out` per 1M (reuse `formatCompactPricePerMillionTokens`).
+4. Meta: `ctx` + modality tags (`modTag`).
+5. `~ estimated` tag naming which axes are mock (from `sources`), when any are.
+
+*Right column:*
+6. `capability-radar` `variant="filled"`, `showLabels`, ~120px, vertically centered.
+
+**Layout:** card is `display:flex` (facts `1fr`, radar `auto`), `align-items:center`. Grid of cards is
+`repeat(auto-fit, minmax(280px, 1fr))` — 3-up desktop, 2-up tablet, 1-up mobile, no breakpoints. On the
+narrowest 1-up cards the small radar can stay beside the facts, or wrap below — decide in build.
+
+**Interaction:** whole card is an `<a href="/models/{id}">`; hover raises border (`--line` → strong). No
+expand. No terminal in the card (the terminal moves to the model page).
+
+---
+
+## 5. Frame 3 — Table view
+
+The existing `.mtable` extended: five axes become numeric columns, everything sortable, rows link out.
+
+```
+[▦ cards] [▤ table]                                    sort: any column ▾
+
+model                     ctx    in/1M  out/1M │ int code agnt spd rel │ mod
+────────────────────────────────────────────── │ ──────────────────────│ ────
+qwen/qwen-3.7        oss   256K   $0.07  $0.28  │  61   72   58   90  88 │ TXT
+deepseek/deepseek-v4pro    164K   $0.20  $0.80  │  78   80   74   61  84 │ TXT
+moonshot/kimi-k2.6   oss   200K   $0.15  $2.50  │  70   68   66   55  79 │ TXT
+claude-opus-4.8            200K   $15.0  $75.0  │  95   90   92   50  99 │ TXT·IMG
+────────────────────────────────────────────── │ ──────────────────────│ ────
+   axes 0–100 · int/code/agentic/speed/reliability · cost = the $ columns · ~ estimated
+```
+
+**Columns:** `model` (icon + id + oss) · `ctx` · `in/1M` · `out/1M` · **`int` `code` `agnt` `spd` `rel`**
+(0–100, `tabular-nums`, right-aligned; `agnt`/`rel` rendered faint + `~`-flagged since they're mock) ·
+`modality`. The radar's 6th axis, `cost`, is **not** a duplicate 0–100 column — it's already represented
+by the `in/1M` + `out/1M` price columns. So five axis columns map to five spokes; the sixth (cost) maps
+to the price columns. `ctx` stays a plain fact column (it is no longer a radar axis).
+
+**Sorting:** extend the existing `SORTS`/`cmp` map with `intelligence|coding|agentic|speed|reliability`
+(cost is already covered by the `in$`/`out$` sorts). Clicking a column header sorts by it (asc/desc
+toggle); the toolbar `sort` pills stay as a secondary control. Default sort unchanged (`in$`).
+
+**Rows:** each row is a link to `/models/{id}`. No caret, no expand, no per-row terminal (all removed).
+
+**Responsive:** the five axis columns are the overflow risk. On `< 900px` wrap the table body in an
+`overflow-x: auto` scroller (the `model` column stays sticky-left); do **not** drop columns silently.
+
+---
+
+## 6. View switch (cards ⇄ table)
+
+- A segmented control in the existing `.toolbar`, right of Filters, left of `sort`:
+  `[▦ cards] [▤ table]`, `role="group"`, each button `aria-pressed`.
+- State in `mono-models-page.tsx`: `const [view, setView] = useState<"cards"|"table">(...)`.
+- **Persistence:** reflect in the URL as `?view=cards|table` (shareable, SSR-friendly) and mirror to
+  `localStorage` for the next visit. URL wins on load.
+- **Default:** `cards` on first visit (leads with the new capability shape); returning users get their
+  last choice. *(Open question — see §10.)*
+- Only the list region swaps. Toolbar (search / oss / filters / sort) and the page head are shared.
+
+---
+
+## 7. Frame 4 — Per-model page
+
+**Kill the inline expand entirely.** Cards and rows link to `/models/{id}`, which already exists at
+`app/(home)/models/[...slug]/page.tsx` (server-rendered, `fetchModelById`, canonical URL, `notFound()`).
+This route is **re-skinned to mono** and **enriched**, not rebuilt.
+
+```
+/models/qwen/qwen-3.7                                        ← all models
+
+┌──────────────────────────────────────────────────────────────────────────┐
+│ ◈ Qwen · qwen/qwen-3.7          oss · fast · open      [ copy id ] [ key ] │
+│ 256K ctx · $0.07 in · $0.28 out · p50 61ms                                │
+└──────────────────────────────────────────────────────────────────────────┘
+
+┌ capability shape ─────────────┐   ┌ how the router uses this model ───────┐
+│       intelligence            │   │ policies routing here          (mock) │
+│  relia·⟋ ▨▨ ⟍·coding          │   │  ● cost     default open pool  ▓▓▓▓▓▓ │
+│      ⟍▨████▨⟋                 │   │  ◆ latency  fast tier          ▓▓▓░░░ │
+│  speed·⟍▨▨⟋·agentic           │   │  ▲ balance  under 0.6 cx       ▓▓▓▓░░ │
+│        cost                   │   │  ✕ accuracy rarely             ░░░░░░ │
+│ intel ██████░61  code ███████ │   │ role   reads · edits · format         │
+│ agentic █████58  cost █████████│   │ ~78% of cost-policy calls  (mock)     │
+│ speed █████████90  relia ████88│   └───────────────────────────────────────┘
+└───────────────────────────────┘
+┌ pricing & limits ────────────┐    ┌ call · qwen/qwen-3.7 ─────────────────┐
+│ input $0.07 · output $0.28   │    │ $ bitrouter chat --model qwen/qwen-3.7│
+│ cache $0.01 · ctx 256K · TXT │    │ ✓ routed → qwen · 61ms · $.07/$.28 ▍  │
+└──────────────────────────────┘    └── compare: deepseek-v4 · kimi-k2.6 ───┘
+```
+
+**Sections:**
+1. **Header** — keep existing content (provider, name, `m.id`, copy-id, API-key CTA), re-skinned to mono
+   (`h-display`, mono tokens; drop `RuledSectionLabel`/`Button` warm styling). Add a one-line stat strip
+   (`ctx · in · out · p50`).
+2. **Capability shape** — `capability-radar` (larger, ~200px) beside horizontal axis bars for all six
+   axes (`intelligence · coding · agentic · cost · speed · reliability`), each 0–100 with its value.
+   Real axes attributed to Artificial Analysis; `agentic`/`reliability` `~ estimated` and attributed to
+   BitRouter telemetry.
+3. **How the router uses this model** *(new, mock)* — the differentiator vs an AA card. Which of the four
+   policies (cost / accuracy / latency / balance) route here, the model's role (reads/edits/reasoning/…),
+   and an illustrative traffic share. **Every number here is labelled `(mock)`** until telemetry exists.
+4. **Pricing & limits** — the existing overview stat grid, re-skinned; add cache tiers when present.
+5. **Call terminal** — reuse the mono `Terminal` (the program currently inline in the expand row moves
+   here).
+6. **Compare** — links to `/compare/{a}-vs-{b}` for 2–3 sibling models (same tier or same provider),
+   reusing the existing compare route.
+7. **Quickstart** — keep the OpenAI + Anthropic `SnippetCard`s, re-skinned.
+
+**Metadata:** keep `generateMetadata`; extend description to mention the capability axes so the page is a
+strong GEO/citation surface (each model = one indexable URL).
+
+---
+
+## 8. Mock data plan
+
+- `capabilityAxes(m)` (§2.1) is the only mock surface for the shapes — cards, table, and model page all
+  read through it, so they agree. `intelligence`/`coding`/`speed` use real AA values when present (mock
+  fallback when missing); `cost` is always real (from `pricing.input`); `agentic`/`reliability` are always
+  mock this session, with `reliability`'s real source being BitRouter routing telemetry later.
+- The model page's "how the router uses this model" panel is **fully mock** for now: a small static map
+  keyed by `tierOf(m)` (e.g. `fast/open` → cost-heavy; `frontier` → accuracy-heavy) so it's plausible and
+  consistent, every figure tagged `(mock)`.
+- No mock in the price/context/modality fields — those are already real from `useModels`.
+
+---
+
+## 9. Files
+
+**New**
+- `lib/model-capability.ts` — axes, normalization, `capabilityAxes()`, mock fallback.
+- `components/models/capability-radar.tsx` — SVG radar.
+- `components/models/model-card.tsx` — the card (§4).
+- (optional) `components/models/axis-bars.tsx` — the horizontal 0–100 bars for the model page.
+
+**Modified**
+- `components/models/mono-models-page.tsx` — add `view` state + URL/localStorage sync, view switch in
+  toolbar, render cards grid or table, extend sort map, **remove the expand/`ModelRow` detail + per-row
+  terminal**, make rows/cards link to `/models/{id}`.
+- `app/(home)/models/[...slug]/page.tsx` — re-skin to mono; add capability + router-usage sections.
+- `components/landing/mono/mono.css` — card classes (`.mcard*`), axis-column classes, radar helpers,
+  view-switch classes, model-page section classes.
+
+**Untouched**
+- `lib/models-server.ts`, `lib/models-data.ts`, `useModels`, `FilterSidebar`, search/filter logic.
+
+---
+
+## 10. Open questions (for review)
+
+1. **Default view** — cards or table on first visit? Spec proposes **cards** (showcases the shape); table
+   is the denser lookup. Reasonable to flip to table if `/models` is treated as a pure utility.
+2. **Table axis columns on mobile** — horizontal scroll (spec's choice) vs. collapse axes into a single
+   "shape" mini-radar cell vs. hide axes under `< 900px`. Scroll keeps all data; mini-radar is prettier
+   but less precise.
+3. **"How the router uses this model"** — keep it first-class on the model page even while fully mock, or
+   gate it behind a flag until telemetry lands? Spec keeps it (labelled) because it's the panel that makes
+   the page *ours* and not a re-skinned AA card.
+4. **Mock shapes when AA data is missing** — acceptable to ship estimated shapes with a `~` tag, or only
+   render radars for models that have real AA coverage (and show a "no benchmark" state otherwise)? Note
+   `agentic` + `reliability` are *always* estimated this session regardless, so some `~` is unavoidable.
+5. **`agentic` real source** — no field is fetched today. Options later: AA's agentic/tool-use index if
+   licensed, or BitRouter's own tool-call success telemetry (same pipe as `reliability`). Which do we aim
+   the mock at?
+
+---
+
+## Deferred
+
+**Frame 1 — live-router hero.** Deferred by decision on 2026-07-13. Open thread: radar is likely the
+*wrong* grammar for the hero (radar = one entity's profile; the hero's verb is a live routing *decision*
+across four co-equal policies). Candidate grammars parked for later: live decision lanes, a traffic-flow
+Sankey, or a compact route ticker. Revisit after Frames 2–4 land. Whatever it becomes, it must read as a
+different *verb* than the card/table radars so the page isn't radar-on-radar.

--- a/lib/model-capability.ts
+++ b/lib/model-capability.ts
@@ -1,0 +1,215 @@
+/* Capability model — the shared vocabulary behind the Models radar, the cards,
+   the table columns, and the per-model page.
+
+   Six axes reflect BitRouter's moat rather than mirror Artificial Analysis's
+   benchmark breakdown: three capability (intelligence / coding / agentic) and
+   three operational (cost / speed / reliability).
+
+   ┌──────────────────────────────────────────────────────────────────────────┐
+   │ SWITCH TO REAL DATA BEFORE MERGE.                                          │
+   │ `capabilityAxes` and `routerUsage` are deterministic MOCKS (shapes seeded  │
+   │ by model id; every axis flagged `~ estimated` in the UI except `cost`,     │
+   │ which is real, derived from the model's input price). Wire real sources:   │
+   │   • intelligence / coding → Artificial Analysis (or your evals)            │
+   │   • agentic / reliability → BitRouter routing telemetry                    │
+   │   • routerUsage policy mix / role / share → routing telemetry              │
+   │ Keep the return shapes identical; the components need no changes. */
+
+import { type Model } from "@/lib/models-types";
+
+export const AXES = [
+  "intelligence",
+  "coding",
+  "agentic",
+  "cost",
+  "speed",
+  "reliability",
+] as const;
+export type Axis = (typeof AXES)[number];
+export type AxisSet = Record<Axis, number>; // each 0..100
+export type SourceSet = Record<Axis, "real" | "mock">;
+
+export const AXIS_META: Record<Axis, { label: string; short: string }> = {
+  intelligence: { label: "intelligence", short: "int" },
+  coding: { label: "coding", short: "code" },
+  agentic: { label: "agentic", short: "agnt" },
+  cost: { label: "cost", short: "cost" },
+  speed: { label: "speed", short: "spd" },
+  reliability: { label: "reliability", short: "rel" },
+};
+
+/* ---- deterministic RNG so a model's mock shape is stable across renders ---- */
+function hashStr(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+function mulberry32(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/* Input price ($/1M) mapped to a 0..1 quality proxy (pricier → more capable)
+   and to affordability (cheaper → higher). Fixed log bounds keep the scale
+   stable as the catalog changes. */
+const P_MIN = 0.05;
+const P_MAX = 75;
+function priceT(price: number): number {
+  if (!price || price <= 0) return 0.3;
+  const p = Math.min(P_MAX, Math.max(P_MIN, price));
+  return (Math.log(p) - Math.log(P_MIN)) / (Math.log(P_MAX) - Math.log(P_MIN));
+}
+export function affordability(price: number): number {
+  if (!price || price <= 0) return 100;
+  return Math.round((1 - priceT(price)) * 100);
+}
+
+export function capabilityAxes(m: Model): { axes: AxisSet; sources: SourceSet } {
+  const rnd = mulberry32(hashStr(m.id));
+  const q = priceT(m.pricing.input); // 0..1, pricier → more capable
+  const j = () => (rnd() - 0.5) * 0.16; // deterministic per-axis jitter
+  const clamp = (x: number) => Math.max(8, Math.min(99, Math.round(x)));
+
+  const axes: AxisSet = {
+    intelligence: clamp(100 * (0.4 + 0.55 * q + j())),
+    coding: clamp(100 * (0.42 + 0.52 * q + j())),
+    agentic: clamp(100 * (0.38 + 0.55 * q + j())),
+    cost: affordability(m.pricing.input),
+    speed: clamp(100 * (0.5 + 0.42 * (1 - q) + j())),
+    reliability: clamp(100 * (0.74 + 0.22 * rnd())),
+  };
+  const sources: SourceSet = {
+    intelligence: "mock",
+    coding: "mock",
+    agentic: "mock",
+    cost: "real",
+    speed: "mock",
+    reliability: "mock",
+  };
+  return { axes, sources };
+}
+
+/* ---- coarse tier from price (used for labels + router-usage archetype) ---- */
+export type Tier = "frontier" | "balanced" | "fast" | "reasoning";
+export function modelTier(m: Model): Tier {
+  const id = m.id.toLowerCase();
+  if (/(^|\/)(o1|o3|o4)|r1|reason|think|qwq/.test(id)) return "reasoning";
+  const p = m.pricing.input;
+  if (p >= 10) return "frontier";
+  if (p >= 2) return "balanced";
+  return "fast";
+}
+
+/* ---- "how the router uses this model" — fully mock, keyed by tier ---- */
+export type PolicyKey = "cost" | "accuracy" | "latency" | "balance";
+export const POLICY_META: Record<PolicyKey, { label: string; mark: string }> = {
+  cost: { label: "cost", mark: "●" },
+  accuracy: { label: "accuracy", mark: "◆" },
+  latency: { label: "latency", mark: "◇" },
+  balance: { label: "balance", mark: "▲" },
+};
+
+const POLICY_ORDER: PolicyKey[] = ["cost", "accuracy", "latency", "balance"];
+
+type Archetype = {
+  w: Record<PolicyKey, number>;
+  notes: Record<PolicyKey, string>;
+  role: string;
+};
+
+function archetype(tier: Tier): Archetype {
+  switch (tier) {
+    case "frontier":
+      return {
+        w: { cost: 0.12, accuracy: 0.9, latency: 0.28, balance: 0.46 },
+        notes: {
+          cost: "rarely — too costly",
+          accuracy: "hard reasoning",
+          latency: "only if pinned",
+          balance: "high-stakes paths",
+        },
+        role: "reasoning · hard edits · verification",
+      };
+    case "reasoning":
+      return {
+        w: { cost: 0.3, accuracy: 0.8, latency: 0.22, balance: 0.5 },
+        notes: {
+          cost: "budget reasoning",
+          accuracy: "multi-step",
+          latency: "non-interactive",
+          balance: "planning",
+        },
+        role: "multi-step reasoning · planning",
+      };
+    case "balanced":
+      return {
+        w: { cost: 0.55, accuracy: 0.5, latency: 0.52, balance: 0.82 },
+        notes: {
+          cost: "mid-complexity",
+          accuracy: "when the floor rises",
+          latency: "tool calls",
+          balance: "default workhorse",
+        },
+        role: "medium calls · retrieval · tools",
+      };
+    default:
+      return {
+        w: { cost: 0.9, accuracy: 0.12, latency: 0.82, balance: 0.62 },
+        notes: {
+          cost: "default open pool",
+          accuracy: "rarely",
+          latency: "fast tier",
+          balance: "under 0.6 complexity",
+        },
+        role: "reads · edits · format · classify",
+      };
+  }
+}
+
+export function routerUsage(m: Model): {
+  policies: { key: PolicyKey; label: string; mark: string; weight: number; note: string }[];
+  role: string;
+  dominant: PolicyKey;
+  shareNote: string;
+} {
+  const a = archetype(modelTier(m));
+  const policies = POLICY_ORDER.map((key) => ({
+    key,
+    label: POLICY_META[key].label,
+    mark: POLICY_META[key].mark,
+    weight: a.w[key],
+    note: a.notes[key],
+  }));
+  const dominant = POLICY_ORDER.reduce((best, k) => (a.w[k] > a.w[best] ? k : best), POLICY_ORDER[0]);
+  const share = Math.round(a.w[dominant] * 85);
+  return { policies, role: a.role, dominant, shareNote: `~${share}% of ${dominant}-policy calls` };
+}
+
+/* ---- small display helpers shared by cards / table / page ---- */
+export function formatCtx(tokens: number): string {
+  if (!tokens) return "—";
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(0)}M`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
+  return String(tokens);
+}
+
+const MOD_TAG: Record<string, string> = {
+  text: "TXT",
+  image: "IMG",
+  audio: "AUD",
+  video: "VID",
+  embedding: "EMB",
+  "function-calling": "FN",
+  tools: "FN",
+};
+export function modTag(mod: string): string {
+  return MOD_TAG[mod.toLowerCase()] ?? mod.slice(0, 3).toUpperCase();
+}

--- a/lib/model-usage.ts
+++ b/lib/model-usage.ts
@@ -1,0 +1,159 @@
+/* Mock "what the router routed to" usage series for the Models ranking hero.
+
+   ┌──────────────────────────────────────────────────────────────────────────┐
+   │ SWITCH TO REAL DATA BEFORE MERGE.                                          │
+   │ This whole module is a deterministic MOCK (labelled "sample" in the UI).  │
+   │ Replace `mockUsage` with real BitRouter routing telemetry:                │
+   │   • daily routed-call counts per model over the window (→ series[].values)│
+   │   • this-week vs last-week share per model (→ ranked[].share / .delta)     │
+   │ Keep the return shape (MockUsage) identical and the components + chart     │
+   │ need no changes. Until then it stays biased toward open + cheap models so  │
+   │ the stack matches the "route the routine majority to open models" story.  │
+   └──────────────────────────────────────────────────────────────────────────┘ */
+
+import { type Model } from "@/lib/models-types";
+import {
+  providerFromId,
+  isOpenSourceModel,
+  modelDisplayName,
+} from "@/lib/models-filter";
+
+// Fixed daily window generated from a constant start date so it's deterministic
+// across SSR/CSR (no Date.now → no hydration drift). One bar per day.
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const DAYS = 84; // 12 weeks, one bar per day
+const START_MS = new Date(2026, 4, 12).getTime(); // May 12 2026 (fixed)
+export const DAY_LABELS = Array.from({ length: DAYS }, (_, i) => {
+  const d = new Date(START_MS + i * 86_400_000);
+  return `${MONTHS[d.getMonth()]} ${d.getDate()}`;
+});
+export const WEEKS_SPAN = Math.round(DAYS / 7);
+
+const TOP_N = 8;
+// Cool single-family ramp anchored on the brand accent (violet → cyan) so the
+// stack reads as one on-brand gradient, not a clashing rainbow; long tail
+// collapses to muted gray.
+const COLORS = [
+  "#b57bf0", "#9b7cf2", "#7f83f2", "#6a90f0",
+  "#5aa2ee", "#46b6ea", "#39c6e2", "#33d6cf",
+];
+const OTHER_COLOR = "#3d3f49";
+
+function hashStr(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+function rngFor(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Mock popularity weight: open + cheap models get the bulk of routed traffic.
+function usageWeight(m: Model): number {
+  const base = 0.3 + 0.7 * rngFor(hashStr(m.id))();
+  const open = isOpenSourceModel(m) ? 2.3 : 0.85;
+  const price = m.pricing.input || 0.1;
+  const t = Math.min(1, Math.log(price + 1) / Math.log(80)); // 0 cheap → 1 pricey
+  const cheap = 1.5 - t; // cheap → ~1.5, frontier → ~0.5
+  return base * open * cheap;
+}
+
+export type UsageSeries = {
+  key: string;
+  id: string | null;
+  label: string;
+  provider: string | null;
+  color: string;
+  values: number[]; // one routed-call count per day
+};
+export type RankedRow = {
+  rank: number;
+  id: string;
+  provider: string;
+  label: string;
+  share: number;
+  delta: number;
+  color: string;
+};
+export type MockUsage = {
+  days: string[];
+  series: UsageSeries[]; // base → top for stacking (rank 1 at base, "other" on top)
+  ranked: RankedRow[];
+  total: number;
+};
+
+function sumRange(a: number[], start: number, end: number): number {
+  let s = 0;
+  for (let i = start; i < end; i++) s += a[i];
+  return s;
+}
+
+export function mockUsage(models: Model[]): MockUsage {
+  const days = DAY_LABELS;
+  const D = days.length;
+  if (!models.length) return { days, series: [], ranked: [], total: 0 };
+
+  const scored = models
+    .map((m) => ({ m, w: usageWeight(m) }))
+    .sort((a, b) => b.w - a.w);
+  const top = scored.slice(0, TOP_N);
+  const rest = scored.slice(TOP_N);
+
+  const growth = (i: number) => 0.5 + 0.5 * (i / (D - 1)); // 0.5 → 1.0 over the window
+  const wobble = (id: string, i: number) =>
+    1 + (rngFor(hashStr(id + ":" + i))() - 0.5) * 0.5; // day-to-day jitter for texture
+  // Skewed (Zipf-like) share by global rank so a couple of models dominate the
+  // stack and the long tail stays a modest slice — the shape real routed
+  // traffic takes, not an even spread.
+  const shareByRank = (rank1: number) => 1 / Math.pow(rank1, 1.5);
+  const valuesFor = (id: string, rank1: number) =>
+    days.map((_, i) => shareByRank(rank1) * growth(i) * wobble(id, i) * 15000);
+
+  const topSeries: UsageSeries[] = top.map(({ m }, i) => ({
+    key: m.id,
+    id: m.id,
+    label: modelDisplayName(m),
+    provider: providerFromId(m.id),
+    color: COLORS[i] ?? COLORS[COLORS.length - 1],
+    values: valuesFor(m.id, i + 1),
+  }));
+
+  const otherValues = days.map((_, i) =>
+    rest.reduce(
+      (s, { m }, j) => s + shareByRank(TOP_N + 1 + j) * growth(i) * wobble(m.id, i) * 15000,
+      0,
+    ),
+  );
+  const series: UsageSeries[] = [
+    ...topSeries,
+    { key: "other", id: null, label: "other", provider: null, color: OTHER_COLOR, values: otherValues },
+  ];
+
+  // Rank by share of the last 7 days; delta vs the prior 7 days.
+  const lastWeekTotal = series.reduce((s, se) => s + sumRange(se.values, D - 7, D), 0);
+  const prevWeekTotal = series.reduce((s, se) => s + sumRange(se.values, D - 14, D - 7), 0);
+  const ranked: RankedRow[] = topSeries.map((se, i) => {
+    const shareLast = (sumRange(se.values, D - 7, D) / lastWeekTotal) * 100;
+    const sharePrev = (sumRange(se.values, D - 14, D - 7) / prevWeekTotal) * 100;
+    return {
+      rank: i + 1,
+      id: se.id as string,
+      provider: se.provider as string,
+      label: se.label,
+      share: shareLast,
+      delta: shareLast - sharePrev,
+      color: se.color,
+    };
+  });
+
+  return { days, series, ranked, total: models.length };
+}


### PR DESCRIPTION
Rebuilds `/models` from a flat price catalog into a **capability surface**: every model is shown as the capability *shape* the router matches a call against, and the page opens with **"what the router routed to"** — a routed-usage ranking. All charts share the shadcn Chart (Recharts) stack with hover tooltips.

## ⚠️ Switch to real data before merge

**Everything is deterministic MOCK**, labelled `sample` / `~ estimated` in the UI. Do not merge as live data. Swap points (return shapes stay identical — components need no changes):

- [ ] **`lib/model-usage.ts` → `mockUsage`** — replace with real BitRouter routing telemetry: daily routed-call counts per model (`series[].values`) + this-week/last-week share (`ranked[].share`/`.delta`). See the `SWITCH TO REAL DATA` block at the top of the file.
- [ ] **`lib/model-capability.ts` → `capabilityAxes`** — `intelligence`/`coding` from Artificial Analysis (or our evals); `agentic`/`reliability` from routing telemetry. `cost` is **already real** (from input price). See the `SWITCH TO REAL DATA` block.
- [ ] **`lib/model-capability.ts` → `routerUsage`** — the model page's "how the router uses this model" panel (policy mix / role / share) is mock; wire to routing telemetry.

Until wired, keep the `sample` / `~ estimated` labels visible.

## What's in it

- **Ranking hero** — daily stacked bar chart of routed-call share (dominant open models at the base, long tail as muted "other") + a ranked list with week-over-week ▲▼ deltas. Each row links to the model page.
- **Cards ⇄ table view switch** (`?view=` + localStorage). Cards show a capability radar; table shows the same six axes as sortable columns.
- **Per-model pages** (`models/[...slug]`) re-skinned to mono: capability radar + axis bars, the router-usage panel, an animated call terminal, pricing, and similar-model links. Each model = one indexable URL (GEO).
- **Six moat axes** — `intelligence · coding · agentic · cost · speed · reliability` — deliberately *not* the Artificial Analysis breakdown; `cost` plotted as affordability so bigger-is-better holds on every spoke.
- **Shared shadcn chart wrapper** (`components/ui/chart.tsx`), adapted for recharts v3.
- Design spec: `docs/superpowers/specs/2026-07-13-models-radar-capability-design.md`.

## Notes / decisions

- Radars use Recharts everywhere (incl. the 63-up cards grid) for consistency; verified it renders and scrolls without errors.
- SVG-coordinate hydration mismatches avoided (Recharts renders empty on SSR; the one remaining hand-SVG path was removed).
- `isAnimationActive={false}` on bars is required or Recharts leaves them at ~0 height (ResponsiveContainer measures from 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
