### PR TITLE
ci: push changelog snapshot to the console on release

### DIFF
--- a/.github/workflows/notify-console-changelog.yml
+++ b/.github/workflows/notify-console-changelog.yml
@@ -1,0 +1,66 @@
+name: Notify Console Changelog
+
+# When curated changelog content lands on main, push the changelog snapshot to
+# the BitRouter console so its "What's new" panel updates right away (rather
+# than waiting for the console to poll). The payload is HMAC-signed with
+# CHANGELOG_WEBHOOK_SECRET — the same secret the console verifies with.
+#
+# Setup:
+#   • Actions secret  CHANGELOG_WEBHOOK_SECRET  — must equal the console's env
+#     value (generate once with `openssl rand -hex 32`, set in both).
+#   • Actions variable CONSOLE_URL (optional)   — console origin; defaults to
+#     https://cloud.bitrouter.ai.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "content/changelog/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: notify-console-changelog
+  cancel-in-progress: true
+
+jobs:
+  notify:
+    name: Push changelog snapshot to the console
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # Only js-yaml is needed to read the frontmatter; skip postinstall
+      # (fumadocs codegen) so this stays fast and can't fail on build concerns.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build changelog payload
+        run: node scripts/emit-changelog-json.mjs > changelog.json
+
+      - name: Push signed snapshot to the console
+        env:
+          CHANGELOG_WEBHOOK_SECRET: ${{ secrets.CHANGELOG_WEBHOOK_SECRET }}
+          CONSOLE_URL: ${{ vars.CONSOLE_URL || 'https://cloud.bitrouter.ai' }}
+        run: |
+          if [ -z "$CHANGELOG_WEBHOOK_SECRET" ]; then
+            echo "::error::CHANGELOG_WEBHOOK_SECRET is not set in Actions secrets"
+            exit 1
+          fi
+          # HMAC-SHA256 over the exact bytes we POST (openssl prints
+          # "HMAC-SHA256(changelog.json)= <hex>" — take the last field).
+          sig="sha256=$(openssl dgst -sha256 -hmac "$CHANGELOG_WEBHOOK_SECRET" changelog.json | awk '{print $NF}')"
+          curl -fsS -X POST "$CONSOLE_URL/api/webhooks/changelog" \
+            -H "Content-Type: application/json" \
+            -H "X-Changelog-Signature: $sig" \
+            --data-binary @changelog.json
+          echo "Pushed changelog snapshot to $CONSOLE_URL"

--- a/scripts/emit-changelog-json.mjs
+++ b/scripts/emit-changelog-json.mjs
@@ -1,0 +1,62 @@
+/**
+ * Emit the curated changelog as JSON — `{ items: ChangelogItem[] }` — for the
+ * BitRouter console's "What's New" webhook (POST /api/webhooks/changelog).
+ *
+ * Mirrors the fumadocs changelog source (`getChangelogItems` in lib/source.ts):
+ * one MDX file per entry under content/changelog, `url = /changelog/<stem>`,
+ * with the frontmatter fields declared in source.config.ts (title, description,
+ * date, version, tags, breaking). Kept dependency-light (js-yaml only, like
+ * generate-changelog-latest.mjs) so the notify workflow needs no build step.
+ *
+ * Writes JSON to stdout; diagnostics to stderr.
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+const DIR = "content/changelog";
+const BASE_URL = "/changelog";
+
+function readFrontmatter(src) {
+  const match = src.match(/^---\n([\s\S]*?)\n---/);
+  return match ? (yaml.load(match[1]) ?? {}) : {};
+}
+
+let files = [];
+try {
+  files = (await readdir(DIR)).filter(
+    // Default-locale entries only: skip `name.<locale>.mdx` variants so the
+    // payload matches getChangelogItems("en").
+    (f) => f.endsWith(".mdx") && !/\.[a-z]{2}\.mdx$/.test(f),
+  );
+} catch {
+  // No changelog dir yet — emit an empty snapshot.
+}
+
+const items = [];
+for (const file of files) {
+  const slug = file.replace(/\.mdx$/, "");
+  const fm = readFrontmatter(await readFile(join(DIR, file), "utf8"));
+  if (typeof fm.title !== "string" || typeof fm.date !== "string") {
+    process.stderr.write(`skip ${file}: missing title/date\n`);
+    continue;
+  }
+  items.push({
+    slug,
+    url: `${BASE_URL}/${slug}`,
+    title: fm.title,
+    description: typeof fm.description === "string" ? fm.description : undefined,
+    date: fm.date,
+    version: typeof fm.version === "string" ? fm.version : undefined,
+    tags: Array.isArray(fm.tags)
+      ? fm.tags.filter((t) => typeof t === "string")
+      : [],
+    breaking: fm.breaking === true,
+  });
+}
+
+// Newest first (ISO YYYY-MM-DD sorts lexicographically).
+items.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+
+process.stderr.write(`emit-changelog-json: ${items.length} item(s)\n`);
+process.stdout.write(JSON.stringify({ items }));


### PR DESCRIPTION
Producer side of the console's **What's New** pipeline (Step 4 of replacing UserJot).

When curated changelog content lands on `main`, emit the changelog as JSON and POST it (HMAC-signed) to the BitRouter console's ingest webhook, so its What's New panel updates immediately instead of the console polling.

## What's here
- **`scripts/emit-changelog-json.mjs`** — reads `content/changelog/*.mdx` frontmatter (js-yaml, same style as `generate-changelog-latest.mjs`) into the same `ChangelogItem` shape the site uses (`url = /changelog/<slug>`). No build step needed.
- **`.github/workflows/notify-console-changelog.yml`** — on push to `main` touching `content/changelog/**` (or manual dispatch): build the payload, HMAC-SHA256 sign it with `CHANGELOG_WEBHOOK_SECRET`, and `POST /api/webhooks/changelog` on the console.

## Setup required before this does anything
- Add Actions secret **`CHANGELOG_WEBHOOK_SECRET`** — must equal the console's env value (`openssl rand -hex 32`, set identically in both).
- Optional Actions variable **`CONSOLE_URL`** — console origin (defaults to `https://cloud.bitrouter.ai`).

## Validation
- Generator runs clean against current content → 22 items, correct shape.
- Confirmed the workflow's `openssl` HMAC byte-for-byte matches the console's `createHmac` verification, so signatures will be accepted.

Console side (ingest webhook `/api/webhooks/changelog`, `changelog_items` table, What's New panel + unread badge) is on the console branch `claude/userjot-feedback-whats-new-aebccb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)