### PR TITLE
Reframe hero copy and unify the quickstart card

### DIFF
--- a/components/landing/zed/brand-icon.tsx
+++ b/components/landing/zed/brand-icon.tsx
@@ -6,6 +6,8 @@ import Cline from "@lobehub/icons/es/Cline/components/Mono";
 import Codex from "@lobehub/icons/es/Codex/components/Mono";
 import Cursor from "@lobehub/icons/es/Cursor/components/Mono";
 import DeepSeek from "@lobehub/icons/es/DeepSeek/components/Mono";
+import Exa from "@lobehub/icons/es/Exa/components/Mono";
+import Figma from "@lobehub/icons/es/Figma/components/Mono";
 import Gemini from "@lobehub/icons/es/Gemini/components/Mono";
 import Github from "@lobehub/icons/es/Github/components/Mono";
 import Grok from "@lobehub/icons/es/Grok/components/Mono";
@@ -17,8 +19,11 @@ import Minimax from "@lobehub/icons/es/Minimax/components/Mono";
 import Mistral from "@lobehub/icons/es/Mistral/components/Mono";
 import Moonshot from "@lobehub/icons/es/Moonshot/components/Mono";
 import Notion from "@lobehub/icons/es/Notion/components/Mono";
+import Obsidian from "@lobehub/icons/es/Obsidian/components/Mono";
 import OpenAI from "@lobehub/icons/es/OpenAI/components/Mono";
+import OpenCode from "@lobehub/icons/es/OpenCode/components/Mono";
 import Qwen from "@lobehub/icons/es/Qwen/components/Mono";
+import Snowflake from "@lobehub/icons/es/Snowflake/components/Mono";
 import Stepfun from "@lobehub/icons/es/Stepfun/components/Mono";
 import Windsurf from "@lobehub/icons/es/Windsurf/components/Mono";
 import XiaomiMiMo from "@lobehub/icons/es/XiaomiMiMo/components/Mono";
@@ -32,8 +37,8 @@ type IconComponent = ComponentType<
  * Shared brand-glyph resolver for the Zed surfaces. Maps a model / lab / agent /
  * tool name (any casing/punctuation) to its @lobehub/icons monochrome mark, which
  * renders in `currentColor` — so callers tint it by setting `color`. Names lobehub
- * doesn't carry (Playwright, Postgres, Slack, …) fall back to a lettered monogram
- * tile that matches the mono aesthetic, so every row still gets a real glyph.
+ * doesn't carry fall back to a lettered monogram tile that matches the mono
+ * aesthetic — prefer names with a real mark for anything user-facing.
  */
 const ICONS: Record<string, IconComponent> = {
   // ── model providers / labs ──
@@ -70,10 +75,15 @@ const ICONS: Record<string, IconComponent> = {
   cursor: Cursor,
   codex: Codex,
   cline: Cline,
+  opencode: OpenCode,
   windsurf: Windsurf,
-  // ── capabilities / tools ──
+  // ── contexts: MCP servers / skills / sources ──
   github: Github,
   notion: Notion,
+  figma: Figma,
+  obsidian: Obsidian,
+  exa: Exa,
+  snowflake: Snowflake,
   mcp: MCP,
 };
 

--- a/components/landing/zed/data.ts
+++ b/components/landing/zed/data.ts
@@ -7,7 +7,7 @@
 export const HERO = {
   announcement: "self-tuning routing policies",
   headline: "Stop tokenmaxxing while loop engineering.",
-  sub: "A self-improving LLM router that optimizes agentic workflows with every run.",
+  sub: "Context-aware LLM router that continuously improves your agent workflows",
 };
 
 // ── Bring-your-own ──────────────────────────────────────────────────────────
@@ -20,16 +20,16 @@ export const BYO: ByoGroup[] = [
     logos: ["OpenAI", "Anthropic", "Qwen", "DeepSeek", "Mistral", "Llama"],
   },
   {
-    title: "bring your own capabilities",
-    desc: "MCPs & Skills — any tool your agent needs",
+    title: "bring your own contexts",
+    desc: "MCPs & Skills — any context your agent needs",
     duration: "26s",
-    logos: ["Playwright", "Postgres", "GitHub", "Slack", "Filesystem", "Notion"],
+    logos: ["GitHub", "Notion", "Figma", "Obsidian", "Exa", "Snowflake"],
   },
   {
     title: "bring your own agents",
     desc: "Claude Code, Cursor, Codex — or your own",
     duration: "24s",
-    logos: ["Claude Code", "Cursor", "Codex", "Cline", "Aider", "Windsurf"],
+    logos: ["Claude Code", "Cursor", "Codex", "Cline", "OpenCode", "Windsurf"],
   },
 ];
 

--- a/components/landing/zed/hero-quickstart.tsx
+++ b/components/landing/zed/hero-quickstart.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { Check, Copy } from "lucide-react";
 import { useState } from "react";
 
 /**
- * Hero quickstart — a compact tabbed command switcher that replaces the old
- * "Works with …" line. Four ways to point an agent at BitRouter; the CLI / MCP /
- * Agent Skills commands are carried over verbatim from the previous (main) hero
- * quickstart, and Wizard is the interactive `bitrouter init` setup.
+ * Hero quickstart — one card: an underlined tab strip on top, the command for the
+ * active tab below the rule. Four ways to point an agent at BitRouter; the CLI /
+ * MCP / Agent Skills commands are carried over verbatim from the previous (main)
+ * hero quickstart, and Wizard is the interactive `bitrouter init` setup.
  */
 type Tab = { key: string; label: string; cmd: string; sub: string };
 
@@ -53,99 +54,110 @@ export function HeroQuickstart() {
   };
 
   return (
-    <div style={{ maxWidth: 580, margin: "36px auto 0", textAlign: "left" }}>
-      {/* tabs — centered segmented control */}
-      <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
-        <div
-          role="tablist"
-          aria-label="Quickstart method"
-          style={{
-            display: "inline-flex",
-            border: "1px solid var(--z-rule)",
-            borderRadius: 8,
-            overflow: "hidden",
-          }}
-        >
-          {TABS.map((t, i) => {
-            const on = t.key === active;
-            return (
-              <button
-                key={t.key}
-                role="tab"
-                aria-selected={on}
-                onClick={() => setActive(t.key)}
-                style={{
-                  cursor: "pointer",
-                  fontFamily: MONO,
-                  fontSize: 12.5,
-                  padding: "7px 15px",
-                  border: "none",
-                  borderLeft: i === 0 ? "none" : "1px solid var(--z-rule)",
-                  background: on ? "#12161d" : "transparent",
-                  color: on ? "#8fb4ff" : "var(--z-ink-5)",
-                  transition: "color .15s ease, background .15s ease",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {t.label}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* command box */}
+    <div
+      style={{
+        maxWidth: 580,
+        margin: "36px auto 0",
+        textAlign: "left",
+        border: "1px solid var(--z-rule)",
+        borderRadius: 10,
+        background: "var(--z-inset)",
+        overflow: "hidden",
+      }}
+    >
+      {/* tab strip — inside the card, underline marks the active tab */}
       <div
+        role="tablist"
+        aria-label="Quickstart method"
         style={{
-          border: "1px solid var(--z-rule)",
-          borderRadius: 10,
-          background: "var(--z-inset)",
-          overflow: "hidden",
+          display: "flex",
+          gap: 4,
+          padding: "0 8px",
+          borderBottom: "1px solid var(--z-rule)",
+          overflowX: "auto",
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "13px 15px" }}>
-          <span style={{ color: "var(--z-green)", fontFamily: MONO, fontSize: 13.5, flex: "0 0 auto" }}>
-            $
-          </span>
-          <div style={{ flex: 1, minWidth: 0, overflowX: "auto" }}>
-            <code
+        {TABS.map((t) => {
+          const on = t.key === active;
+          return (
+            <button
+              key={t.key}
+              role="tab"
+              aria-selected={on}
+              onClick={() => setActive(t.key)}
               style={{
+                position: "relative",
+                cursor: "pointer",
                 fontFamily: MONO,
-                fontSize: 13.5,
-                color: "var(--z-ink-2)",
+                fontSize: 12.5,
+                padding: "11px 12px",
+                border: "none",
+                background: "transparent",
+                color: on ? "var(--z-ink)" : "var(--z-ink-5)",
+                transition: "color .15s ease",
                 whiteSpace: "nowrap",
               }}
             >
-              {tab.cmd}
-            </code>
-          </div>
-          <button
-            onClick={copy}
-            aria-label="Copy command"
+              {t.label}
+              <span
+                aria-hidden
+                style={{
+                  position: "absolute",
+                  left: 12,
+                  right: 12,
+                  bottom: -1,
+                  height: 2,
+                  background: on ? "var(--z-blue)" : "transparent",
+                }}
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      {/* command for the active tab */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "13px 15px 4px" }}>
+        <span style={{ color: "var(--z-green)", fontFamily: MONO, fontSize: 13.5, flex: "0 0 auto" }}>
+          $
+        </span>
+        <div style={{ flex: 1, minWidth: 0, overflowX: "auto" }}>
+          <code
             style={{
-              cursor: "pointer",
-              flex: "0 0 auto",
-              background: "none",
-              border: "none",
               fontFamily: MONO,
-              fontSize: 11.5,
-              color: copied ? "var(--z-green)" : "var(--z-ink-6)",
-              transition: "color .15s ease",
+              fontSize: 13.5,
+              color: "var(--z-ink-2)",
+              whiteSpace: "nowrap",
             }}
           >
-            {copied ? "✓ copied" : "copy"}
-          </button>
+            {tab.cmd}
+          </code>
         </div>
-        <div
+        <button
+          onClick={copy}
+          aria-label={copied ? "Command copied" : "Copy command"}
           style={{
-            padding: "0 15px 12px 33px",
-            fontFamily: MONO,
-            fontSize: 12.5,
-            color: "var(--z-ink-6)",
+            cursor: "pointer",
+            flex: "0 0 auto",
+            display: "inline-flex",
+            background: "none",
+            border: "none",
+            padding: 2,
+            color: copied ? "var(--z-green)" : "var(--z-ink-6)",
+            transition: "color .15s ease",
           }}
         >
-          ↳ {tab.sub}
-        </div>
+          {copied ? <Check size={15} /> : <Copy size={15} />}
+        </button>
+      </div>
+      <div
+        style={{
+          padding: "0 15px 12px 33px",
+          fontFamily: MONO,
+          fontSize: 12.5,
+          color: "var(--z-ink-6)",
+        }}
+      >
+        ↳ {tab.sub}
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed

**Hero subheadline** — now "Context-aware LLM router that continuously improves your agent workflows" (was "A self-improving LLM router that optimizes agentic workflows with every run.").

**Bring-your-own middle column** — retitled "bring your own contexts"; its description follows suit ("any context your agent needs").

**Real logos for that column.** Four of its six names had no mark in `@lobehub/icons` and rendered as lettered monogram fallbacks — Playwright, Postgres, Slack, Filesystem. None of those brands exist in the package, so they're replaced with context sources that do have marks: **GitHub, Notion, Figma, Obsidian, Exa, Snowflake** (code, docs, design, notes, web search, warehouse). **Aider** in the agents column had the same problem and becomes **OpenCode** — the harness already named throughout the TUI demo data. Verified in the browser: zero monogram fallbacks left in the section.

**Quickstart tabs** — one unified card instead of a segmented control floating above a separate command box. Tab strip sits inside the card with a blue underline on the active tab, a rule across the card, then the command with a lucide copy/check icon button.

## Verification

- Dev server: all `.zed-marq-logo` entries render a real `<svg>` mark; clicking **Wizard** switches the body to `bitrouter init` and moves the underline.
- `tsc --noEmit` clean for all three touched files (remaining errors are pre-existing, in `components/ai/search.tsx` and `components/markdown.tsx`).

## Note

`postgres-mcp` / `filesystem` still appear as tool names in the TUI demo trace rows and MCP ledgers. Those are plain text with no logo attached, so they were left alone — say the word if you want that copy changed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)