### PR TITLE
Document bitrouter.yaml and pivot to config-forward

### DIFF
--- a/content/docs/(guide)/gateway-and-routing/virtual-model.mdx
+++ b/content/docs/(guide)/gateway-and-routing/virtual-model.mdx
@@ -83,9 +83,24 @@ The full CRUD surface — `list`, `get`, `create`, `update`, `delete`, plus `dis
 
 A virtual model can be disabled without deleting it (`POST …/routing-presets/{id}/disable`, re-enable with `/enable`, or toggle it in the console). A disabled one is treated as if it doesn't exist: invoking its `@name` returns the same `400` as an unknown name, while the definition is preserved for when you switch it back on.
 
-## Self-hosted: aliases over your own endpoints
+## Self-hosted
 
-The `@name` form above is a BitRouter Cloud namespace feature. When you [self-host](/docs/guides/self-host), the `models` section of `bitrouter.yaml` gives you the other half of the idea — a named alias over an ordered list of endpoints, so one model name fails over across providers:
+`@name` is not Cloud-only. The local binary resolves it from the `presets:` block of [`bitrouter.yaml`](/docs/usage/configuration), with the same fields the API and console expose:
+
+```yaml
+# bitrouter.yaml
+presets:
+  fast:
+    model: "openai/gpt-4o-mini"
+    params:
+      temperature: 0.2
+    routing:
+      sort: cost
+```
+
+`bitrouter route "@fast"` previews the resolution without sending a request. What Cloud adds is the managed lifecycle — namespaces, enable/disable, and the `routing-presets` endpoints — not the `@name` grammar itself.
+
+The separate `models` section is a different feature that's easy to confuse with this one: a named alias over an **ordered list of endpoints**, so one model name fails over across providers. It is not invoked with `@`:
 
 ```yaml
 # bitrouter.yaml

--- a/content/docs/(guide)/usage/configuration.mdx
+++ b/content/docs/(guide)/usage/configuration.mdx
@@ -1,0 +1,264 @@
+---
+title: Configuration
+description: bitrouter.yaml — the single file that holds your routing policy, providers, and gateways, with a JSON Schema for your editor and a validate command for CI.
+---
+
+BitRouter runs with no configuration at all. When you outgrow that, everything it does becomes **one file you commit**: `bitrouter.yaml`.
+
+That is the whole idea behind **routing as code**. Which model serves which kind of request, which providers are eligible, what happens when one fails, when to spend on a frontier model and when not to — these are policy decisions. Policy that lives in a dashboard drifts, resists review, and can't be rolled back. Policy that lives in a file gets diffed, reviewed, and reverted like anything else you ship.
+
+BitRouter goes one step further than a static file: the router can **propose changes to its own policy**, which you review and merge. See [Routing as code](#routing-as-code).
+
+## Zero-config is still the default
+
+You do not need this file to start. With no config anywhere, BitRouter builds an in-memory default and auto-enables any provider whose key is in your environment:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+bitrouter serve
+```
+
+Reach for `bitrouter.yaml` when you want something zero-config can't express: named routing policy, provider allow/deny lists, a tiered cost policy, MCP or ACP gateways, or anything you want under review. `bitrouter init` writes a starter file.
+
+## Where the file lives
+
+Resolution stops at the first hit:
+
+| Order | Location | Notes |
+| --- | --- | --- |
+| 1 | `-c/--config <PATH>` | Explicit. A missing path is a hard error, not a fallback. |
+| 2 | `./bitrouter.yaml` | The repo-local file — this is the one you commit. |
+| 3 | `$BITROUTER_HOME/bitrouter.yaml` | If the variable is set, the file **must** be there. |
+| 4 | `~/.bitrouter/bitrouter.yaml` | Per-user default. |
+| 5 | *(none)* | Zero-config in-memory defaults, with `~/.bitrouter` as the implicit home. |
+
+<Callout type="warning">
+**`BITROUTER_HOME` fails loudly on purpose.** If it's set but holds no `bitrouter.yaml`, BitRouter errors instead of falling through to `~/.bitrouter` or zero-config. Silently ignoring an operator's explicit choice of config directory is how the wrong policy reaches production.
+</Callout>
+
+## Editor support
+
+The config has a published JSON Schema, regenerated from the binary's own types on every release, so it never drifts from what the version you run accepts.
+
+Add a modeline to the top of the file and any `yaml-language-server` editor (VS Code, Neovim, JetBrains) gives you completion, hover docs, and inline validation:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bitrouter/bitrouter/main/dist/schema/bitrouter.config.schema.json
+server:
+  listen: "127.0.0.1:4356"
+```
+
+Or wire it up globally in VS Code's `settings.json`:
+
+```json
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/bitrouter/bitrouter/main/dist/schema/bitrouter.config.schema.json": "bitrouter.yaml"
+  }
+}
+```
+
+That URL tracks the OSS `main` branch. To pin a release instead, swap `main` for a tag such as `v1.0.0-alpha.27`.
+
+## Environment variables
+
+Any value may reference an environment variable. Keys stay out of the file, so the file stays committable:
+
+```yaml
+providers:
+  openai:
+    api_key: "${OPENAI_API_KEY}"
+  selfhosted:
+    # `:-` supplies a fallback when the variable is unset
+    endpoint: "${LLM_ENDPOINT:-http://127.0.0.1:8000/v1}"
+```
+
+Substitution is **comment-aware** — a `${VAR}` inside a `#` comment is left literal and never looked up, so a commented-out example referencing an unset variable won't break loading.
+
+## What the file holds
+
+Every block is optional and defaults to something sensible. An empty file is valid.
+
+| Block | What it configures |
+| --- | --- |
+| `providers` | Upstream providers and their keys. See [BYOK](/docs/gateway-and-routing/bring-your-own-provider) |
+| `presets` | `@name` definitions — model substitution, system prompt, params, routing. See [Virtual models](/docs/gateway-and-routing/virtual-model) |
+| `variants` | `:name` definitions — routing modifiers only. See [Model variants](/docs/gateway-and-routing/model-variants) |
+| `models` | Named models over an ordered endpoint chain. See [Model fallback](/docs/gateway-and-routing/model-fallback) |
+| `policy_table` | Tiered per-request routing by request shape. See [The policy table](#the-policy-table) |
+| `policy` | Where the policy lock lives and whether it may self-update. See [The adaptive loop](#the-adaptive-loop) |
+| `registry` | Public-registry integration and the provider-class priority ladder |
+| `server` | Listen address and HTTP server settings |
+| `upstream` | Outbound HTTP client settings (timeouts, retries) |
+| `database` | Database connection |
+| `mcp` | MCP gateway aggregation and caching. See [MCP gateway](/docs/gateway-and-routing/mcp-gateway) |
+| `mcp_servers` | Upstream MCP servers, keyed by id |
+| `server_tools` | MCP server ids whose tools BitRouter injects and executes itself. See [Server tools](/docs/gateway-and-routing/server-tools) |
+| `agents` | Upstream ACP agents. See [ACP gateway](/docs/gateway-and-routing/acp-gateway) |
+| `plugins` | Plugin config, keyed by plugin or bundle id |
+| `worktrees` | Worktree isolation for orchestrator-spawned subagents |
+| `tui` | Terminal console settings |
+| `inherit_defaults` | Whether providers inherit workspace defaults |
+
+## Routing as code
+
+### Presets and variants
+
+A preset is a name you define once and invoke by putting `@name` in the `model` field. It needs no SDK and no body fields, so it works identically on the OpenAI, Anthropic, and Google surfaces:
+
+```yaml
+presets:
+  fast:
+    model: "openai/gpt-4o-mini"
+    params:
+      temperature: 0.2
+    routing:
+      sort: cost
+      ignore: ["some-slow-provider"]
+
+  careful:
+    model: "anthropic/claude-sonnet-4.6"
+    system_prompt: "Think step by step before answering."
+    routing:
+      require_tags: ["soc2"]
+
+variants:
+  cheap:
+    routing:
+      sort: cost
+```
+
+A request for `@fast` gets the substituted model and the overrides; `@careful:cheap` applies the preset, then lets the variant override its sort. Callers never change — the policy moved into the file.
+
+<Callout type="info">
+**Presets work self-hosted, not just on Cloud.** The `@name` grammar is often described as a Cloud namespace feature, but the local binary resolves `@name` straight from this `presets:` block. `bitrouter route "@fast"` shows you the resolution without sending a request.
+</Callout>
+
+Semantics — precedence, the `@name/base-model` form, what happens on an unknown name — are covered on [Virtual models](/docs/gateway-and-routing/virtual-model) and [Model variants](/docs/gateway-and-routing/model-variants). This page only shows the file.
+
+### The policy table
+
+Presets require the caller to opt in by name. The **policy table** applies policy to traffic that asks for nothing special — it routes each request by its *shape* in an agent loop, so a coding agent's cheap bookkeeping turns stop costing frontier-model money.
+
+```yaml
+policy_table:
+  # Tier name → the model every request on that tier routes to.
+  tiers:
+    cheap: "openai/gpt-4o-mini"
+    capable: "anthropic/claude-sonnet-4.6"
+
+  # Request fingerprint → tier.
+  fingerprints:
+    opening: capable        # first turn, no model output yet
+    after_read: cheap       # the model just called the `read` tool
+    midstream: cheap        # a model turn that called no tool
+
+  # Any fingerprint not listed above.
+  default_tier: capable
+
+  # Guardrail: a request carrying tools is clamped UP to `tool_use_tier`
+  # unless the tier it would otherwise get is known tool-safe.
+  tool_use_tier: capable
+  tool_safe_tiers: ["capable"]
+```
+
+A fingerprint is the agent-loop step: `opening` (no model turn yet), `after_<tool>` (the model last called `<tool>`), or `midstream` (a model turn with no tool call). The section is inert while `tiers` is empty, so adding the block changes nothing until you populate it.
+
+The tool guardrail matters more than it looks. Small models are the ones that mangle tool calls, and a downgrade that breaks tool use breaks the agent loop entirely rather than just degrading an answer. `tool_safe_tiers` is the allow-list; anything else gets clamped up.
+
+### The adaptive loop
+
+A static table is a guess. The parts below let the router check that guess against production and correct it — this is what separates routing-as-code here from a config file that only ever does what you typed.
+
+**Escalation** watches downgraded requests and un-does downgrades that are failing:
+
+```yaml
+policy_table:
+  adequacy:
+    enabled: true
+    escalation_tier: capable
+    escalation_threshold: 2      # consecutive hard failures before pinning
+    pin_cooldown_secs: 1800      # then re-try the downgrade
+```
+
+Once a fingerprint accumulates that many consecutive hard failures it is *pinned* to the escalation tier; the pin decays after the cooldown so the cheap path gets another chance. A clean outcome resets the tally. This half only ever escalates — it will never downgrade on its own.
+
+**Exploration** is the opposite half, and it is off by default because it is genuinely aggressive:
+
+```yaml
+policy_table:
+  adequacy:
+    enabled: true
+    explore_enabled: true
+    explore_tier: cheap
+    explore_interval: 5          # ~1 in 5 eligible requests is a trial
+    explore_threshold: 3         # consecutive good trials before locking
+```
+
+It periodically trials the cheap tier on fingerprints you left at the capable tier, and locks one to cheap after enough consecutive adequate trials — so safe downgrades get *found* rather than hand-guessed. A failed trial escalates and stops. It routes real traffic to a cheaper model to learn this, so turn it on deliberately.
+
+**The lock file is the reviewable artifact.** Learned policy lands in `policy-lock.yaml` next to your config, and `policy.writeback` decides whether the router may write it:
+
+```yaml
+policy:
+  writeback: locked   # observe and propose only (default)
+  # writeback: evolve # permit validated evolution to replace the lock
+```
+
+Under the default `locked`, the router proposes and never writes. `bitrouter policy evolve` prints a dry-run report; `--apply` publishes the candidate. So the loop is: the router learns, you read the diff, you commit it — the same review path as any other change. Set `evolve` only when you want the router to publish without you in the middle.
+
+See [the `policy` commands](/docs/usage/cli#policy) for `check`, `status`, `show`, `lock`, `unlock`, and `reload`.
+
+## Validate in CI
+
+`bitrouter config validate` checks structure, provider `derives` resolution, upstream-URL (SSRF) safety, and that the policy lock loads. It exits non-zero on an invalid config, so it drops straight into a pipeline:
+
+```bash
+bitrouter config validate -c bitrouter.yaml
+```
+
+A valid file exits `0` and reports what it found:
+
+```json
+{
+  "valid": true,
+  "path": "/repo/bitrouter.yaml",
+  "providers": 2,
+  "models": 0,
+  "presets": 1,
+  "variants": 1
+}
+```
+
+An invalid one exits `1` with the parse error located by line and column:
+
+```json
+{
+  "valid": false,
+  "path": "/repo/bitrouter.yaml",
+  "errors": ["bad request: invalid bitrouter.yaml: error: line 3 column 14: unexpected event: expected string scalar"]
+}
+```
+
+**Secrets are not required to validate.** An unset `${VAR}` is substituted with a placeholder and reported under `warnings` — it does **not** fail the run. That's deliberate: CI can check the config's shape on every pull request without holding production keys.
+
+```json
+{
+  "valid": true,
+  "warnings": [{ "unset_env": "OPENAI_API_KEY" }]
+}
+```
+
+If you want unset variables to be fatal in a deploy job rather than a PR check, gate on the `warnings` array being empty.
+
+<Callout type="warning">
+**`validate` needs a real file.** Run against zero-config it errors rather than reporting success — there is nothing to check. Pass `-c <path>` in CI so a missing file fails loudly instead of silently validating defaults.
+</Callout>
+
+## See also
+
+- [CLI reference](/docs/usage/cli) — `config validate`, `route`, `policy`
+- [Virtual models](/docs/gateway-and-routing/virtual-model) and [Model variants](/docs/gateway-and-routing/model-variants) — what `presets:` and `variants:` mean
+- [Model fallback](/docs/gateway-and-routing/model-fallback) — what `models:` means
+- [BYOK](/docs/gateway-and-routing/bring-your-own-provider) — the `providers:` block
+- [Self-hosting](/docs/guides/self-host) — running the binary you just configured

--- a/content/docs/(guide)/usage/meta.json
+++ b/content/docs/(guide)/usage/meta.json
@@ -2,5 +2,5 @@
   "title": "Usage",
   "icon": "Terminal",
   "collapsible": false,
-  "pages": ["cli", "mcp", "skills"]
+  "pages": ["cli", "configuration", "mcp", "skills"]
 }

--- a/content/docs/guides/migrate-from-litellm.mdx
+++ b/content/docs/guides/migrate-from-litellm.mdx
@@ -78,7 +78,7 @@ response = client.chat.completions.create(
 </Tab>
 </Tabs>
 
-Fallbacks and provider selection that you'd configure with `litellm.Router` move into BitRouter's [virtual models](/docs/gateway-and-routing/virtual-model) and [model fallback rules](/docs/gateway-and-routing/model-fallback) — declared once, not per call site.
+Fallbacks and provider selection that you'd configure with `litellm.Router` move into BitRouter's [virtual models](/docs/gateway-and-routing/virtual-model) and [model fallback rules](/docs/gateway-and-routing/model-fallback) — declared once in [`bitrouter.yaml`](/docs/usage/configuration), not per call site.
 
 ### From the LiteLLM Proxy
 
@@ -114,7 +114,7 @@ To skip the local proxy entirely, point clients at `https://api.bitrouter.ai/v1`
 
 | LiteLLM concept | BitRouter equivalent | Docs |
 |---|---|---|
-| `model_list` in `config.yaml` | Provider keys + routing presets | [Virtual models](/docs/gateway-and-routing/virtual-model) |
+| `model_list` in `config.yaml` | `providers:` + `presets:` in `bitrouter.yaml` | [Configuration](/docs/usage/configuration) |
 | `router_settings` (retries, fallback) | Model fallback rules | [Model fallback](/docs/gateway-and-routing/model-fallback) |
 | `routing_strategy` (least-busy, latency) | Provider selection | [Provider selection](/docs/gateway-and-routing/provider-selection) |
 | `cache` (Redis/DynamoDB backed) | Not built into the proxy — handle in app/edge if needed | — |

--- a/content/docs/guides/migrate-from-tensorzero.mdx
+++ b/content/docs/guides/migrate-from-tensorzero.mdx
@@ -15,7 +15,7 @@ This guide is for teams who adopted TensorZero mainly as a **gateway** — unifi
 |---|---|---|
 | **Runtime** | Rust gateway | Rust (single static binary) |
 | **Production deps** | ClickHouse (observability store) + Docker/Compose | None |
-| **Configuration** | `tensorzero.toml` — functions, variants, models, providers | Provider keys + routing presets; no schema to maintain |
+| **Configuration** | `tensorzero.toml` — functions, variants, models, providers | `bitrouter.yaml` — optional, JSON Schema published, [validates in CI](/docs/usage/configuration#validate-in-ci) |
 | **Deployment modes** | Self-hosted only | Local binary **or** hosted (`api.bitrouter.ai`) — same OpenAI-compatible endpoint |
 | **Design focus** | Full LLMOps loop: gateway + observability + evals + optimization + experimentation | Agent-first proxy: MCP / ACP / Skills, agent firewall, agentic payment |
 | **Agent protocol surface** | None (gateway is provider-facing) | MCP, ACP, Skills, CLI — the product, not an add-on |
@@ -28,7 +28,9 @@ This guide is for teams who adopted TensorZero mainly as a **gateway** — unifi
 
 TensorZero is built around a feedback loop: route inference, store every call and its metrics in ClickHouse, then evaluate, fine-tune, and A/B test against that history. That's powerful if you run that loop — and it's why TensorZero needs a database and a typed config of functions and variants.
 
-BitRouter deliberately stops at the gateway. There's no `tensorzero.toml` to maintain, no ClickHouse to operate — you set provider keys and route by `provider/model` id. [OpenTelemetry](/docs/observability/opentelemetry) gives you spans and metrics for every request (the same OTLP export TensorZero offers), but they go to a backend you already run, not a warehouse the proxy manages.
+BitRouter deliberately stops at the gateway. There's no ClickHouse to operate — [OpenTelemetry](/docs/observability/opentelemetry) gives you spans and metrics for every request (the same OTLP export TensorZero offers), but they go to a backend you already run, not a warehouse the proxy manages.
+
+Configuration is the other difference, and it's one of degree rather than kind. BitRouter is also configured as code — [`bitrouter.yaml`](/docs/usage/configuration) holds providers, routing policy, and gateways, with a published JSON Schema and a `validate` command for CI. What it doesn't ask you to declare is the *shape of your application*: there are no functions to define and no variants to enumerate before you can route a request. You can run on provider keys alone and add config only where you want policy under review.
 
 ### 2. Agent-native, and cloud/local share one surface
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -36,8 +36,9 @@ tab. Page order within a section is the `pages` list in that section's
 `meta.json`; the section order is the `pages` list in
 `content/docs/(guide)/meta.json`.
 
-`usage/` is the three ways to drive BitRouter: `cli.mdx` (generated — don't
-hand-author it), `mcp.mdx`, and `skills.mdx`.
+`usage/` is how you drive BitRouter: `cli.mdx` (generated — don't hand-author
+it), `configuration.mdx` (the `bitrouter.yaml` reference), `mcp.mdx`, and
+`skills.mdx`.
 
 ## Authoring contract (import-free MDX)
 


### PR DESCRIPTION
Adds `usage/configuration.mdx` and moves the positioning from "no config to maintain" to config-forward.

## Why

The declarative surface was undocumented. Coverage audit against `content/docs/`:

| `bitrouter.yaml` block | Before |
|---|---|
| `presets:` (`@name`) | Concept covered, **YAML key appears on zero pages** |
| `variants:` (`:name`) | Same |
| `routing:` (`sort` / `only` / `ignore` / `require_tags`) | Same |
| `policy_table:` | **Nothing. Zero pages.** |
| `policy:` / `policy-lock.yaml` | Only quickstart + the CLI dump |

Routing was documented API-first and console-first, so a reader who wanted routing in git had nowhere to land.

## The page

`usage/configuration.mdx` — discovery order, the published JSON Schema, `${VAR}` substitution, every top-level block, the policy table, the adaptive loop, and `config validate` in CI. Titled **Configuration** so it sits correctly beside CLI / MCP / Skills and doesn't overclaim (the file also holds `server:`, `database:`, `mcp:`), with **Routing as code** as the opening thesis and a named section anchor.

**The differentiated claim is that the policy isn't inert.** `policy.writeback` defaults to `locked`, so the router observes and proposes rather than writes; `bitrouter policy evolve` prints a dry-run and `--apply` publishes. You read the diff and commit it — the same review path as any other change. Adequacy escalation un-does downgrades that fail in production; exploration (off by default, and flagged as genuinely aggressive) finds safe downgrades instead of making you guess them. That's the part LiteLLM's `config.yaml` has no answer to, and it's exactly what had no docs.

The page owns *the file*; `virtual-model.mdx` and `model-variants.mdx` keep owning *the behavior*, so semantics aren't duplicated.

## Positioning pivot

- **migrate-from-tensorzero** claimed "no schema to maintain" as an advantage. That was the old line and it was misleading regardless — there is a schema, it's published, and it validates in CI. Recast as a difference of degree: BitRouter is also configured as code, it just doesn't make you declare the shape of your application before you can route a request. The ClickHouse/no-database contrast is untouched, since that one is real.
- **migrate-from-litellm** mapped `model_list` onto "provider keys + routing presets" with no config file in sight. Both it and the fallback paragraph now point at the actual file.

## A correction this surfaced

`virtual-model.mdx` said `@name` is a BitRouter Cloud namespace feature and that self-hosting gets `models:` instead. That's wrong. Verified against the binary:

```
$ bitrouter route "@fast" -c bitrouter.yaml
{"error":{"kind":"not_found","message":"no active provider declares model 'openai/gpt-4o-mini'",
          "context":["resolving model '@fast'"]}}
```

`@fast` resolved from the local `presets:` block and substituted the preset's model — it only failed because the test provider doesn't serve that model. `presets:` works self-hosted; Cloud adds the managed lifecycle (namespaces, enable/disable, the `routing-presets` endpoints), not the grammar. Separately, `models:` is a *different* feature — a named alias over an ordered endpoint chain, not invoked with `@` — and the page conflated the two. Both fixed.

## Verification

- **Every YAML example on the page validates**, assembled into one combined config and run against the real binary: `valid: true`, 2 presets, 1 variant.
- **The documented `validate` contract is empirical, not inferred** — exit `0` with counts; exit `1` with a line/column parse error; an unset `${VAR}` reported under `warnings` and **not** fatal, which is what lets CI check shape without production keys.
- **The schema at the URL the page gives** contains every key documented, including all of `policy_table` and the `explore_*` block.
- `pnpm lint:docs` OK, 48 docs / 6 sections.
- All 13 outbound links return 200; all 5 anchors (`#routing-as-code`, `#the-policy-table`, `#the-adaptive-loop`, `#validate-in-ci`, and `cli#policy`) resolve.

## One thing for a follow-up, in the other repo

The schema ships at `dist/schema/bitrouter.config.schema.json` and declares:

```
"$id": "https://bitrouter.dev/schema/v1.0.0-alpha.27/config.schema.json"
```

**`bitrouter.dev` is NXDOMAIN** — the domain doesn't resolve, and `bitrouter.ai` serves 404 there. This page therefore documents the raw GitHub URL, which is live and follows the pattern `DEFAULT_REGISTRY_URL` already uses for the registry. Worth either serving `dist/schema/` from bitrouter.ai or changing the `$id` in `helpers/dist-helper/src/schema.rs` — a two-line fix that needs no infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)