### PR TITLE
docs: rewrite the quickstart around bitrouter/auto and the optimize loop

### DIFF
--- a/cli-overlays/policy.md
+++ b/cli-overlays/policy.md
@@ -2,7 +2,7 @@
 title: Policy
 ---
 
-Routing policies are the artifact the [self-improving loop](/docs/overview/what-is-bitrouter) learns into: `init` scaffolds `policy-lock.yaml` and binds it to a preset, live traffic teaches the adequacy ledger, and `evolve --apply` folds proven downgrades back into the file. The walkthrough, table, and ledger semantics are in [Adaptive routing](/docs/overview/quickstart#adaptive-routing).
+Routing policies are the artifact the [self-improving loop](/docs/overview/what-is-bitrouter) learns into: `init` scaffolds `policy-lock.yaml` and binds it to a preset, live traffic teaches the adequacy ledger, and `evolve --apply` folds proven downgrades back into the file.
 
 <Callout type="info">
 `bitrouter policy create` + `bitrouter key sign` are a **different surface** — per-virtual-key access control (allowed models, budgets, rate limits), not routing. See [Guardrails](/docs/models-and-routing/guardrails).

--- a/cli-overlays/skills.md
+++ b/cli-overlays/skills.md
@@ -2,14 +2,7 @@
 title: Skills and MCP
 ---
 
-`skills` installs and manages [Agent Skills](https://agentskills.io) for your harness; `mcp` runs BitRouter's own MCP server — the tool surface any MCP client can drive instead of shelling out. What the server exposes (backends, transports, the gateway distinction) lives on the [MCP Server](/docs/usage/mcp) page.
-
-## @skills add
-
-```bash
-bitrouter skills add bitrouter        # the /bitrouter skill, from the registry
-bitrouter skills add owner/repo       # from GitHub
-```
+`skills` manages the [Agent Skills](https://agentskills.io) installed for your harness — install them with `npx skills add <source>`; `mcp` runs BitRouter's own MCP server — the tool surface any MCP client can drive instead of shelling out. What the server exposes (backends, transports, the gateway distinction) lives on the [MCP Server](/docs/usage/mcp) page.
 
 ## @mcp serve
 

--- a/content/docs/(guide)/evals-and-tracing/evaluation.mdx
+++ b/content/docs/(guide)/evals-and-tracing/evaluation.mdx
@@ -24,7 +24,7 @@ The classification is recorded against the request's **fingerprint** — which s
 
 There is **no LLM judge in the path**. The signal is deterministic and free, which is what makes cheap-tier downgrades safe to attempt at all: after `escalation_threshold` consecutive failures on a downgraded fingerprint, the route is pinned back up to a more capable tier automatically.
 
-You don't configure the classifier itself — it runs whenever a policy has adequacy enabled. The thresholds that act on it, and the escalation/exploration behavior they drive, are part of the policy: see [Adaptive routing](/docs/overview/quickstart#adaptive-routing).
+You don't configure the classifier itself — it runs whenever a policy has adequacy enabled. The thresholds that act on it, and the escalation/exploration behavior they drive, are part of the policy.
 
 ## Cost metering
 
@@ -46,7 +46,6 @@ The dedicated eval engine — scoring each *run* and routing decision against a 
 ## Next steps
 
 <Cards>
-  <Card title="Adaptive routing" href="/docs/overview/quickstart#adaptive-routing" description="The policy that acts on this signal — escalation, exploration, and publishing." />
   <Card title="OpenTelemetry" href="/docs/evals-and-tracing/opentelemetry" description="The self-run trace and metric substrate evals build on." />
   <Card title="Tracing" href="/docs/evals-and-tracing/tracing" description="The hosted request view, if you'd rather not run a collector." />
 </Cards>

--- a/content/docs/(guide)/overview/quickstart.mdx
+++ b/content/docs/(guide)/overview/quickstart.mdx
@@ -138,13 +138,19 @@ This is not "swap in a cheaper model." BitRouter runs your workflow twice — on
 This needs the CLI, a Git repository, and macOS or Linux. Everything above stays install-free.
 </Callout>
 
-Point it at a command that exercises your agent:
+Setup looks for a command that exercises your agent:
+
+```bash
+bitrouter optimize setup
+```
+
+It reads your project's eval and benchmark entrypoints, adopts the one unambiguous candidate, and offers a numbered choice when several are plausible. Ordinary unit-test scripts are never adopted by guesswork. If nothing is discoverable — or you want a specific command — name it exactly:
 
 ```bash
 bitrouter optimize setup --workflow-command ./run-agent-eval
 ```
 
-That writes three files you own and commit: the workflow intent, a lock of resolved identities and digests, and a success contract describing what a good run looks like.
+Either way it writes three files you own and commit: the workflow intent, a lock of resolved identities and digests, and a success contract describing what a good run looks like.
 
 Then run the loop:
 

--- a/content/docs/(guide)/overview/quickstart.mdx
+++ b/content/docs/(guide)/overview/quickstart.mdx
@@ -1,240 +1,179 @@
 ---
 title: Quickstart
-description: Install BitRouter and get your agent routing in under a minute — pick self-host or Cloud, then onboard via the Agent Skill, the CLI wizard, or manual env keys.
+description: Point your agent at BitRouter, then start optimizing what it costs — one base URL, one key, one model id.
 ---
 
-This page gets BitRouter routing for your agent in under a minute. There are two deployment modes, and three ways to onboard either one — the Agent Skill, the CLI wizard, or manual env keys.
+BitRouter puts every model behind one endpoint and picks which one each request should go to. Then it measures whether the pick was right, so your routing gets cheaper without getting worse.
 
-- **BitRouter Cloud (default).** Hosted endpoint at `api.bitrouter.ai`. No upstream keys to manage; agent-native x402/MPP pay-per-use, or BYOK on top.
-- **Local proxy.** A single binary on your machine, BYOK with your own provider keys. Zero infrastructure dependencies.
+Let an agent set it up, or change three strings yourself.
 
-Both modes run the **same open-source core** (Apache 2.0) — the routing engine is identical, so you can start in one mode and switch later without touching your harness.
+## Set up with the agent
 
-## Self-host or Cloud?
+Four ways to point an agent at BitRouter — pick whichever fits your setup.
 
-Every core capability works the same either way — Cloud only adds what needs a server you don't run.
-
-- **Self-host** if you already have provider keys, run local/private models, have data-residency rules, or are prototyping solo.
-- **Cloud** if you want no key management and per-request billing, a managed provider network without provider signups, team workspaces, or an uptime SLA.
-
-| Capability | Self-hosted (OSS) | Cloud |
-| --- | --- | --- |
-| Universal API + cross-protocol routing | ✅ | ✅ |
-| BYOK (bring your own provider keys) | ✅ | ✅ |
-| Local / private model serving | ✅ | ✅ |
-| Model fallback & provider selection | ✅ | ✅ |
-| Model variants & presets | ✅ | ✅ |
-| Adaptive routing policies | ✅ | ✅ |
-| Guardrails | ✅ | ✅ |
-| Observability (OTLP trace + metric export) | ✅ | ✅ |
-| MCP & ACP gateways | ✅ | ✅ |
-| Structured outputs | ✅ | ✅ |
-| Namespace isolation primitive | ✅ | ✅ |
-| Managed provider network (no upstream keys needed) | — | ✅ |
-| Team seats & per-workspace access control | — | ✅ |
-| Hosted observability console | — | ✅ |
-| Managed billing (one wallet, per-request) | — | ✅ |
-| SLA on the hosted endpoint | — | ✅ |
-| Priority support | — | ✅ |
-| Agentic payment marketplace | — | ✅ |
-
-Do you need your own provider keys? Only if you self-host with BYOK — a Cloud account needs **no upstream keys**: one sign-in covers the whole hosted network, billed per request, failed requests not charged. You can also attach Cloud to a self-hosted binary and use both.
-
-## Install the binary
-
-<Tabs items={['macOS / Linux', 'Homebrew', 'npm', 'cargo']}>
-<Tab value="macOS / Linux">
+<Tabs items={['CLI', 'MCP', 'Agent Skills', 'Wizard']}>
+<Tab value="CLI">
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.sh | sh
+curl -fsSL https://bitrouter.ai/install.sh | sh
+```
+
+Then launch your harness through the router:
+
+```bash
+bitrouter launch claude
 ```
 
 </Tab>
-<Tab value="Homebrew">
+<Tab value="MCP">
 
 ```bash
-brew install bitrouter/tap/bitrouter
+npx bitrouter mcp install --client claude
+```
+
+Registers BitRouter as an MCP server, so the agent can drive it as a tool. See [MCP server](/docs/usage/mcp).
+
+</Tab>
+<Tab value="Agent Skills">
+
+```bash
+npx skills add bitrouter/bitrouter
+```
+
+A drop-in [skill](/docs/usage/skills) for any agent that supports them. Then ask it: *"Set up BitRouter for me."*
+
+</Tab>
+<Tab value="Wizard">
+
+```bash
+npx @bitrouter/agent
+```
+
+[bitrouter-agent](https://github.com/bitrouter/bitrouter-agent) reads your codebase read-only, then writes a starter `bitrouter.yaml`, an audit of your LLM usage, and a savings estimate. It never modifies your source.
+
+</Tab>
+</Tabs>
+
+## Or wire it up yourself
+
+Get a key with `bitrouter cloud login`, or mint one in the [console](https://cloud.bitrouter.ai). Then change three strings:
+
+| String | Value |
+| --- | --- |
+| Base URL | `https://api.bitrouter.ai/v1` |
+| API key | your `brk_` key |
+| Model id | `bitrouter/auto` — or any id from the [catalog](/docs/overview/supported-models) |
+
+<Tabs items={['OpenAI SDK', 'Anthropic SDK', 'curl']}>
+<Tab value="OpenAI SDK">
+
+```python
+from openai import OpenAI
+import os
+
+client = OpenAI(
+    base_url="https://api.bitrouter.ai/v1",
+    api_key=os.environ["BITROUTER_API_KEY"],
+)
+
+response = client.chat.completions.create(
+    model="bitrouter/auto",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
 ```
 
 </Tab>
-<Tab value="npm">
+<Tab value="Anthropic SDK">
 
-```bash
-npm install -g bitrouter
+```python
+from anthropic import Anthropic
+import os
+
+client = Anthropic(
+    base_url="https://api.bitrouter.ai",
+    api_key=os.environ["BITROUTER_API_KEY"],
+)
+
+message = client.messages.create(
+    model="bitrouter/auto",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello!"}],
+)
 ```
 
 </Tab>
-<Tab value="cargo">
+<Tab value="curl">
 
 ```bash
-cargo install bitrouter
+curl https://api.bitrouter.ai/v1/chat/completions \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bitrouter/auto",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
 ```
 
 </Tab>
 </Tabs>
 
-## Onboard via the Agent Skill
+You are not switching to an OpenAI-shaped API. BitRouter speaks four request formats natively on the same host and the same key, so whichever SDK you already use keeps working — only the base URL changes:
 
-For agent runtimes that support skills (Claude Code, Cursor, Codex, Copilot, etc.). BitRouter ships a `/bitrouter` [Agent Skill](https://agentskills.io) so the agent can install, configure, migrate to, and troubleshoot BitRouter **on its own** — the skill carries the facts that drift easily (the listen port, env var names, the `provider/model` slash form, which subcommands exist), and it lives in the main repo at `skills/bitrouter/`, kept in sync with the code in the same change. Install once:
+| Surface | Path |
+| --- | --- |
+| OpenAI Chat Completions | `/v1/chat/completions` |
+| OpenAI Responses | `/v1/responses` |
+| Anthropic Messages | `/v1/messages` |
+| Google Generative Language | `/v1beta/models/{model}:generateContent` |
 
-```bash
-bitrouter skills add bitrouter        # via BitRouter's own installer
-npx skills add bitrouter/bitrouter    # via the generic skills CLI
-```
+Model ids and routing behave identically across all four. `bitrouter/auto` hands the model choice to BitRouter, which decides from evidence you don't have to collect — how models hold up per kind of request, live provider health, current price. Name a model id instead (`anthropic/claude-opus-4.8`) to pin that request. Pinning and routing mix freely.
 
-Then ask your agent: *"Set up BitRouter for me."* — the agent runs the wizard, picks Cloud by default, and verifies the connection autonomously.
+## Start optimizing
+
+`bitrouter/auto` starts from general evidence. Optimizing replaces it with evidence from **your** workflow — and the result routes under the same `bitrouter/auto`, so nothing in your app changes.
+
+This is not "swap in a cheaper model." BitRouter runs your workflow twice — once as-is, once with exactly one routing change — then compares the two. One variable, measured on your code, against a success contract you wrote.
 
 <Callout type="info">
-The `/bitrouter` skill *drives* BitRouter; the [AgentSkills gateway](/docs/mcp-and-tool-calling/mcp-gateway) is the opposite direction — BitRouter *serving* skills as governed, routable resources to the agents behind it.
+This needs the CLI, a Git repository, and macOS or Linux. Everything above stays install-free.
 </Callout>
 
-## Onboard via the CLI wizard
-
-For terminal-first setup, launch the wizard:
+Point it at a command that exercises your agent:
 
 ```bash
-bitrouter
+bitrouter optimize setup --workflow-command ./run-agent-eval
 ```
 
-Bare `bitrouter` runs a **network-free credential probe** — BYOK env keys, the cloud session file, and the local credential store — then launches the wizard when nothing is configured, or prints a one-line status when it is. It never re-onboards a configured user and never silently spawns a daemon. The wizard walks three steps:
+That writes three files you own and commit: the workflow intent, a lock of resolved identities and digests, and a success contract describing what a good run looks like.
 
-1. **Credentials** — sign in to BitRouter Cloud (default), log in to a provider, or paste a BYOK key.
-2. **Harness** — `claude` or `codex`, installed via the native installer when missing.
-3. **Finish** — launch the harness, start the proxy at `http://127.0.0.1:4356`, or exit.
-
-Every step maps to a flag, so an agent (or CI) can run the whole flow without a human. `--yes` never blocks: it consumes flag-supplied credentials, reports-and-skips anything that would need interactive OAuth, and emits a JSON result envelope on stdout:
+Then run the loop:
 
 ```bash
-bitrouter init --yes --provider openai --provider-api-key "sk-..." --harness claude --after serve
-bitrouter init --yes --use-detected --harness claude --after serve   # accept env keys, run proxy
-bitrouter init --yes --api-key "brk_..." --after exit                # Cloud key, no launch
-bitrouter init --reset                                               # clear credentials, start over
+bitrouter optimize run       # baseline and one candidate, once each
+bitrouter optimize review    # the comparison
 ```
 
-Every flag is documented in the [`bitrouter init` reference](/docs/usage/cli#bitrouter-init). The wizard never writes `bitrouter.yaml` beyond the canned starter template — your routing config stays yours to edit.
+`review` reports the route key that changed, which model served each side, the evaluator's verdict on both, the settled cost delta, and whether the candidate is publishable at all. Observed latency is reported alongside but does not gate anything yet.
 
-## Run self-hosted
-
-Set your provider keys in the environment and start the proxy:
+If quality held and cost dropped, apply it:
 
 ```bash
-export OPENAI_API_KEY=sk-...    # ANTHROPIC_API_KEY / GEMINI_API_KEY also work
-bitrouter start
-# Proxy running at http://127.0.0.1:4356
+bitrouter optimize publish
 ```
 
-BitRouter auto-detects any key set in the environment — no config file needed. Any provider whose key is present is immediately available. See [BYOK](/docs/models-and-routing/bring-your-own-provider) for the full list of recognized variables, or [local & private models](/docs/integrations/models) to point BitRouter at Ollama, vLLM, or LM Studio for free.
+From then on `bitrouter/auto` sends that kind of request to the cheaper model **for you** — same base URL, same key, same model id. Then run the loop again. Each cycle moves one more route down a tier, so the savings compound while every step stays individually reviewed. Nothing is ever applied automatically, and every published state is reversible by digest.
 
-For advanced routing rules, guardrails, or multi-account failover, scaffold a config file:
-
-```bash
-bitrouter init          # writes ./bitrouter.yaml (override with `-c <path>`)
-bitrouter start
-```
-
-## Use BitRouter Cloud
-
-Sign in to a BitRouter Cloud account from the terminal — one account covers every model the hosted network offers, with no upstream provider keys required:
-
-```bash
-bitrouter cloud login   # RFC 8628 device flow against api.bitrouter.ai
-bitrouter start         # the `bitrouter` provider auto-enables once signed in
-```
-
-Cloud is not a different binary — it's an account you attach. Signing in from a self-hosted binary routes Cloud-managed models alongside your BYOK keys, and you can add or remove the Cloud account at any time without affecting the binary's self-hosted capabilities. You can also point an agent straight at the hosted endpoint without running a local binary at all. See the [Supported Models](/docs/overview/supported-models) catalog for pricing.
-
-## Point your agent at the proxy
-
-However you start it, BitRouter is a drop-in proxy. Point your agent runtime at the proxy base URL — `http://127.0.0.1:4356` when self-hosting — and every model call routes through BitRouter with no harness changes.
-
-Verify with a request:
-
-```bash
-curl http://127.0.0.1:4356/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "openai/gpt-4o",
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
-```
-
-Point any OpenAI-compatible runtime at `http://127.0.0.1:4356/v1` to route through BitRouter.
-
-Two commands make the routing decision itself legible:
-
-```bash
-bitrouter models                            # every model id routable right now
-bitrouter route anthropic/claude-opus-4.8   # preview the routing decision
-```
-
-## Adaptive routing
-
-Everything above is a static router. The adaptive half — the **learn** step of the [act → observe → evaluate → learn](/docs/overview/what-is-bitrouter) loop — is opt-in, deterministic, and adds no LLM call to the path. Its artifact is `policy-lock.yaml`, living next to `bitrouter.yaml`: **Git owns its history; the local database owns the evidence.**
-
-One command scaffolds everything:
-
-```bash
-bitrouter policy init coding --preset coding --economy moonshotai/kimi-k2.7-code
-```
-
-That writes a two-tier table (strong = your preset's model, economy = the cheap one), clamps tool-carrying requests to the strong tier so a downgrade never strands a tool call, and binds the policy to the preset in `bitrouter.yaml` with `writeback: locked`. Selecting the preset as the model is the entire opt-in boundary — bare model requests are never touched by a policy:
-
-```bash
-curl http://127.0.0.1:4356/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model": "@coding", "messages": [{"role": "user", "content": "..."}]}'
-```
-
-Each request is fingerprinted by loop step (`opening`, `after_<tool>`, `midstream`) and resolved fingerprint → tier → model. An unmatched fingerprint falls back to `default_tier`, and the table starts conservative: everything routes strong until evidence says otherwise.
-
-### Learning from live traffic
-
-With `adequacy` enabled, every request through a policy-bound route is classified by outcome and recorded against its fingerprint — deterministically, with [no LLM judge in the path](/docs/evals-and-tracing/evaluation). Two halves act on that signal:
-
-- **Escalation (the safety half)** — a downgraded fingerprint that hard-fails `escalation_threshold` consecutive times is pinned up to the strong tier. Pins decay after a cooldown.
-- **Exploration (the aggressive half)** — with `explore_enabled`, roughly 1-in-`explore_interval` candidate requests is trialed on the economy tier; `explore_threshold` consecutive adequate trials qualify that fingerprint for the cheap tier. A failed trial escalates and stops.
-
-```yaml
-# policy-lock.yaml
-adequacy:
-  enabled: true
-  escalation_tier: strong
-  escalation_threshold: 2
-  pin_cooldown_secs: 1800
-  explore_enabled: true
-  explore_tier: economy
-  explore_threshold: 3
-  explore_interval: 5
-```
-
-The evidence rule is asymmetric: negative evidence escalates immediately, while a cheaper route needs repeated success before it becomes effective. A policy with `adequacy` off behaves exactly like its deterministic table.
-
-The signal itself — the outcome classes it records, the per-request cost metering alongside it, and the objective-scored eval engine landing on top — is [Evaluation](/docs/evals-and-tracing/evaluation).
-
-### Publishing what it learns
-
-Qualified downgrades live in the database until you publish them. The cycle is explicit and digest-checked:
-
-```bash
-bitrouter policy status          # path, digest, writeback mode, bindings
-bitrouter policy evolve          # dry-run: which routes would materialize
-bitrouter policy unlock          # permit programmatic writeback
-bitrouter policy evolve --apply  # atomically republish policy-lock.yaml
-bitrouter policy reload          # daemon picks it up — no restart
-bitrouter policy lock            # forbid programmatic writes again
-```
-
-`evolve --apply` only **adds** qualified routes — it never overwrites or removes anything you or Git wrote, and a detected intervening edit aborts the publish instead of clobbering it. Commit the result and the improved table is in Git, where a policy belongs.
-
-<Callout type="info">
-`bitrouter policy create` + `bitrouter key sign` are a **different surface** — per-key access control (allowed models, budgets, rate limits), not routing. See [Guardrails](/docs/models-and-routing/guardrails).
+<Callout type="warn">
+`quality-first`, `balanced`, and `savings-first` set what the optimizer tries first. They are not quality-loss budgets, and no percentage is promised — your eval result is the authority on every trade-off. Both sides of a comparison must currently be hosted routes.
 </Callout>
 
 ## Next steps
 
 <Cards>
-  <Card title="Provider selection" href="/docs/models-and-routing/provider-selection" description="Declare providers, rank them, and add multi-account failover." />
-  <Card title="Virtual models" href="/docs/models-and-routing/virtual-model" description="Named routing profiles — the opt-in boundary for adaptive routing." />
+  <Card title="Supported models" href="/docs/overview/supported-models" description="The full catalog, id grammar, and per-model pricing." />
+  <Card title="Virtual models" href="/docs/models-and-routing/virtual-model" description="Named routing profiles you invoke inline with @name." />
   <Card title="Integrations" href="/docs/integrations" description="Step-by-step guides for every supported agent runtime." />
+  <Card title="Self-host" href="/docs/guides/self-host" description="Run the same router on your own infrastructure." />
+  <Card title="Bring your own models" href="/docs/models-and-routing/bring-your-own-model" description="Put a local runner, a fine-tune, or a private cluster behind the same endpoint." />
   <Card title="CLI reference" href="/docs/usage/cli" description="The full command surface of the binary." />
 </Cards>

--- a/content/docs/(guide)/overview/what-is-bitrouter.mdx
+++ b/content/docs/(guide)/overview/what-is-bitrouter.mdx
@@ -11,12 +11,12 @@ It runs anywhere your agent runs, with no dependencies to install, and operates 
 
 ## The idea: a second loop
 
-Our bet is simple: routing is a learning problem. BitRouter wraps your agentic loop in a **second loop**. Each loop gets its own [policy spec](/docs/overview/quickstart#adaptive-routing) — a config file that declares how its calls, tools, and agents should route — and against that spec BitRouter runs a continuous **act → observe → evaluate → learn** cycle. Every step is a component it already ships:
+Our bet is simple: routing is a learning problem. BitRouter wraps your agentic loop in a **second loop**. Each loop gets its own **policy spec** — a config file that declares how its calls, tools, and agents should route — and against that spec BitRouter runs a continuous **act → observe → evaluate → learn** cycle. Every step is a component it already ships:
 
 - **Act — the router.** Each model, tool, and agent call is rewritten to a chosen route: policy-table routing, cross-protocol translation, multi-account failover. See [Provider selection](/docs/models-and-routing/provider-selection).
 - **Observe — telemetry.** Every hop is attributed with cost, tokens, latency, and outcome, exported over OTLP to any backend you run. See [OpenTelemetry](/docs/evals-and-tracing/opentelemetry).
 - **Evaluate — the adequacy signal.** Each served request is scored against the route that served it — did the cheaper path still reach the goal? — and every request is cost-metered. Run-level, objective-scored evals are the next milestone. See [Evaluation](/docs/evals-and-tracing/evaluation).
-- **Learn — the policy engine.** The observed signal folds back into the policy spec: proven downgrades materialize into the table, failed ones escalate back. The next turn of the loop acts on the improved spec. See [Adaptive routing](/docs/overview/quickstart#adaptive-routing).
+- **Learn — the policy engine.** The observed signal folds back into the policy spec: proven downgrades materialize into the table, failed ones escalate back. The next turn of the loop acts on the improved spec.
 
 You choose what the loop optimizes for, and it improves the longer it runs in production. We call this recursive self-improvement applied to infrastructure: the router gets better at routing your loop every time the loop runs.
 

--- a/content/docs/(guide)/usage/cli.mdx
+++ b/content/docs/(guide)/usage/cli.mdx
@@ -316,7 +316,7 @@ Log out of an upstream provider — clears every stored credential for it. For t
 
 ## Policy
 
-Routing policies are the artifact the [self-improving loop](/docs/overview/what-is-bitrouter) learns into: `init` scaffolds `policy-lock.yaml` and binds it to a preset, live traffic teaches the adequacy ledger, and `evolve --apply` folds proven downgrades back into the file. The walkthrough, table, and ledger semantics are in [Adaptive routing](/docs/overview/quickstart#adaptive-routing).
+Routing policies are the artifact the [self-improving loop](/docs/overview/what-is-bitrouter) learns into: `init` scaffolds `policy-lock.yaml` and binds it to a preset, live traffic teaches the adequacy ledger, and `evolve --apply` folds proven downgrades back into the file.
 
 <Callout type="info">
 `bitrouter policy create` + `bitrouter key sign` are a **different surface** — per-virtual-key access control (allowed models, budgets, rate limits), not routing. See [Guardrails](/docs/models-and-routing/guardrails).
@@ -1156,7 +1156,7 @@ Reattach to a warm session: bridge this terminal's stdio to the session's unix s
 
 ## Skills and MCP
 
-`skills` installs and manages [Agent Skills](https://agentskills.io) for your harness; `mcp` runs BitRouter's own MCP server — the tool surface any MCP client can drive instead of shelling out. What the server exposes (backends, transports, the gateway distinction) lives on the [MCP Server](/docs/usage/mcp) page.
+`skills` manages the [Agent Skills](https://agentskills.io) installed for your harness — install them with `npx skills add <source>`; `mcp` runs BitRouter's own MCP server — the tool surface any MCP client can drive instead of shelling out. What the server exposes (backends, transports, the gateway distinction) lives on the [MCP Server](/docs/usage/mcp) page.
 
 ### `bitrouter skills`
 
@@ -1183,11 +1183,6 @@ Install a skill from a source (GitHub `owner/repo`, a git URL, or a registry ski
 | `--registry <URL>` | Registry base URL used when `source` is a bare skill name |
 | `-n, --namespace <NSID>` | Namespace id whose registry hub to query (required for registry operations) |
 
-
-```bash
-bitrouter skills add bitrouter        # the /bitrouter skill, from the registry
-bitrouter skills add owner/repo       # from GitHub
-```
 
 #### `bitrouter skills list`
 

--- a/content/docs/(guide)/usage/skills.mdx
+++ b/content/docs/(guide)/usage/skills.mdx
@@ -11,14 +11,8 @@ Install with the generic skills CLI:
 npx skills add bitrouter/bitrouter
 ```
 
-Or via BitRouter's own installer:
-
-```bash
-bitrouter skills add bitrouter
-```
-
 The skill is kept in sync with the code in the [bitrouter repo](https://github.com/bitrouter/bitrouter).
 
 ## Serving skills to a harness
 
-`bitrouter skills` installs and manages skills locally; `bitrouter mcp serve --backend skills` exposes the installed set as a standalone AgentSkills server so any harness can discover and load them. Under `bitrouter tui` that server is injected into every launched harness automatically — see [MCP server](/docs/usage/mcp#backend-variants).
+`bitrouter skills` manages the locally installed set; `bitrouter mcp serve --backend skills` exposes it as a standalone AgentSkills server so any harness can discover and load them. Under `bitrouter tui` that server is injected into every launched harness automatically — see [MCP server](/docs/usage/mcp#backend-variants).

--- a/content/docs/guides/self-host.mdx
+++ b/content/docs/guides/self-host.mdx
@@ -9,8 +9,7 @@ This is the **production** path for running BitRouter on your own infrastructure
 a committed config file, real provider keys, the router running as a managed
 daemon, metrics export, and basic hardening. If you just want it running in 60
 seconds, start with the [Quickstart](/docs/overview/quickstart) — this guide
-picks up where that leaves off. Deciding between self-host and the hosted product?
-See [Self-host or Cloud?](/docs/overview/quickstart#self-host-or-cloud).
+picks up where that leaves off.
 
 The router listens on `127.0.0.1:4356` by default — loopback only, until you
 explicitly choose otherwise.
@@ -209,7 +208,6 @@ per-request attribution, and per-backend export configs.
 
 <Cards>
   <Card title="Quickstart" href="/docs/overview/quickstart" description="The 60-second local install, if you skipped it." />
-  <Card title="Self-host vs Cloud" href="/docs/overview/quickstart#self-host-or-cloud" description="Pick the deployment model that fits." />
   <Card title="OpenTelemetry" href="/docs/evals-and-tracing/opentelemetry" description="OTLP trace + metric export and per-request attribution." />
   <Card title="Guardrails" href="/docs/models-and-routing/guardrails" description="Content firewall for requests and responses." />
 </Cards>


### PR DESCRIPTION
## ⚠️ Do not merge yet

This documents a UX that is **partly shipped and partly still being designed**. It is opened for review of structure and framing, not to land. See [Blocked on](#blocked-on) below.

## What this does

Refocuses the quickstart on the hosted endpoint and ends it on the optimization loop, instead of walking through a static proxy setup. 240 → 179 lines (~880 words, for reference OpenRouter's quickstart is ~1,500).

The page now has one continuous arc: **send `bitrouter/auto` → measure it on your own workflow → publish → the same model id routes differently for you.**

### Changes

- **Dropped the Cloud-vs-self-host framing**, the capability parity table, and the self-host walkthrough. Self-hosting is a card in Next steps. "Cloud" now appears twice on the page, both unavoidable (`bitrouter cloud login`, the `cloud.bitrouter.ai` console link).
- **Four-tab onboarding strip** matching the landing hero — CLI, MCP, Agent Skills, Wizard — replacing the old "Option A / Option B" split.
- **`bitrouter skills add` removed** (deprecated upstream) from the quickstart, `usage/skills.mdx`, and `cli-overlays/skills.md`.
- **Protocol coverage surfaced.** Tabs are now OpenAI SDK / Anthropic SDK / curl rather than three renderings of the same OpenAI call, plus a table of all four natively supported request formats. Neither comparison page mentions protocol support at all today — this is undersold site-wide.
- **"Start optimizing"** replaces the old adaptive-routing deep dive: what makes it different from swapping in a cheaper model, what `review` reports, how publishing feeds back into `bitrouter/auto`, and how cycles compound.
- **Seven dead inbound links removed** — the `#adaptive-routing` and `#self-host-or-cloud` anchors no longer exist.
- **`optimize setup` no longer opens with a flag.** Guided discovery landed in bitrouter/bitrouter#779, so the section leads with bare `bitrouter optimize setup` and keeps exact argv for the undiscoverable case.

## Blocked on

Updated after bitrouter/bitrouter#777, #779, and #788 merged. The naming question this PR was originally challenged on is **resolved in this PR's favour** — see below.

### Resolved

1. ~~**`bitrouter/auto` does not exist yet.** Zero occurrences in `bitrouter/bitrouter`.~~ **It exists as of bitrouter/bitrouter#788.** `bitrouter/` is now a namespace BitRouter resolves itself, reserved end to end: Stage 0 claims the prefix before any provider lookup, and `dist-helper registry validate` rejects any catalog or provider model id underneath.

   Note that #779 briefly settled this the other way — it shipped `@auto` and stated "`bitrouter/auto` is not introduced as an alias", explicitly correcting this PR. #788 reversed that on the adoption argument this PR was making all along: `vendor/auto` is the convention the ecosystem already uses, so a config pointing at some other `.../auto` model needs one segment changed rather than a new syntax learned. **No page change is needed here — the spelling on this branch was right.**

2. ~~**`bitrouter optimize` is unmerged** — bitrouter/bitrouter#777.~~ Merged, and its UX revision landed in #779.

### Still open

3. **`bitrouter/auto` is a local resolution, and this page is hosted.** This is now the central blocker and it is a genuinely new one. #788 implements the slug in the **local daemon's** Stage-0 resolver, against a locally-bound `presets.auto` and a signed `policy-lock.yaml`. Every code sample on this page sends `model: "bitrouter/auto"` to `https://api.bitrouter.ai/v1` with a `brk_` key — a different service, which does not implement it. The reserved-namespace rule also means `bitrouter/auto` can never arrive via the registry catalog the way every other id on the supported-models page does; if Cloud serves it, it has to be a Cloud-side routing feature. **Needs a decision from whoever owns the cloud registry.**

4. **`bitrouter/auto` does not work on a fresh install.** #788 deliberately shipped the spelling without a default policy: with no bound policy the request returns a `400` naming `bitrouter optimize setup`, rather than falling back to a default route. This page's "change three strings" promise assumes paste-and-go. Tracked for team decision in bitrouter/bitrouter#787 — that issue exists precisely because this page's arc depends on the answer.

5. **`npx @bitrouter/agent` is not on npm.** Confirmed still 404 as of this update. [bitrouter-agent](https://github.com/bitrouter/bitrouter-agent) states it is in development.

6. **Publishing must feed back into `bitrouter/auto`.** True for the local daemon after #788. Not true for the hosted endpoint, which is the one this page tells readers to call — same dependency as (3).

## Known gaps

- **`review` output is described, not shown.** Showing a real captured block would be the strongest three lines on the page; I did not invent a terminal format. #779's merge-readiness gates include capturing verified terminal output from a clean-host walkthrough — that capture is the thing to paste here.
- ~~**`optimize setup` still needs a workflow command.**~~ Closed by guided discovery in #779; the page now leads with bare `bitrouter optimize setup`.
- **`bitrouter skills add` survives in the CLI reference** at `content/docs/(guide)/usage/cli.mdx`. That page is generated from `.cli-snapshot.json` and the snapshot still contains the command — it only disappears after `pnpm snapshot:cli` against a binary that has dropped it.
- **Two different things are now called "optimize"** — `bitrouter optimize` (worktree baseline/candidate with an ACP judge) and `npx @bitrouter/agent optimize` (reads `bitrouter.db`, proposes a tighter policy). The quickstart references both. Worth renaming one.
- **The landing hero ships a broken command.** `components/landing/zed/hero-quickstart.tsx` says `bitrouter run claude-code`; `run` is not in the CLI snapshot — the command is `bitrouter launch`. The docs use `bitrouter launch claude`. Not fixed here.

## Follow-ups not in this PR

- An **adaptive routing** page for the content removed from the quickstart. It needs rewriting regardless: `policy.mode: frozen|adaptive` replaced `writeback`, `policy lock`/`unlock` were removed upstream, and `key_strategy: legacy_fingerprint` is now rejected in favour of `agent_trace/v2|<state>|<risk>`. #788's `skills/bitrouter/references/adaptive-routing.md` is a usable source for the reserved-namespace and error semantics.
- `content/docs/(guide)/usage/configuration.mdx` still documents `writeback: locked|evolve`.
- Collapsing BYOK / BYOM / model-sources into one "bring your own upstreams" concept.

## Verification

- `pnpm lint:docs` passes (49 docs, 7 sections)
- `pnpm generate:cli` re-run after editing `cli-overlays/`
- Full internal-link sweep across all pages: **0 broken** page targets or anchors
- All touched pages render 200 on the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
