### PR TITLE
feat(recipes): add recipe gallery fed by the OSS catalog

### DIFF
--- a/app/(home)/recipes/[slug]/page.tsx
+++ b/app/(home)/recipes/[slug]/page.tsx
@@ -1,0 +1,39 @@
+import { setRequestLocale } from "next-intl/server";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { ZedRecipeDetail } from "@/components/landing/zed/recipe-detail";
+import { fetchRecipeBySlug, fetchRecipes } from "@/lib/recipes-server";
+
+type Props = { params: Promise<{ slug: string }> };
+
+/**
+ * Pre-render whatever the catalog holds at build time; anything merged
+ * upstream afterwards is rendered on first request and then cached, so a new
+ * recipe never needs a docs deploy.
+ */
+export async function generateStaticParams() {
+  const recipes = await fetchRecipes();
+  return recipes.map((recipe) => ({ slug: recipe.slug }));
+}
+
+export default async function RecipeDetailPage({ params }: Props) {
+  const { slug } = await params;
+  setRequestLocale("en");
+
+  const recipe = await fetchRecipeBySlug(slug);
+  if (!recipe) notFound();
+
+  return <ZedRecipeDetail recipe={recipe} />;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const recipe = await fetchRecipeBySlug(slug);
+  if (!recipe) return {};
+
+  return {
+    title: `${recipe.title} — BitRouter recipe`,
+    description: recipe.description,
+    alternates: { canonical: `https://bitrouter.ai/recipes/${recipe.slug}` },
+  };
+}

--- a/app/(home)/recipes/page.tsx
+++ b/app/(home)/recipes/page.tsx
@@ -1,0 +1,19 @@
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import type { Metadata } from "next";
+import { ZedRecipesPage } from "@/components/landing/zed/recipes-page";
+import { fetchRecipes } from "@/lib/recipes-server";
+
+export default async function Page() {
+  setRequestLocale("en");
+  const recipes = await fetchRecipes();
+  return <ZedRecipesPage recipes={recipes} />;
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations({ locale: "en", namespace: "Recipes" });
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    alternates: { canonical: "https://bitrouter.ai/recipes" },
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,6 +7,7 @@ import {
   getChangelogItems,
 } from "@/lib/source";
 import { fetchModels } from "@/lib/models-server";
+import { fetchRecipes } from "@/lib/recipes-server";
 
 export const dynamic = "force-static";
 
@@ -59,6 +60,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
+  // ── Recipe pages (catalog fetched from the OSS repo at build) ──
+  const recipes = await fetchRecipes();
+  const recipePages: Entry[] = recipes.map((recipe) => ({
+    url: `${BASE_URL}/recipes/${recipe.slug}`,
+    lastModified: recipe.updatedAt ? new Date(recipe.updatedAt) : undefined,
+    changeFrequency: "monthly",
+    priority: 0.6,
+  }));
+
   // ── Blog posts (English-only; auto-populates as posts land) ──
   const blogPages: Entry[] = blogSource.getPages("en").map((page) => ({
     url: `${BASE_URL}${page.url}`,
@@ -102,6 +112,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     [
       { url: BASE_URL, file: "app/(home)/page.tsx", priority: 1.0, changeFrequency: "weekly" },
       { url: `${BASE_URL}/models`, file: "app/(home)/models/page.tsx", priority: 0.9, changeFrequency: "weekly" },
+      { url: `${BASE_URL}/recipes`, file: "app/(home)/recipes/page.tsx", priority: 0.8, changeFrequency: "weekly" },
       { url: `${BASE_URL}/pricing`, file: "app/(home)/pricing/page.tsx", priority: 0.8, changeFrequency: "monthly" },
       { url: `${BASE_URL}/compare`, file: "app/(home)/compare/(index)/page.tsx", priority: 0.9, changeFrequency: "monthly" },
       { url: `${BASE_URL}/enterprise`, file: "app/(home)/enterprise/page.tsx", priority: 0.6, changeFrequency: "monthly" },
@@ -135,6 +146,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...staticPages,
     zhLanding,
     ...modelPages,
+    ...recipePages,
     ...blogPages,
     ...changelogPages,
     ...legalPages,

--- a/components/header/nav-config.ts
+++ b/components/header/nav-config.ts
@@ -27,6 +27,7 @@ export interface NavItem {
 // always renders — it's the canonical money page for prospects and customers.
 const NAV_ITEMS: NavItem[] = [
   { key: "models", label: "Models", webPath: "/models" },
+  { key: "recipes", label: "Recipes", webPath: "/recipes" },
   { key: "pricing", label: "Pricing", webPath: "/pricing" },
   { key: "blog", label: "Blog", webPath: "/blog" },
   { key: "changelog", label: "Changelog", webPath: "/changelog" },

--- a/components/landing/footer-nav.test.ts
+++ b/components/landing/footer-nav.test.ts
@@ -45,6 +45,13 @@ describe("buildFooterColumns", () => {
     expect(labels).toContain("Startup");
     expect(labels).not.toContain("Providers");
   });
+  it("Product puts Recipes next to Models — both are catalog pages", () => {
+    const product = buildFooterColumns().find((c) => c.title === "Product")!;
+    expect(product.links.map((l) => l.label)).toEqual([
+      "Models", "Recipes", "Pricing", "Enterprise", "Startup",
+    ]);
+    expect(product.links.find((l) => l.label === "Recipes")!.href).toBe("/recipes");
+  });
   it("Resources folds in Compare alongside its static links", () => {
     const res = buildFooterColumns().find((c) => c.title === "Resources")!;
     expect(res.links.map((l) => l.label)).toEqual([

--- a/components/landing/footer-nav.ts
+++ b/components/landing/footer-nav.ts
@@ -3,6 +3,7 @@ export type FooterColumn = { title: string; links: FooterLink[] };
 
 const PRODUCT: FooterLink[] = [
   { label: "Models", href: "/models" },
+  { label: "Recipes", href: "/recipes" },
   { label: "Pricing", href: "/pricing" },
   { label: "Enterprise", href: "/enterprise" },
   { label: "Startup", href: "/startup" },

--- a/components/landing/zed/recipe-body.tsx
+++ b/components/landing/zed/recipe-body.tsx
@@ -1,0 +1,22 @@
+import { remark } from "remark";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import { toJsxRuntime } from "hast-util-to-jsx-runtime";
+import { Fragment, jsx, jsxs } from "react/jsx-runtime";
+
+/**
+ * A recipe's long-form body, authored as `README.md` in the OSS repo and
+ * carried verbatim in the catalog. Rendered on the server into plain HTML
+ * elements, which `.zed-article` already styles — the body is prose from a
+ * trusted first-party source, not MDX, so no component mapping is needed.
+ */
+export async function RecipeBody({ markdown }: { markdown: string }) {
+  const processor = remark().use(remarkGfm).use(remarkRehype);
+  const tree = await processor.run(processor.parse({ value: markdown }));
+
+  return (
+    <div className="zed-article">
+      {toJsxRuntime(tree, { development: false, jsx, jsxs, Fragment })}
+    </div>
+  );
+}

--- a/components/landing/zed/recipe-detail.tsx
+++ b/components/landing/zed/recipe-detail.tsx
@@ -1,0 +1,323 @@
+import "./zed.css";
+import Link from "next/link";
+import { Kicker, YamlBlock } from "./primitives";
+import { CopySnippet } from "@/components/models/copy-snippet";
+import { RecipeBody } from "./recipe-body";
+import { TONE_COLOR } from "./recipe-tone";
+import {
+  METRIC_ROWS,
+  formatMetric,
+  formatRequirement,
+  metricDelta,
+} from "@/lib/recipes-format";
+import type { Recipe } from "@/lib/recipes-types";
+
+const LABEL: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  letterSpacing: "0.14em",
+  textTransform: "uppercase",
+  color: "var(--z-ink-7)",
+};
+
+const MONO: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 12.5,
+  color: "var(--z-ink-3)",
+};
+
+export function ZedRecipeDetail({ recipe }: { recipe: Recipe }) {
+  const evaluation = recipe.evaluation;
+
+  return (
+    <div className="zed-bg">
+      <section style={{ position: "relative" }}>
+        <div className="zed-glow" />
+        <div className="zed-wrap" style={{ maxWidth: 940 }}>
+          <div style={{ padding: "40px 0 0" }}>
+            <Link href="/recipes" className="zed-link" style={LABEL}>
+              ← all recipes
+            </Link>
+          </div>
+
+          {/* ── Header ─────────────────────────────────────────────── */}
+          <div style={{ padding: "24px 0 30px" }}>
+            <Kicker>
+              // {recipe.workflow}
+              {recipe.harness.length > 0 && ` · ${recipe.harness.join(" · ")}`}
+            </Kicker>
+            <h1
+              className="zed-display"
+              style={{
+                fontSize: "clamp(30px, 4.6vw, 42px)",
+                lineHeight: 1.05,
+                margin: "14px 0 0",
+                maxWidth: "24ch",
+              }}
+            >
+              {recipe.title}
+            </h1>
+            <p
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 14,
+                lineHeight: 1.65,
+                color: "var(--z-ink-4)",
+                margin: "14px 0 0",
+                maxWidth: "68ch",
+              }}
+            >
+              {recipe.description}
+            </p>
+          </div>
+
+          {evaluation && <Measured recipe={recipe} />}
+
+          <Prerequisites recipe={recipe} />
+
+          {/* ── The policy spec ────────────────────────────────────── */}
+          <section style={{ marginTop: 46 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+              <span style={LABEL}>bitrouter.yaml</span>
+              <span style={{ height: 1, flex: 1, background: "var(--z-rule)" }} />
+              <CopySnippet value={recipe.config} label="Copy bitrouter.yaml" />
+            </div>
+            <div
+              style={{
+                border: "1px solid var(--z-rule)",
+                background: "var(--z-inset)",
+                padding: "18px 20px",
+                marginTop: 14,
+                overflowX: "auto",
+              }}
+            >
+              <YamlBlock lines={recipe.config} style={{ fontSize: 12.5, lineHeight: 1.65 }} />
+            </div>
+          </section>
+
+          {recipe.policyLock && (
+            <section style={{ marginTop: 34 }}>
+              <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+                <span style={LABEL}>policy-lock.yaml</span>
+                <span style={{ height: 1, flex: 1, background: "var(--z-rule)" }} />
+                <CopySnippet value={recipe.policyLock} label="Copy policy-lock.yaml" />
+              </div>
+              <div
+                style={{
+                  border: "1px solid var(--z-rule)",
+                  background: "var(--z-inset)",
+                  padding: "18px 20px",
+                  marginTop: 14,
+                  overflowX: "auto",
+                }}
+              >
+                <YamlBlock
+                  lines={recipe.policyLock}
+                  style={{ fontSize: 12.5, lineHeight: 1.65 }}
+                />
+              </div>
+            </section>
+          )}
+
+          {/* ── Body ───────────────────────────────────────────────── */}
+          {recipe.body && (
+            <section style={{ marginTop: 46 }}>
+              <RecipeBody markdown={recipe.body} />
+            </section>
+          )}
+
+          {/* ── Footer ─────────────────────────────────────────────── */}
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 18,
+              justifyContent: "space-between",
+              borderTop: "1px solid var(--z-rule)",
+              margin: "46px 0 64px",
+              paddingTop: 18,
+            }}
+          >
+            <span style={{ ...MONO, color: "var(--z-ink-6)" }}>
+              updated {recipe.updatedAt}
+            </span>
+            <a
+              className="zed-link"
+              href={recipe.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={MONO}
+            >
+              view source on GitHub →
+            </a>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/**
+ * Baseline vs recipe, metric by metric, with the computed delta. The
+ * provenance line under it is not decoration: a single-run number and a
+ * third-party number mean different things, and both are visible here.
+ */
+function Measured({ recipe }: { recipe: Recipe }) {
+  const evaluation = recipe.evaluation;
+  if (!evaluation) return null;
+
+  const rows = METRIC_ROWS.filter(
+    (row) =>
+      evaluation.baseline[row.key] !== undefined ||
+      evaluation.recipe[row.key] !== undefined,
+  );
+
+  return (
+    <section>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+        <span style={LABEL}>measured</span>
+        <span style={{ height: 1, flex: 1, background: "var(--z-rule)" }} />
+      </div>
+
+      <div style={{ border: "1px solid var(--z-rule)", marginTop: 14 }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1.2fr 1fr 1fr 1fr",
+            borderBottom: "1px solid var(--z-rule)",
+            padding: "10px 18px",
+            gap: 12,
+          }}
+        >
+          <span style={LABEL} />
+          <span style={{ ...LABEL, textAlign: "right" }}>baseline</span>
+          <span style={{ ...LABEL, textAlign: "right" }}>this recipe</span>
+          <span style={{ ...LABEL, textAlign: "right" }}>delta</span>
+        </div>
+
+        {rows.map((row) => {
+          const delta = metricDelta(row.key, evaluation.delta);
+          return (
+            <div
+              key={row.key}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1.2fr 1fr 1fr 1fr",
+                padding: "12px 18px",
+                gap: 12,
+                borderBottom: "1px solid var(--z-rule-faint)",
+              }}
+            >
+              <span style={MONO}>{row.label}</span>
+              <span style={{ ...MONO, textAlign: "right", color: "var(--z-ink-5)" }}>
+                {formatMetric(row.key, evaluation.baseline[row.key])}
+              </span>
+              <span style={{ ...MONO, textAlign: "right", color: "var(--z-ink)" }}>
+                {formatMetric(row.key, evaluation.recipe[row.key])}
+              </span>
+              <span
+                style={{
+                  ...MONO,
+                  textAlign: "right",
+                  color: delta ? TONE_COLOR[delta.tone] : "var(--z-ink-6)",
+                }}
+              >
+                {delta?.value ?? "—"}
+              </span>
+            </div>
+          );
+        })}
+
+        <div style={{ padding: "12px 18px", ...MONO, color: "var(--z-ink-6)", fontSize: 11.5 }}>
+          {evaluation.name} · harness {evaluation.harness}
+          {evaluation.config && ` · config ${evaluation.config}`} ·{" "}
+          {evaluation.runs === 1 ? "1 run per task" : `${evaluation.runs} runs per task`} ·
+          measured by {evaluation.measuredBy} · {evaluation.asOf}
+          {evaluation.sourceUrl && (
+            <>
+              {" · "}
+              <a
+                className="zed-link"
+                href={evaluation.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                full report →
+              </a>
+            </>
+          )}
+        </div>
+      </div>
+
+      {evaluation.baseline.label && (
+        <p style={{ ...MONO, color: "var(--z-ink-6)", margin: "10px 0 0", fontSize: 11.5 }}>
+          Baseline: {evaluation.baseline.label}.
+        </p>
+      )}
+    </section>
+  );
+}
+
+/** What a reader must have before the config does anything. */
+function Prerequisites({ recipe }: { recipe: Recipe }) {
+  return (
+    <section style={{ marginTop: 46 }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+        <span style={LABEL}>you will need</span>
+        <span style={{ height: 1, flex: 1, background: "var(--z-rule)" }} />
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+          border: "1px solid var(--z-rule)",
+          marginTop: 14,
+        }}
+      >
+        <Panel label="providers">
+          {recipe.providers.map((provider) => (
+            <div key={provider.name} style={MONO}>
+              <span style={{ color: "var(--z-blue)" }}>{provider.name}</span>
+              {provider.requires.length > 0 && (
+                <span style={{ color: "var(--z-ink-6)" }}>
+                  {" — "}
+                  {provider.requires.map(formatRequirement).join(", ")}
+                </span>
+              )}
+            </div>
+          ))}
+        </Panel>
+
+        <Panel label="models">
+          {recipe.models.map((model) => (
+            <div key={model} style={MONO}>
+              <Link href={`/models/${model}`} className="zed-link">
+                {model}
+              </Link>
+            </div>
+          ))}
+        </Panel>
+
+        {recipe.env.length > 0 && (
+          <Panel label="environment">
+            {recipe.env.map((name) => (
+              <div key={name} style={{ ...MONO, color: "var(--z-code)" }}>
+                {name}
+              </div>
+            ))}
+          </Panel>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Panel({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ padding: "18px 20px", borderRight: "1px solid var(--z-rule)" }}>
+      <div style={{ ...LABEL, marginBottom: 10 }}>{label}</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>{children}</div>
+    </div>
+  );
+}

--- a/components/landing/zed/recipe-tone.ts
+++ b/components/landing/zed/recipe-tone.ts
@@ -1,0 +1,11 @@
+import type { FormattedDelta } from "@/lib/recipes-format";
+
+/**
+ * Delta colours. Green/amber track *direction of benefit*, not sign — a
+ * −32.8% cost delta and a −1.1 pt accuracy delta must not read the same.
+ */
+export const TONE_COLOR: Record<FormattedDelta["tone"], string> = {
+  good: "var(--z-green)",
+  bad: "var(--z-amber)",
+  neutral: "var(--z-ink-3)",
+};

--- a/components/landing/zed/recipes-page.tsx
+++ b/components/landing/zed/recipes-page.tsx
@@ -1,0 +1,816 @@
+"use client";
+
+import "./zed.css";
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { headlineDelta, formatDeltas } from "@/lib/recipes-format";
+import type { Recipe } from "@/lib/recipes-types";
+import { TONE_COLOR } from "./recipe-tone";
+
+type SortKey = "cost" | "accuracy" | "updated" | "name";
+type View = "table" | "cards";
+
+const optStyle = (on: boolean) =>
+  on ? { background: "#12161d", color: "#8fb4ff" } : { color: "var(--z-ink-4)" };
+const segStyle = (on: boolean) =>
+  on
+    ? { background: "#12161d", color: "#8fb4ff" }
+    : { background: "transparent", color: "var(--z-ink-5)" };
+
+const ALL = "All";
+
+/** The delta a sort key ranks on, or undefined when this recipe didn't measure it. */
+function metric(recipe: Recipe, key: "cost" | "accuracy"): number | undefined {
+  const delta = recipe.evaluation?.delta;
+  return key === "cost" ? delta?.costPerTaskPct : delta?.accuracyPoints;
+}
+
+/** Everything a search box should match: what it is, and what it routes. */
+function haystack(recipe: Recipe): string {
+  return [
+    recipe.slug,
+    recipe.title,
+    recipe.description,
+    recipe.workflow,
+    ...recipe.harness,
+    ...recipe.models,
+    ...recipe.providers.map((provider) => provider.name),
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+/**
+ * The recipe gallery — same shell as the model catalog (filter rail, toolbar,
+ * table / cards), driven entirely by the published catalog: every filter, count
+ * and number below is read off the recipes themselves, none of it is authored
+ * here.
+ */
+export function ZedRecipesPage({ recipes }: { recipes: Recipe[] }) {
+  const [objective, setObjective] = useState(ALL);
+  const [harness, setHarness] = useState(ALL);
+  const [workflow, setWorkflow] = useState(ALL);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortKey>("cost");
+  const [view, setView] = useState<View>("table");
+
+  const facets = useMemo(() => {
+    const collect = (pick: (recipe: Recipe) => string[]) => {
+      const counts = new Map<string, number>();
+      for (const recipe of recipes) {
+        for (const value of new Set(pick(recipe))) {
+          counts.set(value, (counts.get(value) ?? 0) + 1);
+        }
+      }
+      return [...counts.entries()].sort(
+        (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+      );
+    };
+    return {
+      objectives: collect((recipe) => recipe.objectives),
+      harnesses: collect((recipe) => recipe.harness),
+      workflows: collect((recipe) => [recipe.workflow]),
+    };
+  }, [recipes]);
+
+  const rows = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const filtered = recipes.filter(
+      (recipe) =>
+        (objective === ALL || recipe.objectives.includes(objective)) &&
+        (harness === ALL || recipe.harness.includes(harness)) &&
+        (workflow === ALL || recipe.workflow === workflow) &&
+        (!query || haystack(recipe).includes(query)),
+    );
+
+    return [...filtered].sort((a, b) => {
+      if (sort === "name") return a.title.localeCompare(b.title);
+      if (sort === "updated") return b.updatedAt.localeCompare(a.updatedAt);
+      // Rank on the measured move, biggest win first; unmeasured metrics sink.
+      const key = sort === "cost" ? "cost" : "accuracy";
+      const av = metric(a, key);
+      const bv = metric(b, key);
+      if (av === undefined && bv === undefined) return a.title.localeCompare(b.title);
+      if (av === undefined) return 1;
+      if (bv === undefined) return -1;
+      return key === "cost" ? av - bv : bv - av;
+    });
+  }, [recipes, objective, harness, workflow, search, sort]);
+
+  const filtersActive =
+    objective !== ALL || harness !== ALL || workflow !== ALL || search !== "";
+  const reset = () => {
+    setObjective(ALL);
+    setHarness(ALL);
+    setWorkflow(ALL);
+    setSearch("");
+  };
+
+  return (
+    <div className="zed-bg">
+      <section style={{ position: "relative" }}>
+        <div className="zed-glow" />
+        <div className="zed-wrap" style={{ maxWidth: 1180 }}>
+          <div style={{ height: 44 }} />
+
+          <div style={{ border: "1px solid var(--z-rule)" }}>
+            <CatalogSummary recipes={recipes} />
+
+            {/* ── catalog: rail + main ── */}
+            <div
+              style={{ display: "grid", gridTemplateColumns: "212px minmax(0,1fr)" }}
+              className="zed-models-body"
+            >
+              <aside
+                style={{ borderRight: "1px solid var(--z-rule)", padding: "18px 14px" }}
+                className="zed-hide-sm"
+              >
+                <div style={{ display: "flex", alignItems: "center", margin: "0 8px 16px" }}>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 10,
+                      letterSpacing: "0.14em",
+                      textTransform: "uppercase",
+                      color: "var(--z-ink-7)",
+                    }}
+                  >
+                    filters
+                  </span>
+                  <button
+                    onClick={reset}
+                    disabled={!filtersActive}
+                    style={{
+                      marginLeft: "auto",
+                      cursor: filtersActive ? "pointer" : "default",
+                      background: "none",
+                      border: "none",
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 11,
+                      color: filtersActive ? "#8fb4ff" : "var(--z-ink-8)",
+                    }}
+                  >
+                    clear
+                  </button>
+                </div>
+
+                <FilterGroup title="optimizes for">
+                  <FilterBtn
+                    label={ALL}
+                    count={String(recipes.length)}
+                    active={objective === ALL}
+                    onClick={() => setObjective(ALL)}
+                  />
+                  {facets.objectives.map(([value, count]) => (
+                    <FilterBtn
+                      key={value}
+                      label={value}
+                      count={String(count)}
+                      active={objective === value}
+                      onClick={() => setObjective(value)}
+                    />
+                  ))}
+                </FilterGroup>
+
+                <FilterGroup title="harness">
+                  <FilterBtn
+                    label={ALL}
+                    count={String(recipes.length)}
+                    active={harness === ALL}
+                    onClick={() => setHarness(ALL)}
+                  />
+                  {facets.harnesses.map(([value, count]) => (
+                    <FilterBtn
+                      key={value}
+                      label={value}
+                      count={String(count)}
+                      active={harness === value}
+                      onClick={() => setHarness(value)}
+                    />
+                  ))}
+                </FilterGroup>
+
+                <FilterGroup title="workflow">
+                  <FilterBtn
+                    label={ALL}
+                    count={String(recipes.length)}
+                    active={workflow === ALL}
+                    onClick={() => setWorkflow(ALL)}
+                  />
+                  {facets.workflows.map(([value, count]) => (
+                    <FilterBtn
+                      key={value}
+                      label={value}
+                      count={String(count)}
+                      active={workflow === value}
+                      onClick={() => setWorkflow(value)}
+                    />
+                  ))}
+                </FilterGroup>
+              </aside>
+
+              <div style={{ minWidth: 0 }}>
+                {/* toolbar */}
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 12,
+                    flexWrap: "wrap",
+                    padding: "14px 16px",
+                    borderBottom: "1px solid var(--z-rule)",
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 9,
+                      background: "var(--z-inset)",
+                      border: "1px solid var(--z-rule)",
+                      borderRadius: 7,
+                      padding: "7px 11px",
+                      flex: 1,
+                      minWidth: 180,
+                    }}
+                  >
+                    <svg
+                      width="13"
+                      height="13"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="#6b727e"
+                      strokeWidth="2"
+                      style={{ flex: "0 0 auto" }}
+                    >
+                      <circle cx="11" cy="11" r="7" />
+                      <path d="M21 21l-4-4" />
+                    </svg>
+                    <input
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      placeholder="Search recipes…"
+                      style={{
+                        flex: 1,
+                        background: "none",
+                        border: "none",
+                        outline: "none",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 12.5,
+                        color: "var(--z-ink)",
+                        minWidth: 0,
+                      }}
+                    />
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+                    <span
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 11,
+                        color: "var(--z-ink-7)",
+                      }}
+                    >
+                      sort
+                    </span>
+                    <div
+                      style={{
+                        display: "flex",
+                        border: "1px solid var(--z-rule)",
+                        borderRadius: 7,
+                        overflow: "hidden",
+                      }}
+                    >
+                      {(
+                        [
+                          ["cost", "cost Δ"],
+                          ["accuracy", "accuracy Δ"],
+                          ["updated", "updated"],
+                          ["name", "name"],
+                        ] as [SortKey, string][]
+                      ).map(([key, label]) => (
+                        <button
+                          key={key}
+                          onClick={() => setSort(key)}
+                          style={{
+                            cursor: "pointer",
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 11.5,
+                            padding: "6px 11px",
+                            border: "none",
+                            ...segStyle(sort === key),
+                          }}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <div
+                    style={{
+                      display: "flex",
+                      border: "1px solid var(--z-rule)",
+                      borderRadius: 7,
+                      overflow: "hidden",
+                    }}
+                  >
+                    <button
+                      onClick={() => setView("table")}
+                      title="Table"
+                      style={{
+                        cursor: "pointer",
+                        display: "flex",
+                        padding: "6px 10px",
+                        border: "none",
+                        ...segStyle(view === "table"),
+                      }}
+                    >
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                      >
+                        <rect x="3" y="4" width="18" height="16" rx="1" />
+                        <path d="M3 10h18M9 4v16" />
+                      </svg>
+                    </button>
+                    <button
+                      onClick={() => setView("cards")}
+                      title="Cards"
+                      style={{
+                        cursor: "pointer",
+                        display: "flex",
+                        padding: "6px 10px",
+                        border: "none",
+                        borderLeft: "1px solid var(--z-rule)",
+                        ...segStyle(view === "cards"),
+                      }}
+                    >
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                      >
+                        <rect x="3" y="3" width="8" height="8" rx="1" />
+                        <rect x="13" y="3" width="8" height="8" rx="1" />
+                        <rect x="3" y="13" width="8" height="8" rx="1" />
+                        <rect x="13" y="13" width="8" height="8" rx="1" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+
+                {rows.length === 0 ? (
+                  <EmptyState catalogEmpty={recipes.length === 0} />
+                ) : view === "table" ? (
+                  <TableView rows={rows} />
+                ) : (
+                  <CardView rows={rows} />
+                )}
+
+                <div
+                  style={{
+                    padding: "14px 16px",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 12,
+                    color: "var(--z-ink-6)",
+                    borderTop: "1px solid var(--z-rule)",
+                  }}
+                >
+                  {rows.length} of {recipes.length} shown · every published recipe ships the
+                  measured run behind its claim
+                </div>
+              </div>
+            </div>
+          </div>
+          <div style={{ height: 76 }} />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+// ── sub-components ──────────────────────────────────────────────────────
+
+/**
+ * The panel above the catalog. Every figure is computed from the recipes on
+ * screen — the best measured saving, which harnesses are covered, which
+ * evaluations produced the numbers.
+ */
+function CatalogSummary({ recipes }: { recipes: Recipe[] }) {
+  const costDeltas = recipes
+    .map((recipe) => recipe.evaluation?.delta.costPerTaskPct)
+    .filter((value): value is number => value !== undefined);
+  const bestCost = costDeltas.length > 0 ? Math.min(...costDeltas) : undefined;
+  const harnesses = [...new Set(recipes.flatMap((recipe) => recipe.harness))].sort();
+  const evaluations = [
+    ...new Set(recipes.map((recipe) => recipe.evaluation?.name).filter(Boolean)),
+  ].sort();
+
+  return (
+    <div
+      style={{
+        background: "var(--z-inset)",
+        borderBottom: "1px solid var(--z-rule)",
+        padding: "16px 20px",
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: "var(--z-ink-6)",
+        }}
+      >
+        recipes · drop-in bitrouter.yaml per workflow
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 16,
+          flexWrap: "wrap",
+          marginTop: 12,
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+          color: "var(--z-ink-4)",
+        }}
+      >
+        <span>
+          <b style={{ color: "var(--z-blue)" }}>{recipes.length}</b> published
+        </span>
+        {bestCost !== undefined && (
+          <>
+            <span style={{ color: "var(--z-ink-7)" }}>·</span>
+            <span>
+              best measured saving{" "}
+              <b style={{ color: "var(--z-green)" }}>
+                −{Math.abs(bestCost).toFixed(1)}%
+              </b>{" "}
+              cost / task
+            </span>
+          </>
+        )}
+        {harnesses.length > 0 && (
+          <>
+            <span style={{ color: "var(--z-ink-7)" }}>·</span>
+            <span>{harnesses.join(", ")}</span>
+          </>
+        )}
+        {evaluations.length > 0 && (
+          <span style={{ marginLeft: "auto", color: "var(--z-ink-6)" }}>
+            measured on {evaluations.join(", ")}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FilterGroup({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 9.5,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: "var(--z-ink-7)",
+          padding: "0 8px 8px",
+        }}
+      >
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function FilterBtn({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count?: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 9,
+        width: "100%",
+        background: "none",
+        border: "none",
+        cursor: "pointer",
+        textAlign: "left",
+        padding: "6px 8px",
+        borderRadius: 6,
+        fontFamily: "var(--font-mono)",
+        fontSize: 12.5,
+        ...optStyle(active),
+      }}
+    >
+      <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {label}
+      </span>
+      {count && <span style={{ marginLeft: "auto", color: "var(--z-ink-7)" }}>{count}</span>}
+    </button>
+  );
+}
+
+const TABLE_COLS = "minmax(0,2.6fr) 0.9fr 1fr 0.85fr 0.85fr 0.9fr";
+
+function TableView({ rows }: { rows: Recipe[] }) {
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <div style={{ minWidth: 720 }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: TABLE_COLS,
+            background: "var(--z-inset)",
+            borderBottom: "1px solid var(--z-rule)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            color: "var(--z-ink-7)",
+          }}
+        >
+          <div style={{ padding: "11px 16px" }}>recipe</div>
+          <div style={{ padding: "11px 10px" }}>workflow</div>
+          <div style={{ padding: "11px 10px" }}>harness</div>
+          <div style={{ padding: "11px 10px" }}>cost Δ</div>
+          <div style={{ padding: "11px 10px" }}>accuracy Δ</div>
+          <div style={{ padding: "11px 10px" }}>measured</div>
+        </div>
+        {rows.map((recipe) => {
+          const deltas = recipe.evaluation
+            ? formatDeltas(recipe.evaluation.delta)
+            : [];
+          const cost = deltas.find((entry) => entry.metric === "cost/task");
+          const accuracy = deltas.find((entry) => entry.metric === "accuracy");
+          return (
+            <Link
+              key={recipe.slug}
+              href={`/recipes/${recipe.slug}`}
+              className="zed-row-hover"
+              style={{
+                display: "grid",
+                gridTemplateColumns: TABLE_COLS,
+                alignItems: "center",
+                borderBottom: "1px solid var(--z-rule-faint)",
+                textDecoration: "none",
+              }}
+            >
+              <div style={{ padding: "12px 16px", minWidth: 0 }}>
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 12.5,
+                    color: "var(--z-ink-2)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {recipe.title}
+                </div>
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 11,
+                    color: "var(--z-ink-6)",
+                    marginTop: 3,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {recipe.slug}
+                </div>
+              </div>
+              <Cell>{recipe.workflow}</Cell>
+              <Cell>{recipe.harness.join(", ")}</Cell>
+              <DeltaCell value={cost?.value} tone={cost?.tone} />
+              <DeltaCell value={accuracy?.value} tone={accuracy?.tone} />
+              <Cell>
+                {recipe.evaluation
+                  ? `${recipe.evaluation.name} · ${recipe.evaluation.runs}×`
+                  : "—"}
+              </Cell>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function CardView({ rows }: { rows: Recipe[] }) {
+  return (
+    <div
+      className="zed-grid-2"
+      style={{ display: "grid", gridTemplateColumns: "repeat(2,1fr)", padding: 16, gap: 14 }}
+    >
+      {rows.map((recipe) => {
+        const headline = headlineDelta(recipe);
+        return (
+          <Link
+            key={recipe.slug}
+            href={`/recipes/${recipe.slug}`}
+            className="zed-row-hover"
+            style={{
+              border: "1px solid var(--z-rule)",
+              borderRadius: 9,
+              padding: 18,
+              textDecoration: "none",
+              display: "block",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 9,
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                letterSpacing: "0.14em",
+                textTransform: "uppercase",
+                color: "var(--z-ink-7)",
+              }}
+            >
+              <span>{recipe.workflow}</span>
+              <span style={{ color: "var(--z-blue)" }}>{recipe.harness.join(" · ")}</span>
+            </div>
+
+            <div
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontWeight: 600,
+                fontSize: 15,
+                color: "var(--z-ink)",
+                marginTop: 10,
+              }}
+            >
+              {recipe.title}
+            </div>
+            <p
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 12,
+                lineHeight: 1.6,
+                color: "var(--z-ink-4)",
+                margin: "8px 0 0",
+              }}
+            >
+              {recipe.description}
+            </p>
+
+            {headline && (
+              <div style={{ marginTop: 16 }}>
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                    color: "var(--z-ink-7)",
+                  }}
+                >
+                  {headline.metric}
+                </div>
+                <div
+                  style={{
+                    fontFamily: "var(--font-display)",
+                    fontStyle: "italic",
+                    fontSize: 26,
+                    color: TONE_COLOR[headline.tone],
+                    marginTop: 2,
+                  }}
+                >
+                  {headline.value}
+                </div>
+              </div>
+            )}
+
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                marginTop: 16,
+                paddingTop: 14,
+                borderTop: "1px solid var(--z-rule)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 11.5,
+                color: "var(--z-ink-6)",
+                flexWrap: "wrap",
+              }}
+            >
+              {recipe.evaluation && (
+                <>
+                  <span>{recipe.evaluation.name}</span>
+                  <span>·</span>
+                  <span>
+                    {recipe.evaluation.runs === 1
+                      ? "1 run"
+                      : `${recipe.evaluation.runs} runs`}
+                  </span>
+                </>
+              )}
+              <span style={{ marginLeft: "auto" }}>{recipe.updatedAt}</span>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+function Cell({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        padding: "12px 10px",
+        fontFamily: "var(--font-mono)",
+        fontSize: 12,
+        color: "var(--z-ink-5)",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function DeltaCell({
+  value,
+  tone,
+}: {
+  value?: string;
+  tone?: keyof typeof TONE_COLOR;
+}) {
+  return (
+    <div
+      style={{
+        padding: "12px 10px",
+        fontFamily: "var(--font-mono)",
+        fontSize: 12,
+        color: tone ? TONE_COLOR[tone] : "var(--z-ink-7)",
+      }}
+    >
+      {value ?? "—"}
+    </div>
+  );
+}
+
+/**
+ * Distinguishes "your filters match nothing" from "the catalog itself is
+ * empty", which on this page also covers an upstream fetch that failed.
+ */
+function EmptyState({ catalogEmpty }: { catalogEmpty: boolean }) {
+  return (
+    <div
+      style={{
+        padding: "48px 20px",
+        textAlign: "center",
+        fontFamily: "var(--font-mono)",
+        fontSize: 13,
+        color: "var(--z-ink-5)",
+      }}
+    >
+      {catalogEmpty ? (
+        <>
+          No recipes are published yet.{" "}
+          <a
+            className="zed-link"
+            href="https://github.com/bitrouter/bitrouter/tree/main/recipes"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Contribute one →
+          </a>
+        </>
+      ) : (
+        "No recipe matches these filters."
+      )}
+    </div>
+  );
+}

--- a/content/messages/en.json
+++ b/content/messages/en.json
@@ -173,6 +173,10 @@
     "viewTable": "Table view",
     "viewList": "List view"
   },
+  "Recipes": {
+    "metaTitle": "Recipes — ready-made routing policies for agentic workflows",
+    "metaDescription": "Drop-in bitrouter.yaml policy specs for common agentic workflows, each published with the measured run behind its claim."
+  },
   "ModelDetail": {
     "back": "Back to catalog",
     "ctaApiKey": "Get API key",

--- a/content/messages/zh.json
+++ b/content/messages/zh.json
@@ -20,5 +20,9 @@
     "noResults": "未找到结果。",
     "searchDescription": "搜索页面和操作",
     "themeToggle": "切换主题"
+  },
+  "Recipes": {
+    "metaTitle": "配方 — 面向智能体工作流的开箱即用路由策略",
+    "metaDescription": "可直接使用的 bitrouter.yaml 策略配置，覆盖常见智能体工作流；每个配方都附带其结论背后的实测数据。"
   }
 }

--- a/lib/recipes-format.test.ts
+++ b/lib/recipes-format.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatDeltas,
+  headlineDelta,
+  formatRequirement,
+  formatMetric,
+} from "./recipes-format";
+import type { Recipe } from "./recipes-types";
+
+const recipe = (over: Partial<Recipe>): Recipe => ({
+  slug: "x",
+  title: "x",
+  description: "",
+  workflow: "coding",
+  harness: [],
+  objectives: ["cost"],
+  updatedAt: "2026-07-25",
+  providers: [],
+  models: [],
+  env: [],
+  config: "server: {}",
+  body: "",
+  sourceUrl: "https://example.com",
+  ...over,
+});
+
+describe("formatDeltas", () => {
+  it("reads a cost drop as good and an accuracy drop as bad", () => {
+    const out = formatDeltas({ costPerTaskPct: -32.8, accuracyPoints: -1.1 });
+    expect(out).toEqual([
+      { metric: "cost/task", value: "−32.8%", tone: "good" },
+      { metric: "accuracy", value: "−1.1 pts", tone: "bad" },
+    ]);
+  });
+
+  it("omits metrics that were not measured", () => {
+    expect(formatDeltas({ timePerTaskPct: 4.25 })).toEqual([
+      { metric: "time/task", value: "+4.3%", tone: "bad" },
+    ]);
+  });
+});
+
+describe("headlineDelta", () => {
+  const delta = { costPerTaskPct: -32.8, accuracyPoints: -1.1 };
+  const withEvaluation = (objectives: string[]) =>
+    recipe({
+      objectives,
+      evaluation: {
+        name: "terminal-bench-2.1",
+        harness: "codex",
+        measuredBy: "bitrouter",
+        asOf: "2026-07-14",
+        runs: 1,
+        baseline: {},
+        recipe: {},
+        delta,
+      },
+    });
+
+  it("leads with the objective the recipe claims to optimize", () => {
+    expect(headlineDelta(withEvaluation(["cost"]))?.metric).toBe("cost/task");
+    expect(headlineDelta(withEvaluation(["accuracy"]))?.metric).toBe("accuracy");
+  });
+
+  it("falls back to the first measured metric when the objective was not measured", () => {
+    expect(headlineDelta(withEvaluation(["latency"]))?.metric).toBe("cost/task");
+  });
+
+  it("is null without an evaluation", () => {
+    expect(headlineDelta(recipe({}))).toBeNull();
+  });
+});
+
+describe("formatRequirement", () => {
+  it("renders both sign-in flavours as one user-facing word", () => {
+    expect(formatRequirement("local_oauth")).toBe("sign-in");
+    expect(formatRequirement("local_pkce")).toBe("sign-in");
+    expect(formatRequirement("api_key")).toBe("API key");
+  });
+});
+
+describe("formatMetric", () => {
+  it("renders each metric in its own unit, and a gap as an em dash", () => {
+    expect(formatMetric("accuracy", 77.27)).toBe("77.3%");
+    expect(formatMetric("costPerTask", 3.758)).toBe("$3.76");
+    expect(formatMetric("timePerTask", 4.25)).toBe("4.3 min");
+    expect(formatMetric("costPerTask", undefined)).toBe("—");
+  });
+});

--- a/lib/recipes-format.ts
+++ b/lib/recipes-format.ts
@@ -1,0 +1,128 @@
+import type { Recipe, RecipeDelta } from "./recipes-types";
+
+/**
+ * A rendered delta. `tone` is direction-aware rather than sign-aware: −32.8%
+ * cost is good news, −1.1 accuracy points is not, and the card must not paint
+ * them the same colour.
+ */
+export interface FormattedDelta {
+  /** Which metric moved, e.g. `cost/task`. */
+  metric: string;
+  /** Signed, unit-suffixed value, e.g. `−32.8%`. */
+  value: string;
+  tone: "good" | "bad" | "neutral";
+}
+
+const MINUS = "−"; // typographic minus, so −32.8% aligns with tabular nums
+
+function signed(value: number, suffix: string): string {
+  const rounded = Math.abs(value).toFixed(1);
+  if (value > 0) return `+${rounded}${suffix}`;
+  if (value < 0) return `${MINUS}${rounded}${suffix}`;
+  return `0${suffix}`;
+}
+
+/** Lower is better: a negative move is the win. */
+function lowerIsBetter(value: number): FormattedDelta["tone"] {
+  if (value < 0) return "good";
+  if (value > 0) return "bad";
+  return "neutral";
+}
+
+/** Higher is better: a positive move is the win. */
+function higherIsBetter(value: number): FormattedDelta["tone"] {
+  if (value > 0) return "good";
+  if (value < 0) return "bad";
+  return "neutral";
+}
+
+/** Every metric that moved, in a stable order. */
+export function formatDeltas(delta: RecipeDelta): FormattedDelta[] {
+  const out: FormattedDelta[] = [];
+  if (delta.costPerTaskPct !== undefined) {
+    out.push({
+      metric: "cost/task",
+      value: signed(delta.costPerTaskPct, "%"),
+      tone: lowerIsBetter(delta.costPerTaskPct),
+    });
+  }
+  if (delta.timePerTaskPct !== undefined) {
+    out.push({
+      metric: "time/task",
+      value: signed(delta.timePerTaskPct, "%"),
+      tone: lowerIsBetter(delta.timePerTaskPct),
+    });
+  }
+  if (delta.accuracyPoints !== undefined) {
+    out.push({
+      metric: "accuracy",
+      value: signed(delta.accuracyPoints, " pts"),
+      tone: higherIsBetter(delta.accuracyPoints),
+    });
+  }
+  return out;
+}
+
+/**
+ * The one number a card leads with: the movement on the objective the recipe
+ * claims to optimize, so a cost recipe is never advertised by its accuracy.
+ */
+export function headlineDelta(recipe: Recipe): FormattedDelta | null {
+  const delta = recipe.evaluation?.delta;
+  if (!delta) return null;
+
+  const objective = recipe.objectives[0];
+  const all = formatDeltas(delta);
+  const preferred =
+    objective === "latency"
+      ? "time/task"
+      : objective === "accuracy"
+        ? "accuracy"
+        : "cost/task";
+
+  return all.find((entry) => entry.metric === preferred) ?? all[0] ?? null;
+}
+
+/** `api_key` → `API key`, for the prerequisites list. */
+export function formatRequirement(requirement: string): string {
+  switch (requirement) {
+    case "api_key":
+      return "API key";
+    case "base_url":
+      return "base URL";
+    case "local_oauth":
+    case "local_pkce":
+      return "sign-in";
+    default:
+      return requirement.replaceAll("_", " ");
+  }
+}
+
+/** Metric rows shown side by side on a recipe's detail page. */
+export const METRIC_ROWS = [
+  { key: "accuracy", label: "accuracy" },
+  { key: "costPerTask", label: "cost / task" },
+  { key: "timePerTask", label: "time / task" },
+] as const;
+
+export type MetricKey = (typeof METRIC_ROWS)[number]["key"];
+
+/** Render one raw measurement in its own unit. */
+export function formatMetric(key: MetricKey, value: number | undefined): string {
+  if (value === undefined) return "—";
+  switch (key) {
+    case "accuracy":
+      return `${value.toFixed(1)}%`;
+    case "costPerTask":
+      return `$${value.toFixed(2)}`;
+    case "timePerTask":
+      return `${value.toFixed(1)} min`;
+  }
+}
+
+/** The delta belonging to a metric row, already signed and unit-suffixed. */
+export function metricDelta(key: MetricKey, delta: RecipeDelta): FormattedDelta | null {
+  const metric =
+    key === "accuracy" ? "accuracy" : key === "costPerTask" ? "cost/task" : "time/task";
+  return formatDeltas(delta).find((entry) => entry.metric === metric) ?? null;
+}

--- a/lib/recipes-server.ts
+++ b/lib/recipes-server.ts
@@ -1,0 +1,175 @@
+import "server-only";
+
+import type {
+  Recipe,
+  RecipeDelta,
+  RecipeEvaluation,
+  RecipeMeasurement,
+  RecipeProvider,
+} from "@/lib/recipes-types";
+
+/**
+ * The recipe gallery reads the OSS repo's committed catalog directly, the same
+ * way `lib/providers-server.ts` reads the provider registry: no build step and
+ * no cross-repo dispatch, so a recipe merged upstream appears here within one
+ * revalidation window instead of waiting for a docs deploy.
+ */
+const REPO = process.env.BITROUTER_RECIPES_REPO ?? "bitrouter/bitrouter";
+const REF = process.env.BITROUTER_RECIPES_REF ?? "main";
+const CATALOG_URL = `https://raw.githubusercontent.com/${REPO}/${REF}/dist/recipes/index.json`;
+
+/**
+ * Local sibling checkout, for previewing a recipe before it is merged:
+ * `BITROUTER_REPO=../bitrouter pnpm dev`. Unset in production, where the
+ * published catalog on `main` is the only source.
+ */
+const LOCAL_REPO = process.env.BITROUTER_REPO;
+
+const REVALIDATE_SECONDS = 600;
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function num(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+/** `{ en, zh }` from the catalog. The marketing routes are English-only today. */
+function localized(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  return str((value as Record<string, unknown>).en);
+}
+
+function measurement(value: unknown): RecipeMeasurement {
+  const raw = (value ?? {}) as Record<string, unknown>;
+  return {
+    label: str(raw.label),
+    accuracy: num(raw.accuracy),
+    costPerTask: num(raw.cost_per_task),
+    timePerTask: num(raw.time_per_task),
+  };
+}
+
+function delta(value: unknown): RecipeDelta {
+  const raw = (value ?? {}) as Record<string, unknown>;
+  return {
+    accuracyPoints: num(raw.accuracy_points),
+    costPerTaskPct: num(raw.cost_per_task_pct),
+    timePerTaskPct: num(raw.time_per_task_pct),
+  };
+}
+
+function evaluation(value: unknown): RecipeEvaluation | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  const name = str(raw.eval);
+  const harness = str(raw.harness);
+  const measuredBy = str(raw.measured_by);
+  const asOf = str(raw.as_of);
+  if (!name || !harness || !measuredBy || !asOf) return undefined;
+  return {
+    name,
+    harness,
+    config: str(raw.config),
+    measuredBy,
+    sourceUrl: str(raw.source_url),
+    asOf,
+    runs: num(raw.runs) ?? 1,
+    baseline: measurement(raw.baseline),
+    recipe: measurement(raw.recipe),
+    delta: delta(raw.delta),
+  };
+}
+
+function providers(value: unknown): RecipeProvider[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const raw = entry as Record<string, unknown>;
+    const name = str(raw.name);
+    return name ? [{ name, requires: strings(raw.requires) }] : [];
+  });
+}
+
+function parseRecipe(value: unknown): Recipe | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+
+  const slug = str(raw.slug);
+  const title = localized(raw.title);
+  const config = str(raw.config);
+  const body = localized(raw.body);
+  if (!slug || !title || !config) return null;
+
+  return {
+    slug,
+    title,
+    description: localized(raw.description) ?? "",
+    workflow: str(raw.workflow) ?? "",
+    harness: strings(raw.harness),
+    objectives: strings(raw.objectives),
+    updatedAt: str(raw.updated_at) ?? "",
+    providers: providers(raw.providers),
+    models: strings(raw.models),
+    env: strings(raw.env),
+    config,
+    policyLock: str(raw.policy_lock),
+    body: body ?? "",
+    sourceUrl:
+      str(raw.source_url) ??
+      `https://github.com/${REPO}/tree/${REF}/recipes/${slug}`,
+    evaluation: evaluation(raw.evaluation),
+  };
+}
+
+async function fetchCatalog(): Promise<unknown> {
+  const res = await fetch(CATALOG_URL, { next: { revalidate: REVALIDATE_SECONDS } });
+  if (!res.ok) {
+    console.error(`[recipes] catalog fetch failed: HTTP ${res.status}`);
+    return null;
+  }
+  return res.json();
+}
+
+async function readLocalCatalog(repo: string): Promise<unknown> {
+  const { readFile } = await import("node:fs/promises");
+  const { join } = await import("node:path");
+  const raw = await readFile(join(repo, "dist", "recipes", "index.json"), "utf8");
+  return JSON.parse(raw);
+}
+
+/**
+ * Every published recipe, newest first. An unreachable catalog yields an empty
+ * gallery rather than a 500 — it is an upstream dependency, and the rest of
+ * the site does not depend on it being reachable.
+ */
+export async function fetchRecipes(): Promise<Recipe[]> {
+  let payload: unknown;
+  try {
+    payload = LOCAL_REPO ? await readLocalCatalog(LOCAL_REPO) : await fetchCatalog();
+  } catch (error) {
+    console.error("[recipes] catalog read failed:", error);
+    return [];
+  }
+  if (payload === null) return [];
+
+  const data = (payload as { data?: unknown })?.data;
+  if (!Array.isArray(data)) return [];
+
+  return data
+    .map(parseRecipe)
+    .filter((recipe): recipe is Recipe => recipe !== null)
+    .sort(
+      (a, b) => b.updatedAt.localeCompare(a.updatedAt) || a.slug.localeCompare(b.slug),
+    );
+}
+
+export async function fetchRecipeBySlug(slug: string): Promise<Recipe | null> {
+  const recipes = await fetchRecipes();
+  return recipes.find((recipe) => recipe.slug === slug) ?? null;
+}

--- a/lib/recipes-types.ts
+++ b/lib/recipes-types.ts
@@ -1,0 +1,81 @@
+/**
+ * Shapes for the recipe catalog published by the OSS repo at
+ * `dist/recipes/index.json` (built and validated there by
+ * `dist-helper recipes build`).
+ *
+ * The catalog stores **measurements**; the comparative claim a card shows is
+ * the `delta`, which the builder computes from `baseline` vs `recipe` so a
+ * quoted percentage can never disagree with the numbers under it.
+ */
+
+/** One side of a comparison. Every metric is optional but both sides agree. */
+export interface RecipeMeasurement {
+  label?: string;
+  /** Percent of tasks passed (0–100). */
+  accuracy?: number;
+  /** USD per task. */
+  costPerTask?: number;
+  /** Minutes per task. */
+  timePerTask?: number;
+}
+
+/** Computed at build time from the two measurements — never hand-written. */
+export interface RecipeDelta {
+  /** Accuracy moves in points, not percent. */
+  accuracyPoints?: number;
+  costPerTaskPct?: number;
+  timePerTaskPct?: number;
+}
+
+export interface RecipeEvaluation {
+  /** The evaluation the numbers come from, e.g. `terminal-bench-2.1`. */
+  name: string;
+  harness: string;
+  /** Reasoning-effort / configuration label the run used. */
+  config?: string;
+  /** `bitrouter` for our own runs, otherwise the third-party source. */
+  measuredBy: string;
+  /** Citation, required upstream whenever `measuredBy` isn't `bitrouter`. */
+  sourceUrl?: string;
+  /** YYYY-MM-DD. */
+  asOf: string;
+  /** How many times the evaluation was repeated — 1 means single-attempt noise. */
+  runs: number;
+  baseline: RecipeMeasurement;
+  recipe: RecipeMeasurement;
+  delta: RecipeDelta;
+}
+
+/** A provider the recipe turns on, and what the reader must supply for it. */
+export interface RecipeProvider {
+  name: string;
+  /** `api_key` | `base_url` | `local_oauth` | `local_pkce`, from the registry. */
+  requires: string[];
+}
+
+export interface Recipe {
+  slug: string;
+  title: string;
+  description: string;
+  /** Task type the recipe routes, e.g. `coding`. */
+  workflow: string;
+  harness: string[];
+  /** `cost` | `latency` | `accuracy`. */
+  objectives: string[];
+  /** YYYY-MM-DD. */
+  updatedAt: string;
+  providers: RecipeProvider[];
+  /** Canonical model ids the config routes to. */
+  models: string[];
+  /** Environment variables the config interpolates. */
+  env: string[];
+  /** The drop-in `bitrouter.yaml`, verbatim. */
+  config: string;
+  /** The sibling `policy-lock.yaml`, when the recipe ships one. */
+  policyLock?: string;
+  /** Long-form body, Markdown. */
+  body: string;
+  /** The recipe's directory on GitHub. */
+  sourceUrl: string;
+  evaluation?: RecipeEvaluation;
+}


### PR DESCRIPTION
Adds `/recipes` and `/recipes/[slug]`, rendered from the OSS repo's committed `dist/recipes/index.json`.

**Depends on bitrouter/bitrouter#756** — that PR adds the catalog. Until it merges this builds fine and the gallery renders its empty state (the fetch 404s and is logged, not thrown).

## How it syncs

The catalog is fetched at request time with a 600s revalidate, the same way `lib/providers-server.ts` reads the provider registry: no prebuild script, no `repository_dispatch`, no docs deploy. Merge a recipe upstream and it appears here within one revalidation window. `BITROUTER_REPO=../bitrouter pnpm dev` previews one from a local checkout before it is merged.

## Layout

The gallery reuses the model catalog's shell — filter rail, toolbar, table and card views, footer count line. Every filter, count and figure is derived from the catalog itself; no option lists are authored here, so a new objective or harness appears the moment a recipe uses it.

The models page's 14-day usage chart is deliberately **not** copied: it is fed by hardcoded `CHART_*` arrays in `models-data.ts`, and nothing on this page is mock data. In its place is a summary computed from the recipes on screen — published count, best measured saving, harnesses covered, evaluations used.

The detail page shows baseline vs recipe vs delta per metric, with provenance (evaluation, harness, config, runs, date, who measured it) directly under the numbers, prerequisites derived from the registry (`moonshotai — API key`, `openai-codex — sign-in`), the copyable `bitrouter.yaml`, and the recipe's long-form body.

Deltas are coloured by **direction of benefit**, not sign — a −32.8% cost move is green and a −1.1 point accuracy move is amber.

## Also

- Recipes in the header nav and the footer's Product column, next to Models.
- Sitemap entries for the gallery and each recipe.
- `Recipes` i18n namespace (en + zh).
- 7 new unit tests on the delta/format logic, plus one pinning the footer column order. `next build` passes.

## Note for the reviewer

The working tree of this repo currently holds an unrelated in-flight docs restructure (new `content/docs/overview/`, `models-and-routing/`, the `/compare` page removal). **None of it is in this branch** — this commit is 16 files, 1732 insertions, zero deletions. Three files it touches (`app/sitemap.ts`, `components/landing/footer-nav.ts`, `footer-nav.test.ts`) also carry edits from that work; only the recipe hunks were staged, so expect a small conflict there when the restructure lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)