### PR TITLE
Add cached-input pricing and tighten the supported-models page

### DIFF
--- a/.models-snapshot.json
+++ b/.models-snapshot.json
@@ -15,6 +15,7 @@
       "capabilities": [],
       "providers": 1,
       "inputUsdPerM": 10,
+      "cacheReadUsdPerM": 1,
       "outputUsdPerM": 50,
       "openWeights": false
     },
@@ -32,6 +33,7 @@
       "capabilities": [],
       "providers": 1,
       "inputUsdPerM": 1,
+      "cacheReadUsdPerM": 0.1,
       "outputUsdPerM": 5,
       "openWeights": false
     },
@@ -53,6 +55,7 @@
       ],
       "providers": 2,
       "inputUsdPerM": 5,
+      "cacheReadUsdPerM": 0.5,
       "outputUsdPerM": 25,
       "openWeights": false
     },
@@ -74,6 +77,7 @@
       ],
       "providers": 2,
       "inputUsdPerM": 4.5,
+      "cacheReadUsdPerM": 0.45,
       "outputUsdPerM": 22.5,
       "openWeights": false
     },
@@ -95,6 +99,7 @@
       ],
       "providers": 2,
       "inputUsdPerM": 5,
+      "cacheReadUsdPerM": 0.5,
       "outputUsdPerM": 25,
       "openWeights": false
     },
@@ -112,6 +117,7 @@
       "capabilities": [],
       "providers": 2,
       "inputUsdPerM": 5,
+      "cacheReadUsdPerM": 0.5,
       "outputUsdPerM": 25,
       "openWeights": false
     },
@@ -134,6 +140,7 @@
       ],
       "providers": 2,
       "inputUsdPerM": 3,
+      "cacheReadUsdPerM": 0.3,
       "outputUsdPerM": 15,
       "openWeights": false
     },
@@ -156,6 +163,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 2,
+      "cacheReadUsdPerM": 0.2,
       "outputUsdPerM": 10,
       "openWeights": false
     },
@@ -176,6 +184,7 @@
       ],
       "providers": 6,
       "inputUsdPerM": 0.252,
+      "cacheReadUsdPerM": 0.0252,
       "outputUsdPerM": 0.378,
       "openWeights": true
     },
@@ -195,6 +204,7 @@
       ],
       "providers": 7,
       "inputUsdPerM": 0.112,
+      "cacheReadUsdPerM": 0.022,
       "outputUsdPerM": 0.224,
       "openWeights": true
     },
@@ -214,6 +224,7 @@
       ],
       "providers": 4,
       "inputUsdPerM": 0.14,
+      "cacheReadUsdPerM": 0.028,
       "outputUsdPerM": 0.28,
       "openWeights": true
     },
@@ -234,6 +245,7 @@
       ],
       "providers": 8,
       "inputUsdPerM": 0.435,
+      "cacheReadUsdPerM": 0.003625,
       "outputUsdPerM": 0.87,
       "openWeights": true
     },
@@ -251,6 +263,7 @@
       "capabilities": [],
       "providers": 1,
       "inputUsdPerM": 0.25,
+      "cacheReadUsdPerM": 0.025,
       "outputUsdPerM": 1.5,
       "openWeights": false
     },
@@ -271,6 +284,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 2,
+      "cacheReadUsdPerM": 0.2,
       "outputUsdPerM": 12,
       "openWeights": false
     },
@@ -292,6 +306,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 1.5,
+      "cacheReadUsdPerM": 0.15,
       "outputUsdPerM": 9,
       "openWeights": false
     },
@@ -309,6 +324,7 @@
       "capabilities": [],
       "providers": 3,
       "inputUsdPerM": 0.13,
+      "cacheReadUsdPerM": null,
       "outputUsdPerM": 0.4,
       "openWeights": true
     },
@@ -325,6 +341,7 @@
       "capabilities": [],
       "providers": 1,
       "inputUsdPerM": 0.75,
+      "cacheReadUsdPerM": null,
       "outputUsdPerM": 2.95,
       "openWeights": true
     },
@@ -344,6 +361,7 @@
       ],
       "providers": 6,
       "inputUsdPerM": 0.15,
+      "cacheReadUsdPerM": 0.075,
       "outputUsdPerM": 1.2,
       "openWeights": true
     },
@@ -363,6 +381,7 @@
       ],
       "providers": 3,
       "inputUsdPerM": 0.3,
+      "cacheReadUsdPerM": 0.06,
       "outputUsdPerM": 1.2,
       "openWeights": true
     },
@@ -383,6 +402,7 @@
       ],
       "providers": 4,
       "inputUsdPerM": 0.3,
+      "cacheReadUsdPerM": 0.06,
       "outputUsdPerM": 1.2,
       "openWeights": true
     },
@@ -404,6 +424,7 @@
       ],
       "providers": 6,
       "inputUsdPerM": 0.44,
+      "cacheReadUsdPerM": 0.22,
       "outputUsdPerM": 2,
       "openWeights": true
     },
@@ -424,6 +445,7 @@
       ],
       "providers": 10,
       "inputUsdPerM": 0.66,
+      "cacheReadUsdPerM": 0.33,
       "outputUsdPerM": 3.5,
       "openWeights": true
     },
@@ -445,6 +467,7 @@
       ],
       "providers": 5,
       "inputUsdPerM": 0.73,
+      "cacheReadUsdPerM": 0.15,
       "outputUsdPerM": 3.5,
       "openWeights": true
     },
@@ -466,6 +489,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 3,
+      "cacheReadUsdPerM": 0.3,
       "outputUsdPerM": 15,
       "openWeights": true
     },
@@ -487,6 +511,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 2.5,
+      "cacheReadUsdPerM": 0.25,
       "outputUsdPerM": 15,
       "openWeights": false
     },
@@ -508,6 +533,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 0.75,
+      "cacheReadUsdPerM": 0.075,
       "outputUsdPerM": 4.5,
       "openWeights": false
     },
@@ -529,6 +555,7 @@
       ],
       "providers": 2,
       "inputUsdPerM": 5,
+      "cacheReadUsdPerM": 0.5,
       "outputUsdPerM": 30,
       "openWeights": false
     },
@@ -550,6 +577,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 0.2,
+      "cacheReadUsdPerM": 0.02,
       "outputUsdPerM": 1.2,
       "openWeights": false
     },
@@ -571,6 +599,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 5,
+      "cacheReadUsdPerM": 0.5,
       "outputUsdPerM": 30,
       "openWeights": false
     },
@@ -592,6 +621,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 2,
+      "cacheReadUsdPerM": 0.2,
       "outputUsdPerM": 12,
       "openWeights": false
     },
@@ -609,6 +639,7 @@
       "capabilities": [],
       "providers": 2,
       "inputUsdPerM": 0.26,
+      "cacheReadUsdPerM": null,
       "outputUsdPerM": 2.08,
       "openWeights": true
     },
@@ -626,6 +657,7 @@
       "capabilities": [],
       "providers": 2,
       "inputUsdPerM": 0.25,
+      "cacheReadUsdPerM": null,
       "outputUsdPerM": 2,
       "openWeights": true
     },
@@ -643,6 +675,7 @@
       "capabilities": [],
       "providers": 2,
       "inputUsdPerM": 0.3,
+      "cacheReadUsdPerM": null,
       "outputUsdPerM": 3.2,
       "openWeights": true
     },
@@ -660,6 +693,7 @@
       "capabilities": [],
       "providers": 2,
       "inputUsdPerM": 0.248,
+      "cacheReadUsdPerM": null,
       "outputUsdPerM": 1.485,
       "openWeights": true
     },
@@ -677,6 +711,7 @@
       "capabilities": [],
       "providers": 2,
       "inputUsdPerM": 0.1875,
+      "cacheReadUsdPerM": null,
       "outputUsdPerM": 1.125,
       "openWeights": false
     },
@@ -693,6 +728,7 @@
       "capabilities": [],
       "providers": 4,
       "inputUsdPerM": 2.5,
+      "cacheReadUsdPerM": 0.5,
       "outputUsdPerM": 7.5,
       "openWeights": false
     },
@@ -710,6 +746,7 @@
       "capabilities": [],
       "providers": 3,
       "inputUsdPerM": 0.4,
+      "cacheReadUsdPerM": 0.08,
       "outputUsdPerM": 1.6,
       "openWeights": false
     },
@@ -728,6 +765,7 @@
       "capabilities": [],
       "providers": 1,
       "inputUsdPerM": 2,
+      "cacheReadUsdPerM": 0.25,
       "outputUsdPerM": 6,
       "openWeights": false
     },
@@ -747,6 +785,7 @@
       ],
       "providers": 3,
       "inputUsdPerM": 0.1,
+      "cacheReadUsdPerM": 0.02,
       "outputUsdPerM": 0.3,
       "openWeights": true
     },
@@ -766,6 +805,7 @@
       ],
       "providers": 3,
       "inputUsdPerM": 0.185,
+      "cacheReadUsdPerM": 0.037,
       "outputUsdPerM": 1.11,
       "openWeights": true
     },
@@ -782,6 +822,7 @@
       "capabilities": [],
       "providers": 2,
       "inputUsdPerM": 0.066,
+      "cacheReadUsdPerM": 0.0261,
       "outputUsdPerM": 0.26,
       "openWeights": true
     },
@@ -801,6 +842,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 1.25,
+      "cacheReadUsdPerM": 0.2,
       "outputUsdPerM": 2.5,
       "openWeights": false
     },
@@ -821,6 +863,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 1.25,
+      "cacheReadUsdPerM": 0.2,
       "outputUsdPerM": 2.5,
       "openWeights": false
     },
@@ -841,6 +884,7 @@
       ],
       "providers": 2,
       "inputUsdPerM": 1.25,
+      "cacheReadUsdPerM": 0.2,
       "outputUsdPerM": 2.5,
       "openWeights": false
     },
@@ -861,6 +905,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 2,
+      "cacheReadUsdPerM": 0.3,
       "outputUsdPerM": 6,
       "openWeights": false
     },
@@ -879,6 +924,7 @@
       ],
       "providers": 1,
       "inputUsdPerM": 1,
+      "cacheReadUsdPerM": 0.2,
       "outputUsdPerM": 2,
       "openWeights": false
     },
@@ -898,6 +944,7 @@
       ],
       "providers": 3,
       "inputUsdPerM": 0.14,
+      "cacheReadUsdPerM": 0.0028,
       "outputUsdPerM": 0.28,
       "openWeights": true
     },
@@ -917,6 +964,7 @@
       ],
       "providers": 2,
       "inputUsdPerM": 0.435,
+      "cacheReadUsdPerM": 0.0036,
       "outputUsdPerM": 0.87,
       "openWeights": true
     },
@@ -933,6 +981,7 @@
       "capabilities": [],
       "providers": 2,
       "inputUsdPerM": 0.6,
+      "cacheReadUsdPerM": 0.11,
       "outputUsdPerM": 2.2,
       "openWeights": true
     },
@@ -953,6 +1002,7 @@
       ],
       "providers": 7,
       "inputUsdPerM": 0.6,
+      "cacheReadUsdPerM": 0.12,
       "outputUsdPerM": 1.92,
       "openWeights": true
     },
@@ -972,6 +1022,7 @@
       ],
       "providers": 8,
       "inputUsdPerM": 0.98,
+      "cacheReadUsdPerM": 0.49,
       "outputUsdPerM": 3.08,
       "openWeights": true
     },
@@ -991,6 +1042,7 @@
       ],
       "providers": 8,
       "inputUsdPerM": 0.979,
+      "cacheReadUsdPerM": 0.182,
       "outputUsdPerM": 3.08,
       "openWeights": true
     }

--- a/content/docs/(guide)/overview/supported-models.mdx
+++ b/content/docs/(guide)/overview/supported-models.mdx
@@ -1,89 +1,80 @@
 ---
 title: Supported Models
-description: The full catalog of models any BitRouter account can call — with pricing, reachable over your own keys or one hosted BitRouter Cloud account.
+description: The models hosted BitRouter routes to natively — a curated SOTA set for agentic and coding work, with input, cached-input, and output pricing — plus how to bring your own.
 ---
 
-Every model BitRouter can route to is listed below. Reach any of them over your own provider keys ([BYOK](/docs/models-and-routing/bring-your-own-provider), paid to the providers at their list price) or one [BitRouter Cloud](/docs/overview/quickstart) account — one sign-in, no upstream keys, billed per request with failed requests not charged. Running your own model? See [local & private models](/docs/integrations/models) (free).
+These are the models **hosted BitRouter** supports natively for context-aware routing: the ones the router can score, downgrade, and fail over between without any setup on your side. It is a curated set, not an everything-catalog — we track the best SOTA models for **agentic and coding** workloads, so the router always has a strong frontier option and a strong cheap option for every step of a loop.
 
-Prices are USD per **million tokens** — what a BitRouter Cloud request costs today, from the cheapest provider actually serving that model (`—` means no per-token provider is currently serving it). A provider listed in the [registry](https://github.com/bitrouter/bitrouter/tree/main/registry) but not currently reachable isn't priced here, so bringing your own key to one of them can beat these rates. Every model is served by one or more registered providers — membership lives in the public, open-source [registry](https://github.com/bitrouter/bitrouter/tree/main/registry), and anyone can [register a provider](/docs/guides/register-as-a-provider).
-
-## How model ids work
-
-On BitRouter a "model" is not a single endpoint. It's an **aggregate**: one logical model — say `openai/gpt-4o` or `anthropic/claude-sonnet-4.6` — that can be served by many providers at once. You address it by the stable **model id** in the catalog below, and BitRouter decides which underlying provider endpoint actually answers each request. That indirection is the point: you write your agent against `anthropic/claude-sonnet-4.6`, and the set of providers behind it can grow, shrink, or re-price without you changing a line of code.
-
-Because a model is an aggregate, requesting one kicks off a [provider selection](/docs/models-and-routing/provider-selection) step — BitRouter ranks the eligible providers on a blend of cost, latency, throughput, and uptime, and sends your request to the best one. A transient failure falls through to the next-ranked provider, or to the next model you listed via [fallback](/docs/models-and-routing/model-fallback). Append a [variant](/docs/models-and-routing/model-variants) suffix — `:cost`, `:latency`, `:throughput` — to re-rank the eligible providers along one axis for a single request; a bare id is the balanced default.
-
-### Four protocols in
-
-You reach the models gateway through whichever API your runtime already speaks. BitRouter exposes **four protocols**, side by side, on one endpoint:
-
-- **OpenAI Chat Completions** — `POST /v1/chat/completions`
-- **OpenAI Responses** — `POST /v1/responses`
-- **Anthropic Messages** — `POST /v1/messages`
-- **Google Generative AI** — `POST /v1beta/models/{model}:generateContent`
-
-Pick the one your SDK is already wired for — you don't adopt a new client. And because the gateway speaks all four, it can **route across them**: a request that arrives as Anthropic Messages can be served by an OpenAI provider, and vice-versa. One model id, reachable four ways, answerable by any eligible provider.
+You are never limited to this list. Any model you run yourself — local or remote, a fine-tune, a private cluster — routes alongside these with the same ids, fallbacks, and variants: see [bring your own model](/docs/models-and-routing/bring-your-own-model). To reach a model on your own provider account instead of ours, see [bring your own provider](/docs/models-and-routing/bring-your-own-provider).
 
 ## Model catalog
 
-| Model | Name | Context | Modalities | Open weights | Input $/M | Output $/M |
+| Model | Context | Modalities | Open weights | Input $/M | Cached input $/M | Output $/M |
 | --- | --- | --- | --- | --- | --- | --- |
-| `anthropic/claude-fable-5` | Anthropic: Claude Fable 5 | 1M | text, image | — | $10 | $50 |
-| `anthropic/claude-haiku-4.5` | Anthropic: Claude Haiku 4.5 | 200K | text, image | — | $1 | $5 |
-| `anthropic/claude-opus-4.6` | Anthropic: Claude Opus 4.6 | 200K | text, image | — | $5 | $25 |
-| `anthropic/claude-opus-4.7` | Anthropic: Claude Opus 4.7 | 200K | text, image | — | $4.5 | $22.5 |
-| `anthropic/claude-opus-4.8` | Anthropic: Claude Opus 4.8 | 1M | text, image | — | $5 | $25 |
-| `anthropic/claude-opus-5` | Anthropic: Claude Opus 5 | 1M | text, image | — | $5 | $25 |
-| `anthropic/claude-sonnet-4.6` | Anthropic: Claude Sonnet 4.6 | 1M | text, image | — | $3 | $15 |
-| `anthropic/claude-sonnet-5` | Anthropic: Claude Sonnet 5 | 1M | text, image | — | $2 | $10 |
-| `deepseek/deepseek-v3.2` | DeepSeek: DeepSeek V3.2 | 128K | text | ✅ | $0.252 | $0.378 |
-| `deepseek/deepseek-v4-flash` | DeepSeek: DeepSeek V4 Flash | 256K | text | ✅ | $0.112 | $0.224 |
-| `deepseek/deepseek-v4-flash-0731` | DeepSeek: DeepSeek V4 Flash 0731 | 1M | text | ✅ | $0.14 | $0.28 |
-| `deepseek/deepseek-v4-pro` | DeepSeek: DeepSeek V4 Pro | 256K | text | ✅ | $0.435 | $0.87 |
-| `google/gemini-3.1-flash-lite-preview` | Google: Gemini 3.1 Flash Lite Preview | 1M | text, image | — | $0.25 | $1.5 |
-| `google/gemini-3.1-pro-preview` | Google: Gemini 3.1 Pro Preview | 2M | text, image | — | $2 | $12 |
-| `google/gemini-3.5-flash` | Google: Gemini 3.5 Flash | 1M | text, image, audio | — | $1.5 | $9 |
-| `google/gemma-4-31b` | Google: Gemma 4 31B | 128K | text, image | ✅ | $0.13 | $0.4 |
-| `meituan/longcat-2.0` | LongCat 2.0 | 1M | text | ✅ | $0.75 | $2.95 |
-| `minimax/minimax-m2.5` | MiniMax: M2.5 | 192K | text | ✅ | $0.15 | $1.2 |
-| `minimax/minimax-m2.7` | MiniMax: M2.7 | 192K | text | ✅ | $0.3 | $1.2 |
-| `minimax/minimax-m3` | MiniMax: M3 | 1M | text, image | ✅ | $0.3 | $1.2 |
-| `moonshotai/kimi-k2.5` | Kimi: K2.5 | 256K | text, image | ✅ | $0.44 | $2 |
-| `moonshotai/kimi-k2.6` | Kimi: K2.6 | 256K | text | ✅ | $0.66 | $3.5 |
-| `moonshotai/kimi-k2.7-code` | Kimi: K2.7 Code | 256K | text, image | ✅ | $0.73 | $3.5 |
-| `moonshotai/kimi-k3` | Kimi: K3 | 1M | text, image | ✅ | $3 | $15 |
-| `openai/gpt-5.4` | OpenAI: GPT-5.4 | 128K | text, image | — | $2.5 | $15 |
-| `openai/gpt-5.4-mini` | OpenAI: GPT-5.4 Mini | 128K | text, image | — | $0.75 | $4.5 |
-| `openai/gpt-5.5` | OpenAI: GPT-5.5 | 128K | text, image | — | $5 | $30 |
-| `openai/gpt-5.6-luna` | OpenAI: GPT-5.6 Luna | 400K | text, image | — | $0.2 | $1.2 |
-| `openai/gpt-5.6-sol` | OpenAI: GPT-5.6 Sol | 1M | text, image | — | $5 | $30 |
-| `openai/gpt-5.6-terra` | OpenAI: GPT-5.6 Terra | 1M | text, image | — | $2 | $12 |
-| `qwen/qwen3.5-122b-a10b` | Qwen: Qwen3.5 122B-A10B | 256K | text, image | ✅ | $0.26 | $2.08 |
-| `qwen/qwen3.5-27b` | Qwen: Qwen3.5 27B | 256K | text, image | ✅ | $0.25 | $2 |
-| `qwen/qwen3.6-27b` | Qwen: Qwen3.6 27B | 256K | text, image | ✅ | $0.3 | $3.2 |
-| `qwen/qwen3.6-35b-a3b` | Qwen: Qwen3.6 35B-A3B | 256K | text, image | ✅ | $0.248 | $1.485 |
-| `qwen/qwen3.6-flash` | Qwen: Qwen3.6 Flash | 1M | text, image | — | $0.1875 | $1.125 |
-| `qwen/qwen3.7-max` | Qwen: Qwen3.7 Max | 1M | text | — | $2.5 | $7.5 |
-| `qwen/qwen3.7-plus` | Qwen: Qwen3.7 Plus | 1M | text, image | — | $0.4 | $1.6 |
-| `qwen/qwen3.8-max` | Qwen: Qwen3.8 Max | 1M | text, image, video | — | $2 | $6 |
-| `stepfun/step-3.5-flash` | StepFun: Step 3.5 Flash | 256K | text | ✅ | $0.1 | $0.3 |
-| `stepfun/step-3.7-flash` | StepFun: Step 3.7 Flash | 256K | text, image | ✅ | $0.185 | $1.11 |
-| `tencent/hy3` | Hunyuan 3 | 256K | text | ✅ | $0.066 | $0.26 |
-| `x-ai/grok-4.20` | xAI: Grok 4.20 | 128K | text, image | — | $1.25 | $2.5 |
-| `x-ai/grok-4.20-multi-agent` | xAI: Grok 4.20 Multi-Agent | 1M | text, image | — | $1.25 | $2.5 |
-| `x-ai/grok-4.3` | xAI: Grok 4.3 | 1M | text, image | — | $1.25 | $2.5 |
-| `x-ai/grok-4.5` | xAI: Grok 4.5 | 500K | text, image | — | $2 | $6 |
-| `x-ai/grok-build-0.1` | xAI: Grok Build 0.1 | 256K | text | — | $1 | $2 |
-| `xiaomi/mimo-v2.5` | Xiaomi: MiMo V2.5 | 256K | text | ✅ | $0.14 | $0.28 |
-| `xiaomi/mimo-v2.5-pro` | Xiaomi: MiMo V2.5 Pro | 256K | text | ✅ | $0.435 | $0.87 |
-| `z-ai/glm-4.7` | Zhipu: GLM-4.7 | 200K | text | ✅ | $0.6 | $2.2 |
-| `z-ai/glm-5` | Zhipu: GLM-5 | 198K | text | ✅ | $0.6 | $1.92 |
-| `z-ai/glm-5.1` | Zhipu: GLM-5.1 | 128K | text | ✅ | $0.98 | $3.08 |
-| `z-ai/glm-5.2` | Zhipu: GLM-5.2 | 1M | text | ✅ | $0.979 | $3.08 |
+| `anthropic/claude-fable-5` | 1M | text, image | — | $10 | $1 | $50 |
+| `anthropic/claude-haiku-4.5` | 200K | text, image | — | $1 | $0.1 | $5 |
+| `anthropic/claude-opus-4.6` | 200K | text, image | — | $5 | $0.5 | $25 |
+| `anthropic/claude-opus-4.7` | 200K | text, image | — | $4.5 | $0.45 | $22.5 |
+| `anthropic/claude-opus-4.8` | 1M | text, image | — | $5 | $0.5 | $25 |
+| `anthropic/claude-opus-5` | 1M | text, image | — | $5 | $0.5 | $25 |
+| `anthropic/claude-sonnet-4.6` | 1M | text, image | — | $3 | $0.3 | $15 |
+| `anthropic/claude-sonnet-5` | 1M | text, image | — | $2 | $0.2 | $10 |
+| `deepseek/deepseek-v3.2` | 128K | text | ✅ | $0.252 | $0.0252 | $0.378 |
+| `deepseek/deepseek-v4-flash` | 256K | text | ✅ | $0.112 | $0.022 | $0.224 |
+| `deepseek/deepseek-v4-flash-0731` | 1M | text | ✅ | $0.14 | $0.028 | $0.28 |
+| `deepseek/deepseek-v4-pro` | 256K | text | ✅ | $0.435 | $0.003625 | $0.87 |
+| `google/gemini-3.1-flash-lite-preview` | 1M | text, image | — | $0.25 | $0.025 | $1.5 |
+| `google/gemini-3.1-pro-preview` | 2M | text, image | — | $2 | $0.2 | $12 |
+| `google/gemini-3.5-flash` | 1M | text, image, audio | — | $1.5 | $0.15 | $9 |
+| `google/gemma-4-31b` | 128K | text, image | ✅ | $0.13 | — | $0.4 |
+| `meituan/longcat-2.0` | 1M | text | ✅ | $0.75 | — | $2.95 |
+| `minimax/minimax-m2.5` | 192K | text | ✅ | $0.15 | $0.075 | $1.2 |
+| `minimax/minimax-m2.7` | 192K | text | ✅ | $0.3 | $0.06 | $1.2 |
+| `minimax/minimax-m3` | 1M | text, image | ✅ | $0.3 | $0.06 | $1.2 |
+| `moonshotai/kimi-k2.5` | 256K | text, image | ✅ | $0.44 | $0.22 | $2 |
+| `moonshotai/kimi-k2.6` | 256K | text | ✅ | $0.66 | $0.33 | $3.5 |
+| `moonshotai/kimi-k2.7-code` | 256K | text, image | ✅ | $0.73 | $0.15 | $3.5 |
+| `moonshotai/kimi-k3` | 1M | text, image | ✅ | $3 | $0.3 | $15 |
+| `openai/gpt-5.4` | 128K | text, image | — | $2.5 | $0.25 | $15 |
+| `openai/gpt-5.4-mini` | 128K | text, image | — | $0.75 | $0.075 | $4.5 |
+| `openai/gpt-5.5` | 128K | text, image | — | $5 | $0.5 | $30 |
+| `openai/gpt-5.6-luna` | 400K | text, image | — | $0.2 | $0.02 | $1.2 |
+| `openai/gpt-5.6-sol` | 1M | text, image | — | $5 | $0.5 | $30 |
+| `openai/gpt-5.6-terra` | 1M | text, image | — | $2 | $0.2 | $12 |
+| `qwen/qwen3.5-122b-a10b` | 256K | text, image | ✅ | $0.26 | — | $2.08 |
+| `qwen/qwen3.5-27b` | 256K | text, image | ✅ | $0.25 | — | $2 |
+| `qwen/qwen3.6-27b` | 256K | text, image | ✅ | $0.3 | — | $3.2 |
+| `qwen/qwen3.6-35b-a3b` | 256K | text, image | ✅ | $0.248 | — | $1.485 |
+| `qwen/qwen3.6-flash` | 1M | text, image | — | $0.1875 | — | $1.125 |
+| `qwen/qwen3.7-max` | 1M | text | — | $2.5 | $0.5 | $7.5 |
+| `qwen/qwen3.7-plus` | 1M | text, image | — | $0.4 | $0.08 | $1.6 |
+| `qwen/qwen3.8-max` | 1M | text, image, video | — | $2 | $0.25 | $6 |
+| `stepfun/step-3.5-flash` | 256K | text | ✅ | $0.1 | $0.02 | $0.3 |
+| `stepfun/step-3.7-flash` | 256K | text, image | ✅ | $0.185 | $0.037 | $1.11 |
+| `tencent/hy3` | 256K | text | ✅ | $0.066 | $0.0261 | $0.26 |
+| `x-ai/grok-4.20` | 128K | text, image | — | $1.25 | $0.2 | $2.5 |
+| `x-ai/grok-4.20-multi-agent` | 1M | text, image | — | $1.25 | $0.2 | $2.5 |
+| `x-ai/grok-4.3` | 1M | text, image | — | $1.25 | $0.2 | $2.5 |
+| `x-ai/grok-4.5` | 500K | text, image | — | $2 | $0.3 | $6 |
+| `x-ai/grok-build-0.1` | 256K | text | — | $1 | $0.2 | $2 |
+| `xiaomi/mimo-v2.5` | 256K | text | ✅ | $0.14 | $0.0028 | $0.28 |
+| `xiaomi/mimo-v2.5-pro` | 256K | text | ✅ | $0.435 | $0.0036 | $0.87 |
+| `z-ai/glm-4.7` | 200K | text | ✅ | $0.6 | $0.11 | $2.2 |
+| `z-ai/glm-5` | 198K | text | ✅ | $0.6 | $0.12 | $1.92 |
+| `z-ai/glm-5.1` | 128K | text | ✅ | $0.98 | $0.49 | $3.08 |
+| `z-ai/glm-5.2` | 1M | text | ✅ | $0.979 | $0.182 | $3.08 |
 
-## Using BitRouter Cloud
+Prices are USD per **million tokens** — what a hosted [BitRouter](/docs/overview/quickstart) request costs today, from the cheapest provider actually serving that model (`—` means no per-token provider is currently serving it; cached input is `—` where the model prices no cache tier). **Modalities** are the inputs a model accepts; every model returns text. A provider listed in the public, open-source [registry](https://github.com/bitrouter/bitrouter/tree/main/registry) but not currently reachable isn't priced here, so bringing your own key to one of them can beat these rates — and anyone can [register a provider](/docs/guides/register-as-a-provider).
 
-The **BitRouter Cloud provider** lets an agent call any model above with a single BitRouter account — no upstream provider keys, no per-provider signups. You pay BitRouter directly at the prices listed here, billed per request; failed requests aren't billed.
+## How model ids work
+
+On BitRouter a "model" is not a single endpoint. It's an **aggregate**: one logical model — say `openai/gpt-4o` or `anthropic/claude-sonnet-4.6` — that can be served by many providers at once. You address it by the stable **model id** in the catalog above, and BitRouter decides which underlying provider endpoint actually answers each request. That indirection is the point: you write your agent against `anthropic/claude-sonnet-4.6`, and the set of providers behind it can grow, shrink, or re-price without you changing a line of code.
+
+Because a model is an aggregate, requesting one kicks off a [provider selection](/docs/models-and-routing/provider-selection) step — BitRouter ranks the eligible providers on a blend of cost, latency, throughput, and uptime, and sends your request to the best one. A transient failure falls through to the next-ranked provider, or to the next model you listed via [fallback](/docs/models-and-routing/model-fallback). Append a [variant](/docs/models-and-routing/model-variants) suffix — `:cost`, `:latency`, `:throughput` — to re-rank the eligible providers along one axis for a single request; a bare id is the balanced default.
+
+## Calling these models
+
+Every model above is reachable on hosted **BitRouter** — one account against `api.bitrouter.ai`, no upstream provider keys, no per-provider signups. You pay BitRouter directly at the prices listed here, billed per request; failed requests aren't billed.
 
 ```bash
 bitrouter cloud login   # one-time device-flow sign-in

--- a/scripts/generate-models.mjs
+++ b/scripts/generate-models.mjs
@@ -52,6 +52,10 @@ function normalize(model, registryOpenWeights) {
     capabilities: model.capabilities ?? [],
     providers: model.providers?.total_online ?? 0,
     inputUsdPerM: inUsd,
+    // Cached-input reads are a separate line on every bill and the price an
+    // agent loop actually pays on turn two onward, so the catalog carries it
+    // beside the uncached rate. Null where the model prices no cache tier.
+    cacheReadUsdPerM: p?.input_tokens?.cache_read ?? null,
     outputUsdPerM: outUsd,
     openWeights:
       typeof model.open_weights === "boolean"

--- a/scripts/generate-supported-tables.mjs
+++ b/scripts/generate-supported-tables.mjs
@@ -55,14 +55,17 @@ function table(header, rows) {
   ].join("\n");
 }
 
+// The display name restates the id ("anthropic/claude-opus-5" → "Anthropic:
+// Claude Opus 5"), so the table quotes only the id — the string you actually
+// paste into a request — and spends the width on pricing instead.
 function modelRows() {
   return MODELS.map((m) => [
     `\`${m.id}\``,
-    m.name,
     formatContext(m.maxInputTokens),
     (m.inputModalities ?? []).join(", ") || "text",
     m.openWeights === true ? "✅" : "—",
     formatUsd(m.inputUsdPerM),
+    formatUsd(m.cacheReadUsdPerM),
     formatUsd(m.outputUsdPerM),
   ]);
 }
@@ -70,7 +73,15 @@ function modelRows() {
 const TARGETS = [
   {
     file: "content/docs/(guide)/overview/supported-models.mdx",
-    header: ["Model", "Name", "Context", "Modalities", "Open weights", "Input $/M", "Output $/M"],
+    header: [
+      "Model",
+      "Context",
+      "Modalities",
+      "Open weights",
+      "Input $/M",
+      "Cached input $/M",
+      "Output $/M",
+    ],
     rows: modelRows,
   },
 ];


### PR DESCRIPTION
Reworks `/docs/overview/supported-models` around two things: complete per-token pricing, and prose that says what the page is actually for.

## Pricing + modality

The table quoted only uncached input and output. After the first turn of an agent loop most of the prompt is a cache read, and that rate is a separate line on every bill — so the catalog now carries it.

- `generate-models.mjs` reads `pricing.input_tokens.cache_read` from `/v1/models` into `cacheReadUsdPerM`.
- `generate-supported-tables.mjs` renders it as **Cached input $/M** between Input and Output. 45 of 52 models price a cache tier; the rest render `—`.
- **Name** column dropped — it restated the id (`anthropic/claude-opus-5` → "Anthropic: Claude Opus 5") while pushing the table past the content column at 1440px. Modalities were already a column.

`.models-snapshot.json` was regenerated: the only change is the new field, no price or model churn.

## Prose

Above the table is now exactly two paragraphs — this is the curated SOTA set hosted BitRouter routes to natively for agentic and coding work, and you are never limited to it (links to bring your own model / bring your own provider).

Everything else moved below the catalog:

- The pricing-units footnote, trimmed and now covering the `—` in the cached column.
- **How model ids work**, unchanged. The `#how-model-ids-work` anchor is preserved — `what-is-bitrouter.mdx` deep-links to it.
- **Four protocols in** is deleted. The quickstart covers it (in a separate unmerged PR) and the API Reference tab is already split by those four protocols.
- **Using BitRouter Cloud** → **Calling these models**, reframed for BitRouter Cloud now being just BitRouter rather than an optional provider bolted onto the OSS core. The CLI snippet keeps `bitrouter cloud login`, which is still the real command.

## Verification

- `pnpm lint:docs` passes.
- `node scripts/generate-supported-tables.mjs --check` is clean, so the CI drift gate holds.
- Rendered locally: 7 columns fit the content column at 1440px, headings and the `#how-model-ids-work` anchor resolve, no new console errors.

## Note for review

The rest of the docs still treat "BitRouter Cloud" as a separate product — `quickstart.mdx` frames the whole page as "self-host or Cloud" with a Cloud-vs-OSS capability matrix. This page now reads differently from those. Worth a follow-up sweep once the naming is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)