### PR TITLE
WIP: agent playground with a model × harness picker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,44 @@
 # BETTER_AUTH_TRUSTED_ORIGINS + set BETTER_AUTH_COOKIE_DOMAIN).
 NEXT_PUBLIC_WEB_URL=https://bitrouter.ai
 NEXT_PUBLIC_CONSOLE_URL=https://cloud.bitrouter.ai
+
+# Router credentials for the /chat agent playground, which spends this one
+# shared key on behalf of anonymous visitors.
+BITROUTER_API_BASE=https://api.bitrouter.ai/v1
+BITROUTER_API_KEY=
+
+# Set to 1 to offer the Pi harness in the /chat harness picker.
+#
+# Leave it unset in production until there is auth and per-user billing in
+# front of it: unlike the default AI SDK loop, Pi holds a live agent session on
+# the server for every visitor and gives the model a shell and filesystem.
+# Requires Node 22+ and a single long-lived server process — harness sessions
+# are process-local and do not survive a redeploy or a second replica.
+#
+# Unset, Pi still appears in the picker but is greyed out with the reason, so
+# the harness axis is visible either way.
+ENABLE_PI_HARNESS=
+
+# Sandbox credentials for the BitRouter ACP harnesses (`BitRouter · Claude
+# Code`, `· Codex`, `· Gemini CLI`, `· Pi`).
+#
+# Those run BitRouter's own agent catalog over ACP, which needs a sandbox that
+# can expose a port: the ACP bridge runs inside the sandbox and is dialled back
+# over a WebSocket. `@ai-sdk/sandbox-just-bash` (what Pi uses) exposes no ports,
+# so these need a real VM — today `@ai-sdk/sandbox-vercel`, later Railway.
+#
+# Cost warning: this is one VM per chat session, currently on an unauthenticated
+# page. Leave unset until auth and per-user billing are in front of it. Unset,
+# the four entries still appear in the picker, greyed out with the reason.
+#
+# Deployment path — set all three. Note `@vercel/sandbox` does NOT read these
+# itself; `lib/harness-sandbox.server.ts` threads them through explicitly.
+VERCEL_TOKEN=
+VERCEL_PROJECT_ID=
+VERCEL_TEAM_ID=
+#
+# Local path — leave the trio empty and authenticate over OIDC instead:
+#   npx vercel link        # writes .vercel/project.json (gitignored)
+#   npx vercel env pull    # writes VERCEL_OIDC_TOKEN into .env.local
+# The token is short-lived; re-run `env pull` when provisioning starts failing
+# with LocalOidcContextError.

--- a/.env.example
+++ b/.env.example
@@ -5,16 +5,36 @@
 NEXT_PUBLIC_WEB_URL=https://bitrouter.ai
 NEXT_PUBLIC_CONSOLE_URL=https://cloud.bitrouter.ai
 
-# Router credentials for the /chat agent playground, which spends this one
-# shared key on behalf of anonymous visitors.
+# Where the /chat agent playground gets its spend authority.
+#
+#   byo-key  (default) — BITROUTER_API_KEY below, spent on behalf of anonymous
+#                        visitors with nothing capping it. What a fork, a local
+#                        checkout, or a self-hoster gets.
+#   session            — the visitor is signed in to the console on the sibling
+#                        subdomain, and this site forwards their session cookie
+#                        to NEXT_PUBLIC_CONSOLE_URL/api/playground/token to mint
+#                        a short-lived credential scoped to them. Their turns are
+#                        attributed and capped against their own grant, and
+#                        BITROUTER_API_KEY is not used for the playground at all.
+#
+# Session mode additionally needs NEXT_PUBLIC_WEB_URL above (sent as the Origin
+# on that server-to-server mint, so it must be on the console's
+# BETTER_AUTH_TRUSTED_ORIGINS).
+PLAYGROUND_CREDENTIAL_MODE=byo-key
+
+# The router endpoint. Required in both modes.
 BITROUTER_API_BASE=https://api.bitrouter.ai/v1
+# The house key. Required in byo-key mode. In session mode it is still used for
+# the docs "Ask AI" search, which is site functionality rather than a visitor's
+# billable turn — leave it set if you want that to work.
 BITROUTER_API_KEY=
 
 # Set to 1 to offer the Pi harness in the /chat harness picker.
 #
-# Leave it unset in production until there is auth and per-user billing in
-# front of it: unlike the default AI SDK loop, Pi holds a live agent session on
-# the server for every visitor and gives the model a shell and filesystem.
+# In byo-key mode leave it unset in production: unlike the default AI SDK loop,
+# Pi holds a live agent session on the server for every visitor and gives the
+# model a shell and filesystem, with nothing capping the shared key. Session
+# mode is what makes it safe to switch on.
 # Requires Node 22+ and a single long-lived server process — harness sessions
 # are process-local and do not survive a redeploy or a second replica.
 #
@@ -30,9 +50,10 @@ ENABLE_PI_HARNESS=
 # over a WebSocket. `@ai-sdk/sandbox-just-bash` (what Pi uses) exposes no ports,
 # so these need a real VM — today `@ai-sdk/sandbox-vercel`, later Railway.
 #
-# Cost warning: this is one VM per chat session, currently on an unauthenticated
-# page. Leave unset until auth and per-user billing are in front of it. Unset,
-# the four entries still appear in the picker, greyed out with the reason.
+# Cost warning: this is one VM per chat session. In byo-key mode that is an
+# uncapped cost on an unauthenticated page — leave unset there. Session mode
+# puts a signed-in visitor's own grant behind each one. Unset, the four entries
+# still appear in the picker, greyed out with the reason.
 #
 # Deployment path — set all three. Note `@vercel/sandbox` does NOT read these
 # itself; `lib/harness-sandbox.server.ts` threads them through explicitly.

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ next-env.d.ts
 # owns them here; content/docs/reference/ operation pages are regenerated at build
 # by scripts/generate-openapi.mjs.
 .claude/launch.json
+
+# Vercel project link (written by `vercel link`; used by @vercel/sandbox
+# to resolve the team/project it provisions sandboxes into).
+.vercel

--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -3,6 +3,7 @@ import "@/components/landing/zed/zed.css";
 import "@/components/chat/chat.css";
 import { ChatShell } from "@/components/chat/playground";
 import { getHarnessAvailability } from "@/lib/harnesses.server";
+import { credentialMode } from "@/lib/playground-credential";
 
 export const metadata: Metadata = {
   title: "Agent playground — BitRouter",
@@ -18,5 +19,13 @@ export const metadata: Metadata = {
 export const dynamic = "force-dynamic";
 
 export default function ChatPage() {
-  return <ChatShell harnesses={getHarnessAvailability()} />;
+  return (
+    <ChatShell
+      harnesses={getHarnessAvailability()}
+      // Whether this deployment bills a signed-in visitor. Only the mode
+      // crosses to the client — who the visitor *is* is read there from the
+      // shared console session, and settled for real by the route handler.
+      requiresAuth={credentialMode() === "session"}
+    />
+  );
 }

--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import "@/components/landing/zed/zed.css";
+import "@/components/chat/chat.css";
+import { ChatShell } from "@/components/chat/playground";
+import { getHarnessAvailability } from "@/lib/harnesses.server";
+
+export const metadata: Metadata = {
+  title: "Agent playground — BitRouter",
+  description:
+    "Run any agent harness on any model — the AI SDK's own loop, Pi, Claude Code and more — through a single BitRouter endpoint.",
+};
+
+/**
+ * Availability is deployment config, not build config. Without this the page
+ * prerenders and bakes in whichever harnesses were switched on at build time,
+ * so flipping `ENABLE_PI_HARNESS` on Railway would need a rebuild to show up.
+ */
+export const dynamic = "force-dynamic";
+
+export default function ChatPage() {
+  return <ChatShell harnesses={getHarnessAvailability()} />;
+}

--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -1,0 +1,22 @@
+import { HomeLayout } from "fumadocs-ui/layouts/home";
+import { SiteProviders } from "@/components/site-providers";
+import { baseOptions } from "@/lib/layout.shared";
+
+/**
+ * Same shell as the `(home)` group, deliberately without `SiteZedFooter`.
+ *
+ * `/chat` is a full-viewport app surface — the composer is pinned to the
+ * bottom of the viewport, so a marketing footer underneath it would hang
+ * below the fold and turn the page into a scrolling document.
+ */
+export default function ChatGroupLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <SiteProviders>
+      <HomeLayout {...baseOptions()}>{children}</HomeLayout>
+    </SiteProviders>
+  );
+}

--- a/app/api/chat/playground/route.ts
+++ b/app/api/chat/playground/route.ts
@@ -8,7 +8,7 @@ import {
   type UIMessage,
 } from "ai";
 
-import { bitrouter } from "@/lib/bitrouter-provider";
+import { createBitrouterProvider } from "@/lib/bitrouter-provider";
 import {
   AGENT_INSTRUCTIONS,
   AGENT_MAX_STEPS,
@@ -22,6 +22,11 @@ import {
 } from "@/lib/chat-models";
 import { DEFAULT_HARNESS, type HarnessId, isHarnessId } from "@/lib/harnesses";
 import { isHarnessAvailable } from "@/lib/harnesses.server";
+import {
+  CredentialError,
+  type PlaygroundCredential,
+  resolveCredential,
+} from "@/lib/playground-credential";
 import { getPostHogClient } from "@/lib/posthog-server";
 
 /**
@@ -63,11 +68,30 @@ export async function POST(req: Request) {
   }
 
   // Never forward a client-supplied model id straight to the router — this
-  // endpoint spends the site's shared key.
+  // endpoint spends a real credential.
   const modelId = isAllowedChatModel(model) ? model : DEFAULT_CHAT_MODEL;
 
+  // Who is paying. In session mode this is the authoritative gate: the UI's
+  // sign-in prompt is advisory, and a hand-rolled request that skips it gets a
+  // 401 here rather than spending the house key.
+  //
+  // A session-backed harness holds its credential for the life of the session,
+  // so it asks for the revocable kind.
+  let credential: PlaygroundCredential;
+  try {
+    credential = await resolveCredential(
+      req,
+      harnessId === "ai-sdk" ? "chat" : "harness",
+    );
+  } catch (err) {
+    if (err instanceof CredentialError) {
+      return Response.json({ error: err.message }, { status: err.status });
+    }
+    throw err;
+  }
+
   if (harnessId === "ai-sdk") {
-    return streamAiSdkLoop({ messages, modelId, distinctId });
+    return streamAiSdkLoop({ messages, modelId, distinctId, credential });
   }
 
   // Imported lazily: the packaged harnesses pull in a large dependency tree,
@@ -79,6 +103,7 @@ export async function POST(req: Request) {
     harnessId,
     sessionId,
     distinctId,
+    credential,
     abortSignal: req.signal,
   });
 }
@@ -90,12 +115,15 @@ async function streamAiSdkLoop({
   messages,
   modelId,
   distinctId,
+  credential,
 }: {
   messages: UIMessage[];
   modelId: string;
   distinctId: string;
+  credential: PlaygroundCredential;
 }) {
   let steps = 0;
+  const bitrouter = createBitrouterProvider(credential);
 
   const result = streamText({
     model: bitrouter(AGENT_STEP_MODEL),

--- a/app/api/chat/playground/route.ts
+++ b/app/api/chat/playground/route.ts
@@ -1,0 +1,148 @@
+import {
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  stepCountIs,
+  streamText,
+  type ToolSet,
+  toUIMessageStream,
+  type UIMessage,
+} from "ai";
+
+import { bitrouter } from "@/lib/bitrouter-provider";
+import {
+  AGENT_INSTRUCTIONS,
+  AGENT_MAX_STEPS,
+  AGENT_STEP_MODEL,
+  agentTools,
+} from "@/lib/chat-agent";
+import {
+  type ChatUIMessage,
+  DEFAULT_CHAT_MODEL,
+  isAllowedChatModel,
+} from "@/lib/chat-models";
+import { DEFAULT_HARNESS, type HarnessId, isHarnessId } from "@/lib/harnesses";
+import { isHarnessAvailable } from "@/lib/harnesses.server";
+import { getPostHogClient } from "@/lib/posthog-server";
+
+/**
+ * The playground's only backend.
+ *
+ * Both axes are chosen per request: `model` picks what BitRouter routes to,
+ * `harness` picks what drives the agent loop. The harnesses differ in how they
+ * hold history, so the dispatch below is a real fork rather than a config
+ * switch — the stateless loop is handed the whole transcript, while a
+ * session-backed runtime is handed only the newest turn.
+ */
+
+// The ceiling for the slowest harness. A sandbox-backed turn can spend a long
+// time in tool calls before it produces any text.
+export const maxDuration = 300;
+
+type Body = {
+  messages: UIMessage[];
+  model?: string;
+  harness?: string;
+  sessionId?: string;
+};
+
+export async function POST(req: Request) {
+  const distinctId = req.headers.get("X-POSTHOG-DISTINCT-ID") ?? "anonymous";
+
+  const { messages, model, harness, sessionId }: Body = await req.json();
+
+  const harnessId: HarnessId = isHarnessId(harness) ? harness : DEFAULT_HARNESS;
+
+  // A client asking for a harness this deployment cannot run is a bug or a
+  // hand-rolled request, not something to silently downgrade — falling back to
+  // another harness would answer as something the caller did not ask for.
+  if (!isHarnessAvailable(harnessId)) {
+    return Response.json(
+      { error: `The ${harnessId} harness is not available here.` },
+      { status: 400 },
+    );
+  }
+
+  // Never forward a client-supplied model id straight to the router — this
+  // endpoint spends the site's shared key.
+  const modelId = isAllowedChatModel(model) ? model : DEFAULT_CHAT_MODEL;
+
+  if (harnessId === "ai-sdk") {
+    return streamAiSdkLoop({ messages, modelId, distinctId });
+  }
+
+  // Imported lazily: the packaged harnesses pull in a large dependency tree,
+  // and the stateless path must not pay to evaluate it.
+  const { streamHarnessTurn } = await import("@/lib/harness-stream");
+  return streamHarnessTurn({
+    messages,
+    modelId,
+    harnessId,
+    sessionId,
+    distinctId,
+    abortSignal: req.signal,
+  });
+}
+
+/**
+ * The AI SDK's own loop: `streamText` with the docs tools, no server session.
+ */
+async function streamAiSdkLoop({
+  messages,
+  modelId,
+  distinctId,
+}: {
+  messages: UIMessage[];
+  modelId: string;
+  distinctId: string;
+}) {
+  let steps = 0;
+
+  const result = streamText({
+    model: bitrouter(AGENT_STEP_MODEL),
+    instructions: AGENT_INSTRUCTIONS,
+    messages: await convertToModelMessages(messages),
+    tools: agentTools,
+    // The loop already ends on its own when the model answers without calling
+    // a tool; this only bounds the runaway case.
+    stopWhen: stepCountIs(AGENT_MAX_STEPS),
+    // The routing demo, and the reason an agent is interesting on a router:
+    // step 0 is a mechanical "which tool do I call for this question?", which
+    // the cheap model handles fine. From step 1 the agent is reasoning over
+    // real content and likely writing the answer, so it runs on the model the
+    // user picked. On the final allowed step tools are withdrawn, forcing an
+    // answer instead of another search.
+    prepareStep: ({ stepNumber }) => {
+      steps = stepNumber + 1;
+
+      if (stepNumber >= AGENT_MAX_STEPS - 1) {
+        return { model: bitrouter(modelId), activeTools: [] };
+      }
+      if (stepNumber === 0) return {};
+      return { model: bitrouter(modelId) };
+    },
+    onEnd({ usage }) {
+      getPostHogClient().capture({
+        distinctId,
+        event: "chat_playground_completion",
+        properties: {
+          model: modelId,
+          harness: "ai-sdk",
+          steps,
+          input_tokens: usage?.inputTokens,
+          output_tokens: usage?.outputTokens,
+        },
+      });
+    },
+  });
+
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream<ToolSet, ChatUIMessage>({
+      stream: result.stream,
+      tools: agentTools,
+      messageMetadata: ({ part }) =>
+        part.type === "finish"
+          ? { model: modelId, harness: "ai-sdk", usage: part.totalUsage }
+          : undefined,
+    }),
+  });
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,24 +1,22 @@
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import {
   convertToModelMessages,
+  createUIMessageStreamResponse,
   stepCountIs,
   streamText,
   tool,
+  toUIMessageStream,
   type UIMessage,
 } from "ai";
 import { z } from "zod";
 import { searchServer } from "@/lib/search-server";
 import { getPostHogClient } from "@/lib/posthog-server";
+import { bitrouter } from "@/lib/bitrouter-provider";
 
 export const maxDuration = 30;
 
-const bitrouter = createOpenAICompatible({
-  name: "bitrouter",
-  baseURL: process.env.BITROUTER_API_BASE!,
-  apiKey: process.env.BITROUTER_API_KEY,
-});
+const DOCS_MODEL = "deepseek/deepseek-v4-pro";
 
-const SYSTEM_PROMPT = `You are a helpful assistant for BitRouter documentation.
+const INSTRUCTIONS =`You are a helpful assistant for BitRouter documentation.
 Always use the \`search\` tool to find relevant documentation before answering.
 Base your answer only on the search results and cite the pages you used.
 Be concise and accurate. If the search returns nothing relevant, say you don't know.`;
@@ -29,38 +27,42 @@ export async function POST(req: Request) {
 
   let searchCalls = 0;
 
+  const tools = {
+    search: tool({
+      description:
+        "Search the BitRouter documentation. Returns relevant sections, each with its page title and URL.",
+      inputSchema: z.object({
+        query: z.string().describe("The search query"),
+      }),
+      async execute({ query }) {
+        searchCalls++;
+        const results = await searchServer.search(query);
+        return results.slice(0, 8).map((r) => ({
+          url: r.url,
+          title: r.breadcrumbs?.length ? r.breadcrumbs.join(" › ") : r.content,
+          content: r.content,
+        }));
+      },
+    }),
+  };
+
   const result = streamText({
-    model: bitrouter("deepseek/deepseek-v4-pro"),
-    system: SYSTEM_PROMPT,
+    model: bitrouter(DOCS_MODEL),
+    instructions: INSTRUCTIONS,
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(4),
-    tools: {
-      search: tool({
-        description:
-          "Search the BitRouter documentation. Returns relevant sections, each with its page title and URL.",
-        inputSchema: z.object({
-          query: z.string().describe("The search query"),
-        }),
-        async execute({ query }) {
-          searchCalls++;
-          const results = await searchServer.search(query);
-          return results.slice(0, 8).map((r) => ({
-            url: r.url,
-            title: r.breadcrumbs?.length ? r.breadcrumbs.join(" › ") : r.content,
-            content: r.content,
-          }));
-        },
-      }),
-    },
-    onFinish() {
+    tools,
+    onEnd() {
       const posthog = getPostHogClient();
       posthog.capture({
         distinctId,
         event: "ai_chat_completion",
-        properties: { model: "deepseek/deepseek-v4-pro", search_calls: searchCalls },
+        properties: { model: DOCS_MODEL, search_calls: searchCalls },
       });
     },
   });
 
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream, tools }),
+  });
 }

--- a/components/ai-elements/code-block.tsx
+++ b/components/ai-elements/code-block.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import {
+  type ComponentProps,
+  createContext,
+  type HTMLAttributes,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { type BundledLanguage, codeToHtml, type ShikiTransformer } from "shiki";
+
+type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
+  code: string;
+  language: BundledLanguage;
+  showLineNumbers?: boolean;
+};
+
+type CodeBlockContextType = {
+  code: string;
+};
+
+const CodeBlockContext = createContext<CodeBlockContextType>({
+  code: "",
+});
+
+const lineNumberTransformer: ShikiTransformer = {
+  name: "line-numbers",
+  line(node, line) {
+    node.children.unshift({
+      type: "element",
+      tagName: "span",
+      properties: {
+        className: [
+          "inline-block",
+          "min-w-10",
+          "mr-4",
+          "text-right",
+          "select-none",
+          "text-muted-foreground",
+        ],
+      },
+      children: [{ type: "text", value: String(line) }],
+    });
+  },
+};
+
+export async function highlightCode(
+  code: string,
+  language: BundledLanguage,
+  showLineNumbers = false
+) {
+  const transformers: ShikiTransformer[] = showLineNumbers
+    ? [lineNumberTransformer]
+    : [];
+
+  return await Promise.all([
+    codeToHtml(code, {
+      lang: language,
+      theme: "one-light",
+      transformers,
+    }),
+    codeToHtml(code, {
+      lang: language,
+      theme: "one-dark-pro",
+      transformers,
+    }),
+  ]);
+}
+
+export const CodeBlock = ({
+  code,
+  language,
+  showLineNumbers = false,
+  className,
+  children,
+  ...props
+}: CodeBlockProps) => {
+  const [html, setHtml] = useState<string>("");
+  const [darkHtml, setDarkHtml] = useState<string>("");
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    highlightCode(code, language, showLineNumbers).then(([light, dark]) => {
+      if (!mounted.current) {
+        setHtml(light);
+        setDarkHtml(dark);
+        mounted.current = true;
+      }
+    });
+
+    return () => {
+      mounted.current = false;
+    };
+  }, [code, language, showLineNumbers]);
+
+  return (
+    <CodeBlockContext.Provider value={{ code }}>
+      <div
+        className={cn(
+          "group relative w-full overflow-hidden rounded-md border bg-background text-foreground",
+          className
+        )}
+        {...props}
+      >
+        <div className="relative">
+          <div
+            className="overflow-auto dark:hidden [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed."
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+          <div
+            className="hidden overflow-auto dark:block [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed."
+            dangerouslySetInnerHTML={{ __html: darkHtml }}
+          />
+          {children && (
+            <div className="absolute top-2 right-2 flex items-center gap-2">
+              {children}
+            </div>
+          )}
+        </div>
+      </div>
+    </CodeBlockContext.Provider>
+  );
+};
+
+export type CodeBlockCopyButtonProps = ComponentProps<typeof Button> & {
+  onCopy?: () => void;
+  onError?: (error: Error) => void;
+  timeout?: number;
+};
+
+export const CodeBlockCopyButton = ({
+  onCopy,
+  onError,
+  timeout = 2000,
+  children,
+  className,
+  ...props
+}: CodeBlockCopyButtonProps) => {
+  const [isCopied, setIsCopied] = useState(false);
+  const { code } = useContext(CodeBlockContext);
+
+  const copyToClipboard = async () => {
+    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
+      onError?.(new Error("Clipboard API not available"));
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(code);
+      setIsCopied(true);
+      onCopy?.();
+      setTimeout(() => setIsCopied(false), timeout);
+    } catch (error) {
+      onError?.(error as Error);
+    }
+  };
+
+  const Icon = isCopied ? CheckIcon : CopyIcon;
+
+  return (
+    <Button
+      className={cn("shrink-0", className)}
+      onClick={copyToClipboard}
+      size="icon"
+      variant="ghost"
+      {...props}
+    >
+      {children ?? <Icon size={14} />}
+    </Button>
+  );
+};

--- a/components/ai-elements/context.tsx
+++ b/components/ai-elements/context.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+import type { LanguageModelUsage } from "ai";
+import { type ComponentProps, createContext, useContext } from "react";
+import { estimateCostUsd } from "@/lib/chat-models";
+
+const PERCENT_MAX = 100;
+const ICON_RADIUS = 10;
+const ICON_VIEWBOX = 24;
+const ICON_CENTER = 12;
+const ICON_STROKE_WIDTH = 2;
+
+type ModelId = string;
+
+type ContextSchema = {
+  usedTokens: number;
+  maxTokens: number;
+  usage?: LanguageModelUsage;
+  modelId?: ModelId;
+};
+
+const ContextContext = createContext<ContextSchema | null>(null);
+
+const useContextValue = () => {
+  const context = useContext(ContextContext);
+
+  if (!context) {
+    throw new Error("Context components must be used within Context");
+  }
+
+  return context;
+};
+
+export type ContextProps = ComponentProps<typeof HoverCard> & ContextSchema;
+
+export const Context = ({
+  usedTokens,
+  maxTokens,
+  usage,
+  modelId,
+  ...props
+}: ContextProps) => (
+  <ContextContext.Provider
+    value={{
+      usedTokens,
+      maxTokens,
+      usage,
+      modelId,
+    }}
+  >
+    <HoverCard closeDelay={0} openDelay={0} {...props} />
+  </ContextContext.Provider>
+);
+
+const ContextIcon = () => {
+  const { usedTokens, maxTokens } = useContextValue();
+  const circumference = 2 * Math.PI * ICON_RADIUS;
+  const usedPercent = usedTokens / maxTokens;
+  const dashOffset = circumference * (1 - usedPercent);
+
+  return (
+    <svg
+      aria-label="Model context usage"
+      height="20"
+      role="img"
+      style={{ color: "currentcolor" }}
+      viewBox={`0 0 ${ICON_VIEWBOX} ${ICON_VIEWBOX}`}
+      width="20"
+    >
+      <circle
+        cx={ICON_CENTER}
+        cy={ICON_CENTER}
+        fill="none"
+        opacity="0.25"
+        r={ICON_RADIUS}
+        stroke="currentColor"
+        strokeWidth={ICON_STROKE_WIDTH}
+      />
+      <circle
+        cx={ICON_CENTER}
+        cy={ICON_CENTER}
+        fill="none"
+        opacity="0.7"
+        r={ICON_RADIUS}
+        stroke="currentColor"
+        strokeDasharray={`${circumference} ${circumference}`}
+        strokeDashoffset={dashOffset}
+        strokeLinecap="round"
+        strokeWidth={ICON_STROKE_WIDTH}
+        style={{ transformOrigin: "center", transform: "rotate(-90deg)" }}
+      />
+    </svg>
+  );
+};
+
+export type ContextTriggerProps = ComponentProps<typeof Button>;
+
+export const ContextTrigger = ({ children, ...props }: ContextTriggerProps) => {
+  const { usedTokens, maxTokens } = useContextValue();
+  const usedPercent = usedTokens / maxTokens;
+  const renderedPercent = new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 1,
+  }).format(usedPercent);
+
+  return (
+    <HoverCardTrigger asChild>
+      {children ?? (
+        <Button type="button" variant="ghost" {...props}>
+          <span className="font-medium text-muted-foreground">
+            {renderedPercent}
+          </span>
+          <ContextIcon />
+        </Button>
+      )}
+    </HoverCardTrigger>
+  );
+};
+
+export type ContextContentProps = ComponentProps<typeof HoverCardContent>;
+
+export const ContextContent = ({
+  className,
+  ...props
+}: ContextContentProps) => (
+  <HoverCardContent
+    className={cn("min-w-60 divide-y overflow-hidden p-0", className)}
+    {...props}
+  />
+);
+
+export type ContextContentHeaderProps = ComponentProps<"div">;
+
+export const ContextContentHeader = ({
+  children,
+  className,
+  ...props
+}: ContextContentHeaderProps) => {
+  const { usedTokens, maxTokens } = useContextValue();
+  const usedPercent = usedTokens / maxTokens;
+  const displayPct = new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 1,
+  }).format(usedPercent);
+  const used = new Intl.NumberFormat("en-US", {
+    notation: "compact",
+  }).format(usedTokens);
+  const total = new Intl.NumberFormat("en-US", {
+    notation: "compact",
+  }).format(maxTokens);
+
+  return (
+    <div className={cn("w-full space-y-2 p-3", className)} {...props}>
+      {children ?? (
+        <>
+          <div className="flex items-center justify-between gap-3 text-xs">
+            <p>{displayPct}</p>
+            <p className="font-mono text-muted-foreground">
+              {used} / {total}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Progress className="bg-muted" value={usedPercent * PERCENT_MAX} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export type ContextContentBodyProps = ComponentProps<"div">;
+
+export const ContextContentBody = ({
+  children,
+  className,
+  ...props
+}: ContextContentBodyProps) => (
+  <div className={cn("w-full p-3", className)} {...props}>
+    {children}
+  </div>
+);
+
+export type ContextContentFooterProps = ComponentProps<"div">;
+
+export const ContextContentFooter = ({
+  children,
+  className,
+  ...props
+}: ContextContentFooterProps) => {
+  const { modelId, usage } = useContextValue();
+  const costUSD = estimateCostUsd({
+    modelId,
+    inputTokens: usage?.inputTokens ?? 0,
+    outputTokens: usage?.outputTokens ?? 0,
+  });
+  const totalCost = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(costUSD ?? 0);
+
+  return (
+    <div
+      className={cn(
+        "flex w-full items-center justify-between gap-3 bg-secondary p-3 text-xs",
+        className
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <span className="text-muted-foreground">Total cost</span>
+          <span>{totalCost}</span>
+        </>
+      )}
+    </div>
+  );
+};
+
+export type ContextInputUsageProps = ComponentProps<"div">;
+
+export const ContextInputUsage = ({
+  className,
+  children,
+  ...props
+}: ContextInputUsageProps) => {
+  const { usage, modelId } = useContextValue();
+  const inputTokens = usage?.inputTokens ?? 0;
+
+  if (children) {
+    return children;
+  }
+
+  if (!inputTokens) {
+    return null;
+  }
+
+  const inputCost = estimateCostUsd({ modelId, inputTokens });
+  const inputCostText = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(inputCost ?? 0);
+
+  return (
+    <div
+      className={cn("flex items-center justify-between text-xs", className)}
+      {...props}
+    >
+      <span className="text-muted-foreground">Input</span>
+      <TokensWithCost costText={inputCostText} tokens={inputTokens} />
+    </div>
+  );
+};
+
+export type ContextOutputUsageProps = ComponentProps<"div">;
+
+export const ContextOutputUsage = ({
+  className,
+  children,
+  ...props
+}: ContextOutputUsageProps) => {
+  const { usage, modelId } = useContextValue();
+  const outputTokens = usage?.outputTokens ?? 0;
+
+  if (children) {
+    return children;
+  }
+
+  if (!outputTokens) {
+    return null;
+  }
+
+  const outputCost = estimateCostUsd({ modelId, outputTokens });
+  const outputCostText = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(outputCost ?? 0);
+
+  return (
+    <div
+      className={cn("flex items-center justify-between text-xs", className)}
+      {...props}
+    >
+      <span className="text-muted-foreground">Output</span>
+      <TokensWithCost costText={outputCostText} tokens={outputTokens} />
+    </div>
+  );
+};
+
+export type ContextReasoningUsageProps = ComponentProps<"div">;
+
+export const ContextReasoningUsage = ({
+  className,
+  children,
+  ...props
+}: ContextReasoningUsageProps) => {
+  const { usage, modelId } = useContextValue();
+  // AI SDK 7 moved this out of the top-level usage object.
+  const reasoningTokens = usage?.outputTokenDetails?.reasoningTokens ?? 0;
+
+  if (children) {
+    return children;
+  }
+
+  if (!reasoningTokens) {
+    return null;
+  }
+
+  const reasoningCost = estimateCostUsd({
+    modelId,
+    outputTokens: reasoningTokens,
+  });
+  const reasoningCostText = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(reasoningCost ?? 0);
+
+  return (
+    <div
+      className={cn("flex items-center justify-between text-xs", className)}
+      {...props}
+    >
+      <span className="text-muted-foreground">Reasoning</span>
+      <TokensWithCost costText={reasoningCostText} tokens={reasoningTokens} />
+    </div>
+  );
+};
+
+export type ContextCacheUsageProps = ComponentProps<"div">;
+
+export const ContextCacheUsage = ({
+  className,
+  children,
+  ...props
+}: ContextCacheUsageProps) => {
+  const { usage, modelId } = useContextValue();
+  // AI SDK 7 moved this out of the top-level usage object.
+  const cacheTokens = usage?.inputTokenDetails?.cacheReadTokens ?? 0;
+
+  if (children) {
+    return children;
+  }
+
+  if (!cacheTokens) {
+    return null;
+  }
+
+  const cacheCost = estimateCostUsd({ modelId, inputTokens: cacheTokens });
+  const cacheCostText = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cacheCost ?? 0);
+
+  return (
+    <div
+      className={cn("flex items-center justify-between text-xs", className)}
+      {...props}
+    >
+      <span className="text-muted-foreground">Cache</span>
+      <TokensWithCost costText={cacheCostText} tokens={cacheTokens} />
+    </div>
+  );
+};
+
+const TokensWithCost = ({
+  tokens,
+  costText,
+}: {
+  tokens?: number;
+  costText?: string;
+}) => (
+  <span>
+    {tokens === undefined
+      ? "—"
+      : new Intl.NumberFormat("en-US", {
+          notation: "compact",
+        }).format(tokens)}
+    {costText ? (
+      <span className="ml-2 text-muted-foreground">• {costText}</span>
+    ) : null}
+  </span>
+);

--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ArrowDownIcon } from "lucide-react";
+import type { ComponentProps } from "react";
+import { useCallback } from "react";
+import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
+
+export type ConversationProps = ComponentProps<typeof StickToBottom>;
+
+export const Conversation = ({ className, ...props }: ConversationProps) => (
+  <StickToBottom
+    className={cn("relative flex-1 overflow-y-hidden", className)}
+    initial="smooth"
+    resize="smooth"
+    role="log"
+    {...props}
+  />
+);
+
+export type ConversationContentProps = ComponentProps<
+  typeof StickToBottom.Content
+>;
+
+export const ConversationContent = ({
+  className,
+  ...props
+}: ConversationContentProps) => (
+  <StickToBottom.Content
+    className={cn("flex flex-col gap-8 p-4", className)}
+    {...props}
+  />
+);
+
+export type ConversationEmptyStateProps = ComponentProps<"div"> & {
+  title?: string;
+  description?: string;
+  icon?: React.ReactNode;
+};
+
+export const ConversationEmptyState = ({
+  className,
+  title = "No messages yet",
+  description = "Start a conversation to see messages here",
+  icon,
+  children,
+  ...props
+}: ConversationEmptyStateProps) => (
+  <div
+    className={cn(
+      "flex size-full flex-col items-center justify-center gap-3 p-8 text-center",
+      className
+    )}
+    {...props}
+  >
+    {children ?? (
+      <>
+        {icon && <div className="text-muted-foreground">{icon}</div>}
+        <div className="space-y-1">
+          <h3 className="font-medium text-sm">{title}</h3>
+          {description && (
+            <p className="text-muted-foreground text-sm">{description}</p>
+          )}
+        </div>
+      </>
+    )}
+  </div>
+);
+
+export type ConversationScrollButtonProps = ComponentProps<typeof Button>;
+
+export const ConversationScrollButton = ({
+  className,
+  ...props
+}: ConversationScrollButtonProps) => {
+  const { isAtBottom, scrollToBottom } = useStickToBottomContext();
+
+  const handleScrollToBottom = useCallback(() => {
+    scrollToBottom();
+  }, [scrollToBottom]);
+
+  return (
+    !isAtBottom && (
+      <Button
+        className={cn(
+          "absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full",
+          className
+        )}
+        onClick={handleScrollToBottom}
+        size="icon"
+        type="button"
+        variant="outline"
+        {...props}
+      >
+        <ArrowDownIcon className="size-4" />
+      </Button>
+    )
+  );
+};

--- a/components/ai-elements/loader.tsx
+++ b/components/ai-elements/loader.tsx
@@ -1,0 +1,96 @@
+import { cn } from "@/lib/utils";
+import type { HTMLAttributes } from "react";
+
+type LoaderIconProps = {
+  size?: number;
+};
+
+const LoaderIcon = ({ size = 16 }: LoaderIconProps) => (
+  <svg
+    height={size}
+    strokeLinejoin="round"
+    style={{ color: "currentcolor" }}
+    viewBox="0 0 16 16"
+    width={size}
+  >
+    <title>Loader</title>
+    <g clipPath="url(#clip0_2393_1490)">
+      <path d="M8 0V4" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="M8 16V12"
+        opacity="0.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M3.29773 1.52783L5.64887 4.7639"
+        opacity="0.9"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M12.7023 1.52783L10.3511 4.7639"
+        opacity="0.1"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M12.7023 14.472L10.3511 11.236"
+        opacity="0.4"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M3.29773 14.472L5.64887 11.236"
+        opacity="0.6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M15.6085 5.52783L11.8043 6.7639"
+        opacity="0.2"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M0.391602 10.472L4.19583 9.23598"
+        opacity="0.7"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M15.6085 10.4722L11.8043 9.2361"
+        opacity="0.3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M0.391602 5.52783L4.19583 6.7639"
+        opacity="0.8"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_2393_1490">
+        <rect fill="white" height="16" width="16" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
+export type LoaderProps = HTMLAttributes<HTMLDivElement> & {
+  size?: number;
+};
+
+export const Loader = ({ className, size = 16, ...props }: LoaderProps) => (
+  <div
+    className={cn(
+      "inline-flex animate-spin items-center justify-center",
+      className
+    )}
+    {...props}
+  >
+    <LoaderIcon size={size} />
+  </div>
+);

--- a/components/ai-elements/message.tsx
+++ b/components/ai-elements/message.tsx
@@ -1,0 +1,448 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  ButtonGroup,
+  ButtonGroupText,
+} from "@/components/ui/button-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { FileUIPart, UIMessage } from "ai";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  PaperclipIcon,
+  XIcon,
+} from "lucide-react";
+import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
+import { createContext, memo, useContext, useEffect, useState } from "react";
+import { Streamdown } from "streamdown";
+
+export type MessageProps = HTMLAttributes<HTMLDivElement> & {
+  from: UIMessage["role"];
+};
+
+export const Message = ({ className, from, ...props }: MessageProps) => (
+  <div
+    className={cn(
+      "group flex w-full max-w-[95%] flex-col gap-2",
+      from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
+      className
+    )}
+    {...props}
+  />
+);
+
+export type MessageContentProps = HTMLAttributes<HTMLDivElement>;
+
+export const MessageContent = ({
+  children,
+  className,
+  ...props
+}: MessageContentProps) => (
+  <div
+    className={cn(
+      "is-user:dark flex w-fit max-w-full min-w-0 flex-col gap-2 overflow-hidden text-sm",
+      "group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+      "group-[.is-assistant]:text-foreground",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+);
+
+export type MessageActionsProps = ComponentProps<"div">;
+
+export const MessageActions = ({
+  className,
+  children,
+  ...props
+}: MessageActionsProps) => (
+  <div className={cn("flex items-center gap-1", className)} {...props}>
+    {children}
+  </div>
+);
+
+export type MessageActionProps = ComponentProps<typeof Button> & {
+  tooltip?: string;
+  label?: string;
+};
+
+export const MessageAction = ({
+  tooltip,
+  children,
+  label,
+  variant = "ghost",
+  size = "icon-sm",
+  ...props
+}: MessageActionProps) => {
+  const button = (
+    <Button size={size} type="button" variant={variant} {...props}>
+      {children}
+      <span className="sr-only">{label || tooltip}</span>
+    </Button>
+  );
+
+  if (tooltip) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{button}</TooltipTrigger>
+          <TooltipContent>
+            <p>{tooltip}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return button;
+};
+
+type MessageBranchContextType = {
+  currentBranch: number;
+  totalBranches: number;
+  goToPrevious: () => void;
+  goToNext: () => void;
+  branches: ReactElement[];
+  setBranches: (branches: ReactElement[]) => void;
+};
+
+const MessageBranchContext = createContext<MessageBranchContextType | null>(
+  null
+);
+
+const useMessageBranch = () => {
+  const context = useContext(MessageBranchContext);
+
+  if (!context) {
+    throw new Error(
+      "MessageBranch components must be used within MessageBranch"
+    );
+  }
+
+  return context;
+};
+
+export type MessageBranchProps = HTMLAttributes<HTMLDivElement> & {
+  defaultBranch?: number;
+  onBranchChange?: (branchIndex: number) => void;
+};
+
+export const MessageBranch = ({
+  defaultBranch = 0,
+  onBranchChange,
+  className,
+  ...props
+}: MessageBranchProps) => {
+  const [currentBranch, setCurrentBranch] = useState(defaultBranch);
+  const [branches, setBranches] = useState<ReactElement[]>([]);
+
+  const handleBranchChange = (newBranch: number) => {
+    setCurrentBranch(newBranch);
+    onBranchChange?.(newBranch);
+  };
+
+  const goToPrevious = () => {
+    const newBranch =
+      currentBranch > 0 ? currentBranch - 1 : branches.length - 1;
+    handleBranchChange(newBranch);
+  };
+
+  const goToNext = () => {
+    const newBranch =
+      currentBranch < branches.length - 1 ? currentBranch + 1 : 0;
+    handleBranchChange(newBranch);
+  };
+
+  const contextValue: MessageBranchContextType = {
+    currentBranch,
+    totalBranches: branches.length,
+    goToPrevious,
+    goToNext,
+    branches,
+    setBranches,
+  };
+
+  return (
+    <MessageBranchContext.Provider value={contextValue}>
+      <div
+        className={cn("grid w-full gap-2 [&>div]:pb-0", className)}
+        {...props}
+      />
+    </MessageBranchContext.Provider>
+  );
+};
+
+export type MessageBranchContentProps = HTMLAttributes<HTMLDivElement>;
+
+export const MessageBranchContent = ({
+  children,
+  ...props
+}: MessageBranchContentProps) => {
+  const { currentBranch, setBranches, branches } = useMessageBranch();
+  const childrenArray = Array.isArray(children) ? children : [children];
+
+  // Use useEffect to update branches when they change
+  useEffect(() => {
+    if (branches.length !== childrenArray.length) {
+      setBranches(childrenArray);
+    }
+  }, [childrenArray, branches, setBranches]);
+
+  return childrenArray.map((branch, index) => (
+    <div
+      className={cn(
+        "grid gap-2 overflow-hidden [&>div]:pb-0",
+        index === currentBranch ? "block" : "hidden"
+      )}
+      key={branch.key}
+      {...props}
+    >
+      {branch}
+    </div>
+  ));
+};
+
+export type MessageBranchSelectorProps = HTMLAttributes<HTMLDivElement> & {
+  from: UIMessage["role"];
+};
+
+export const MessageBranchSelector = ({
+  className,
+  from,
+  ...props
+}: MessageBranchSelectorProps) => {
+  const { totalBranches } = useMessageBranch();
+
+  // Don't render if there's only one branch
+  if (totalBranches <= 1) {
+    return null;
+  }
+
+  return (
+    <ButtonGroup
+      className="[&>*:not(:first-child)]:rounded-l-md [&>*:not(:last-child)]:rounded-r-md"
+      orientation="horizontal"
+      {...props}
+    />
+  );
+};
+
+export type MessageBranchPreviousProps = ComponentProps<typeof Button>;
+
+export const MessageBranchPrevious = ({
+  children,
+  ...props
+}: MessageBranchPreviousProps) => {
+  const { goToPrevious, totalBranches } = useMessageBranch();
+
+  return (
+    <Button
+      aria-label="Previous branch"
+      disabled={totalBranches <= 1}
+      onClick={goToPrevious}
+      size="icon-sm"
+      type="button"
+      variant="ghost"
+      {...props}
+    >
+      {children ?? <ChevronLeftIcon size={14} />}
+    </Button>
+  );
+};
+
+export type MessageBranchNextProps = ComponentProps<typeof Button>;
+
+export const MessageBranchNext = ({
+  children,
+  className,
+  ...props
+}: MessageBranchNextProps) => {
+  const { goToNext, totalBranches } = useMessageBranch();
+
+  return (
+    <Button
+      aria-label="Next branch"
+      disabled={totalBranches <= 1}
+      onClick={goToNext}
+      size="icon-sm"
+      type="button"
+      variant="ghost"
+      {...props}
+    >
+      {children ?? <ChevronRightIcon size={14} />}
+    </Button>
+  );
+};
+
+export type MessageBranchPageProps = HTMLAttributes<HTMLSpanElement>;
+
+export const MessageBranchPage = ({
+  className,
+  ...props
+}: MessageBranchPageProps) => {
+  const { currentBranch, totalBranches } = useMessageBranch();
+
+  return (
+    <ButtonGroupText
+      className={cn(
+        "border-none bg-transparent text-muted-foreground shadow-none",
+        className
+      )}
+      {...props}
+    >
+      {currentBranch + 1} of {totalBranches}
+    </ButtonGroupText>
+  );
+};
+
+export type MessageResponseProps = ComponentProps<typeof Streamdown>;
+
+export const MessageResponse = memo(
+  ({ className, ...props }: MessageResponseProps) => (
+    <Streamdown
+      className={cn(
+        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        className
+      )}
+      {...props}
+    />
+  ),
+  (prevProps, nextProps) => prevProps.children === nextProps.children
+);
+
+MessageResponse.displayName = "MessageResponse";
+
+export type MessageAttachmentProps = HTMLAttributes<HTMLDivElement> & {
+  data: FileUIPart;
+  className?: string;
+  onRemove?: () => void;
+};
+
+export function MessageAttachment({
+  data,
+  className,
+  onRemove,
+  ...props
+}: MessageAttachmentProps) {
+  const filename = data.filename || "";
+  const mediaType =
+    data.mediaType?.startsWith("image/") && data.url ? "image" : "file";
+  const isImage = mediaType === "image";
+  const attachmentLabel = filename || (isImage ? "Image" : "Attachment");
+
+  return (
+    <div
+      className={cn(
+        "group relative size-24 overflow-hidden rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {isImage ? (
+        <>
+          <img
+            alt={filename || "attachment"}
+            className="size-full object-cover"
+            height={100}
+            src={data.url}
+            width={100}
+          />
+          {onRemove && (
+            <Button
+              aria-label="Remove attachment"
+              className="absolute top-2 right-2 size-6 rounded-full bg-background/80 p-0 opacity-0 backdrop-blur-sm transition-opacity hover:bg-background group-hover:opacity-100 [&>svg]:size-3"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove();
+              }}
+              type="button"
+              variant="ghost"
+            >
+              <XIcon />
+              <span className="sr-only">Remove</span>
+            </Button>
+          )}
+        </>
+      ) : (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="flex size-full shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                <PaperclipIcon className="size-4" />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{attachmentLabel}</p>
+            </TooltipContent>
+          </Tooltip>
+          {onRemove && (
+            <Button
+              aria-label="Remove attachment"
+              className="size-6 shrink-0 rounded-full p-0 opacity-0 transition-opacity hover:bg-accent group-hover:opacity-100 [&>svg]:size-3"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove();
+              }}
+              type="button"
+              variant="ghost"
+            >
+              <XIcon />
+              <span className="sr-only">Remove</span>
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export type MessageAttachmentsProps = ComponentProps<"div">;
+
+export function MessageAttachments({
+  children,
+  className,
+  ...props
+}: MessageAttachmentsProps) {
+  if (!children) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "ml-auto flex w-fit flex-wrap items-start gap-2",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export type MessageToolbarProps = ComponentProps<"div">;
+
+export const MessageToolbar = ({
+  className,
+  children,
+  ...props
+}: MessageToolbarProps) => (
+  <div
+    className={cn(
+      "mt-4 flex w-full items-center justify-between gap-4",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+);

--- a/components/ai-elements/prompt-input.tsx
+++ b/components/ai-elements/prompt-input.tsx
@@ -1,0 +1,1413 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupTextarea,
+} from "@/components/ui/input-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import type { ChatStatus, FileUIPart } from "ai";
+import {
+  CornerDownLeftIcon,
+  ImageIcon,
+  Loader2Icon,
+  MicIcon,
+  PaperclipIcon,
+  PlusIcon,
+  SquareIcon,
+  XIcon,
+} from "lucide-react";
+import { nanoid } from "nanoid";
+import {
+  type ChangeEvent,
+  type ChangeEventHandler,
+  Children,
+  type ClipboardEventHandler,
+  type ComponentProps,
+  createContext,
+  type FormEvent,
+  type FormEventHandler,
+  Fragment,
+  type HTMLAttributes,
+  type KeyboardEventHandler,
+  type PropsWithChildren,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+// ============================================================================
+// Provider Context & Types
+// ============================================================================
+
+export type AttachmentsContext = {
+  files: (FileUIPart & { id: string })[];
+  add: (files: File[] | FileList) => void;
+  remove: (id: string) => void;
+  clear: () => void;
+  openFileDialog: () => void;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+};
+
+export type TextInputContext = {
+  value: string;
+  setInput: (v: string) => void;
+  clear: () => void;
+};
+
+export type PromptInputControllerProps = {
+  textInput: TextInputContext;
+  attachments: AttachmentsContext;
+  /** INTERNAL: Allows PromptInput to register its file textInput + "open" callback */
+  __registerFileInput: (
+    ref: RefObject<HTMLInputElement | null>,
+    open: () => void
+  ) => void;
+};
+
+const PromptInputController = createContext<PromptInputControllerProps | null>(
+  null
+);
+const ProviderAttachmentsContext = createContext<AttachmentsContext | null>(
+  null
+);
+
+export const usePromptInputController = () => {
+  const ctx = useContext(PromptInputController);
+  if (!ctx) {
+    throw new Error(
+      "Wrap your component inside <PromptInputProvider> to use usePromptInputController()."
+    );
+  }
+  return ctx;
+};
+
+// Optional variants (do NOT throw). Useful for dual-mode components.
+const useOptionalPromptInputController = () =>
+  useContext(PromptInputController);
+
+export const useProviderAttachments = () => {
+  const ctx = useContext(ProviderAttachmentsContext);
+  if (!ctx) {
+    throw new Error(
+      "Wrap your component inside <PromptInputProvider> to use useProviderAttachments()."
+    );
+  }
+  return ctx;
+};
+
+const useOptionalProviderAttachments = () =>
+  useContext(ProviderAttachmentsContext);
+
+export type PromptInputProviderProps = PropsWithChildren<{
+  initialInput?: string;
+}>;
+
+/**
+ * Optional global provider that lifts PromptInput state outside of PromptInput.
+ * If you don't use it, PromptInput stays fully self-managed.
+ */
+export function PromptInputProvider({
+  initialInput: initialTextInput = "",
+  children,
+}: PromptInputProviderProps) {
+  // ----- textInput state
+  const [textInput, setTextInput] = useState(initialTextInput);
+  const clearInput = useCallback(() => setTextInput(""), []);
+
+  // ----- attachments state (global when wrapped)
+  const [attachmentFiles, setAttachmentFiles] = useState<
+    (FileUIPart & { id: string })[]
+  >([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const openRef = useRef<() => void>(() => {});
+
+  const add = useCallback((files: File[] | FileList) => {
+    const incoming = Array.from(files);
+    if (incoming.length === 0) {
+      return;
+    }
+
+    setAttachmentFiles((prev) =>
+      prev.concat(
+        incoming.map((file) => ({
+          id: nanoid(),
+          type: "file" as const,
+          url: URL.createObjectURL(file),
+          mediaType: file.type,
+          filename: file.name,
+        }))
+      )
+    );
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setAttachmentFiles((prev) => {
+      const found = prev.find((f) => f.id === id);
+      if (found?.url) {
+        URL.revokeObjectURL(found.url);
+      }
+      return prev.filter((f) => f.id !== id);
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setAttachmentFiles((prev) => {
+      for (const f of prev) {
+        if (f.url) {
+          URL.revokeObjectURL(f.url);
+        }
+      }
+      return [];
+    });
+  }, []);
+
+  // Keep a ref to attachments for cleanup on unmount (avoids stale closure)
+  const attachmentsRef = useRef(attachmentFiles);
+  attachmentsRef.current = attachmentFiles;
+
+  // Cleanup blob URLs on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      for (const f of attachmentsRef.current) {
+        if (f.url) {
+          URL.revokeObjectURL(f.url);
+        }
+      }
+    };
+  }, []);
+
+  const openFileDialog = useCallback(() => {
+    openRef.current?.();
+  }, []);
+
+  const attachments = useMemo<AttachmentsContext>(
+    () => ({
+      files: attachmentFiles,
+      add,
+      remove,
+      clear,
+      openFileDialog,
+      fileInputRef,
+    }),
+    [attachmentFiles, add, remove, clear, openFileDialog]
+  );
+
+  const __registerFileInput = useCallback(
+    (ref: RefObject<HTMLInputElement | null>, open: () => void) => {
+      fileInputRef.current = ref.current;
+      openRef.current = open;
+    },
+    []
+  );
+
+  const controller = useMemo<PromptInputControllerProps>(
+    () => ({
+      textInput: {
+        value: textInput,
+        setInput: setTextInput,
+        clear: clearInput,
+      },
+      attachments,
+      __registerFileInput,
+    }),
+    [textInput, clearInput, attachments, __registerFileInput]
+  );
+
+  return (
+    <PromptInputController.Provider value={controller}>
+      <ProviderAttachmentsContext.Provider value={attachments}>
+        {children}
+      </ProviderAttachmentsContext.Provider>
+    </PromptInputController.Provider>
+  );
+}
+
+// ============================================================================
+// Component Context & Hooks
+// ============================================================================
+
+const LocalAttachmentsContext = createContext<AttachmentsContext | null>(null);
+
+export const usePromptInputAttachments = () => {
+  // Dual-mode: prefer provider if present, otherwise use local
+  const provider = useOptionalProviderAttachments();
+  const local = useContext(LocalAttachmentsContext);
+  const context = provider ?? local;
+  if (!context) {
+    throw new Error(
+      "usePromptInputAttachments must be used within a PromptInput or PromptInputProvider"
+    );
+  }
+  return context;
+};
+
+export type PromptInputAttachmentProps = HTMLAttributes<HTMLDivElement> & {
+  data: FileUIPart & { id: string };
+  className?: string;
+};
+
+export function PromptInputAttachment({
+  data,
+  className,
+  ...props
+}: PromptInputAttachmentProps) {
+  const attachments = usePromptInputAttachments();
+
+  const filename = data.filename || "";
+
+  const mediaType =
+    data.mediaType?.startsWith("image/") && data.url ? "image" : "file";
+  const isImage = mediaType === "image";
+
+  const attachmentLabel = filename || (isImage ? "Image" : "Attachment");
+
+  return (
+    <PromptInputHoverCard>
+      <HoverCardTrigger asChild>
+        <div
+          className={cn(
+            "group relative flex h-8 cursor-pointer select-none items-center gap-1.5 rounded-md border border-border px-1.5 font-medium text-sm transition-all hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+            className
+          )}
+          key={data.id}
+          {...props}
+        >
+          <div className="relative size-5 shrink-0">
+            <div className="absolute inset-0 flex size-5 items-center justify-center overflow-hidden rounded bg-background transition-opacity group-hover:opacity-0">
+              {isImage ? (
+                <img
+                  alt={filename || "attachment"}
+                  className="size-5 object-cover"
+                  height={20}
+                  src={data.url}
+                  width={20}
+                />
+              ) : (
+                <div className="flex size-5 items-center justify-center text-muted-foreground">
+                  <PaperclipIcon className="size-3" />
+                </div>
+              )}
+            </div>
+            <Button
+              aria-label="Remove attachment"
+              className="absolute inset-0 size-5 cursor-pointer rounded p-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 [&>svg]:size-2.5"
+              onClick={(e) => {
+                e.stopPropagation();
+                attachments.remove(data.id);
+              }}
+              type="button"
+              variant="ghost"
+            >
+              <XIcon />
+              <span className="sr-only">Remove</span>
+            </Button>
+          </div>
+
+          <span className="flex-1 truncate">{attachmentLabel}</span>
+        </div>
+      </HoverCardTrigger>
+      <PromptInputHoverCardContent className="w-auto p-2">
+        <div className="w-auto space-y-3">
+          {isImage && (
+            <div className="flex max-h-96 w-96 items-center justify-center overflow-hidden rounded-md border">
+              <img
+                alt={filename || "attachment preview"}
+                className="max-h-full max-w-full object-contain"
+                height={384}
+                src={data.url}
+                width={448}
+              />
+            </div>
+          )}
+          <div className="flex items-center gap-2.5">
+            <div className="min-w-0 flex-1 space-y-1 px-0.5">
+              <h4 className="truncate font-semibold text-sm leading-none">
+                {filename || (isImage ? "Image" : "Attachment")}
+              </h4>
+              {data.mediaType && (
+                <p className="truncate font-mono text-muted-foreground text-xs">
+                  {data.mediaType}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </PromptInputHoverCardContent>
+    </PromptInputHoverCard>
+  );
+}
+
+export type PromptInputAttachmentsProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "children"
+> & {
+  children: (attachment: FileUIPart & { id: string }) => ReactNode;
+};
+
+export function PromptInputAttachments({
+  children,
+  className,
+  ...props
+}: PromptInputAttachmentsProps) {
+  const attachments = usePromptInputAttachments();
+
+  if (!attachments.files.length) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn("flex flex-wrap items-center gap-2 p-3 w-full", className)}
+      {...props}
+    >
+      {attachments.files.map((file) => (
+        <Fragment key={file.id}>{children(file)}</Fragment>
+      ))}
+    </div>
+  );
+}
+
+export type PromptInputActionAddAttachmentsProps = ComponentProps<
+  typeof DropdownMenuItem
+> & {
+  label?: string;
+};
+
+export const PromptInputActionAddAttachments = ({
+  label = "Add photos or files",
+  ...props
+}: PromptInputActionAddAttachmentsProps) => {
+  const attachments = usePromptInputAttachments();
+
+  return (
+    <DropdownMenuItem
+      {...props}
+      onSelect={(e) => {
+        e.preventDefault();
+        attachments.openFileDialog();
+      }}
+    >
+      <ImageIcon className="mr-2 size-4" /> {label}
+    </DropdownMenuItem>
+  );
+};
+
+export type PromptInputMessage = {
+  text: string;
+  files: FileUIPart[];
+};
+
+export type PromptInputProps = Omit<
+  HTMLAttributes<HTMLFormElement>,
+  "onSubmit" | "onError"
+> & {
+  accept?: string; // e.g., "image/*" or leave undefined for any
+  multiple?: boolean;
+  // When true, accepts drops anywhere on document. Default false (opt-in).
+  globalDrop?: boolean;
+  // Render a hidden input with given name and keep it in sync for native form posts. Default false.
+  syncHiddenInput?: boolean;
+  // Minimal constraints
+  maxFiles?: number;
+  maxFileSize?: number; // bytes
+  onError?: (err: {
+    code: "max_files" | "max_file_size" | "accept";
+    message: string;
+  }) => void;
+  onSubmit: (
+    message: PromptInputMessage,
+    event: FormEvent<HTMLFormElement>
+  ) => void | Promise<void>;
+};
+
+export const PromptInput = ({
+  className,
+  accept,
+  multiple,
+  globalDrop,
+  syncHiddenInput,
+  maxFiles,
+  maxFileSize,
+  onError,
+  onSubmit,
+  children,
+  ...props
+}: PromptInputProps) => {
+  // Try to use a provider controller if present
+  const controller = useOptionalPromptInputController();
+  const usingProvider = !!controller;
+
+  // Refs
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  // ----- Local attachments (only used when no provider)
+  const [items, setItems] = useState<(FileUIPart & { id: string })[]>([]);
+  const files = usingProvider ? controller.attachments.files : items;
+
+  // Keep a ref to files for cleanup on unmount (avoids stale closure)
+  const filesRef = useRef(files);
+  filesRef.current = files;
+
+  const openFileDialogLocal = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const matchesAccept = useCallback(
+    (f: File) => {
+      if (!accept || accept.trim() === "") {
+        return true;
+      }
+
+      const patterns = accept
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+      return patterns.some((pattern) => {
+        if (pattern.endsWith("/*")) {
+          const prefix = pattern.slice(0, -1); // e.g: image/* -> image/
+          return f.type.startsWith(prefix);
+        }
+        return f.type === pattern;
+      });
+    },
+    [accept]
+  );
+
+  const addLocal = useCallback(
+    (fileList: File[] | FileList) => {
+      const incoming = Array.from(fileList);
+      const accepted = incoming.filter((f) => matchesAccept(f));
+      if (incoming.length && accepted.length === 0) {
+        onError?.({
+          code: "accept",
+          message: "No files match the accepted types.",
+        });
+        return;
+      }
+      const withinSize = (f: File) =>
+        maxFileSize ? f.size <= maxFileSize : true;
+      const sized = accepted.filter(withinSize);
+      if (accepted.length > 0 && sized.length === 0) {
+        onError?.({
+          code: "max_file_size",
+          message: "All files exceed the maximum size.",
+        });
+        return;
+      }
+
+      setItems((prev) => {
+        const capacity =
+          typeof maxFiles === "number"
+            ? Math.max(0, maxFiles - prev.length)
+            : undefined;
+        const capped =
+          typeof capacity === "number" ? sized.slice(0, capacity) : sized;
+        if (typeof capacity === "number" && sized.length > capacity) {
+          onError?.({
+            code: "max_files",
+            message: "Too many files. Some were not added.",
+          });
+        }
+        const next: (FileUIPart & { id: string })[] = [];
+        for (const file of capped) {
+          next.push({
+            id: nanoid(),
+            type: "file",
+            url: URL.createObjectURL(file),
+            mediaType: file.type,
+            filename: file.name,
+          });
+        }
+        return prev.concat(next);
+      });
+    },
+    [matchesAccept, maxFiles, maxFileSize, onError]
+  );
+
+  const removeLocal = useCallback(
+    (id: string) =>
+      setItems((prev) => {
+        const found = prev.find((file) => file.id === id);
+        if (found?.url) {
+          URL.revokeObjectURL(found.url);
+        }
+        return prev.filter((file) => file.id !== id);
+      }),
+    []
+  );
+
+  const clearLocal = useCallback(
+    () =>
+      setItems((prev) => {
+        for (const file of prev) {
+          if (file.url) {
+            URL.revokeObjectURL(file.url);
+          }
+        }
+        return [];
+      }),
+    []
+  );
+
+  const add = usingProvider ? controller.attachments.add : addLocal;
+  const remove = usingProvider ? controller.attachments.remove : removeLocal;
+  const clear = usingProvider ? controller.attachments.clear : clearLocal;
+  const openFileDialog = usingProvider
+    ? controller.attachments.openFileDialog
+    : openFileDialogLocal;
+
+  // Let provider know about our hidden file input so external menus can call openFileDialog()
+  useEffect(() => {
+    if (!usingProvider) return;
+    controller.__registerFileInput(inputRef, () => inputRef.current?.click());
+  }, [usingProvider, controller]);
+
+  // Note: File input cannot be programmatically set for security reasons
+  // The syncHiddenInput prop is no longer functional
+  useEffect(() => {
+    if (syncHiddenInput && inputRef.current && files.length === 0) {
+      inputRef.current.value = "";
+    }
+  }, [files, syncHiddenInput]);
+
+  // Attach drop handlers on nearest form and document (opt-in)
+  useEffect(() => {
+    const form = formRef.current;
+    if (!form) return;
+    if (globalDrop) return // when global drop is on, let the document-level handler own drops
+
+    const onDragOver = (e: DragEvent) => {
+      if (e.dataTransfer?.types?.includes("Files")) {
+        e.preventDefault();
+      }
+    };
+    const onDrop = (e: DragEvent) => {
+      if (e.dataTransfer?.types?.includes("Files")) {
+        e.preventDefault();
+      }
+      if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
+        add(e.dataTransfer.files);
+      }
+    };
+    form.addEventListener("dragover", onDragOver);
+    form.addEventListener("drop", onDrop);
+    return () => {
+      form.removeEventListener("dragover", onDragOver);
+      form.removeEventListener("drop", onDrop);
+    };
+  }, [add, globalDrop]);
+
+  useEffect(() => {
+    if (!globalDrop) return;
+
+    const onDragOver = (e: DragEvent) => {
+      if (e.dataTransfer?.types?.includes("Files")) {
+        e.preventDefault();
+      }
+    };
+    const onDrop = (e: DragEvent) => {
+      if (e.dataTransfer?.types?.includes("Files")) {
+        e.preventDefault();
+      }
+      if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
+        add(e.dataTransfer.files);
+      }
+    };
+    document.addEventListener("dragover", onDragOver);
+    document.addEventListener("drop", onDrop);
+    return () => {
+      document.removeEventListener("dragover", onDragOver);
+      document.removeEventListener("drop", onDrop);
+    };
+  }, [add, globalDrop]);
+
+  useEffect(
+    () => () => {
+      if (!usingProvider) {
+        for (const f of filesRef.current) {
+          if (f.url) URL.revokeObjectURL(f.url);
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup only on unmount; filesRef always current
+    [usingProvider]
+  );
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    if (event.currentTarget.files) {
+      add(event.currentTarget.files);
+    }
+    // Reset input value to allow selecting files that were previously removed
+    event.currentTarget.value = "";
+  };
+
+  const convertBlobUrlToDataUrl = async (
+    url: string
+  ): Promise<string | null> => {
+    try {
+      const response = await fetch(url);
+      const blob = await response.blob();
+      return new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result as string);
+        reader.onerror = () => resolve(null);
+        reader.readAsDataURL(blob);
+      });
+    } catch {
+      return null;
+    }
+  };
+
+  const ctx = useMemo<AttachmentsContext>(
+    () => ({
+      files: files.map((item) => ({ ...item, id: item.id })),
+      add,
+      remove,
+      clear,
+      openFileDialog,
+      fileInputRef: inputRef,
+    }),
+    [files, add, remove, clear, openFileDialog]
+  );
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const text = usingProvider
+      ? controller.textInput.value
+      : (() => {
+          const formData = new FormData(form);
+          return (formData.get("message") as string) || "";
+        })();
+
+    // Reset form immediately after capturing text to avoid race condition
+    // where user input during async blob conversion would be lost
+    if (!usingProvider) {
+      form.reset();
+    }
+
+    // Convert blob URLs to data URLs asynchronously
+    Promise.all(
+      files.map(async ({ id, ...item }) => {
+        if (item.url && item.url.startsWith("blob:")) {
+          const dataUrl = await convertBlobUrlToDataUrl(item.url);
+          // If conversion failed, keep the original blob URL
+          return {
+            ...item,
+            url: dataUrl ?? item.url,
+          };
+        }
+        return item;
+      })
+    )
+      .then((convertedFiles: FileUIPart[]) => {
+        try {
+          const result = onSubmit({ text, files: convertedFiles }, event);
+
+          // Handle both sync and async onSubmit
+          if (result instanceof Promise) {
+            result
+              .then(() => {
+                clear();
+                if (usingProvider) {
+                  controller.textInput.clear();
+                }
+              })
+              .catch(() => {
+                // Don't clear on error - user may want to retry
+              });
+          } else {
+            // Sync function completed without throwing, clear attachments
+            clear();
+            if (usingProvider) {
+              controller.textInput.clear();
+            }
+          }
+        } catch {
+          // Don't clear on error - user may want to retry
+        }
+      })
+      .catch(() => {
+        // Don't clear on error - user may want to retry
+      });
+  };
+
+  // Render with or without local provider
+  const inner = (
+    <>
+      <input
+        accept={accept}
+        aria-label="Upload files"
+        className="hidden"
+        multiple={multiple}
+        onChange={handleChange}
+        ref={inputRef}
+        title="Upload files"
+        type="file"
+      />
+      <form
+        className={cn("w-full", className)}
+        onSubmit={handleSubmit}
+        ref={formRef}
+        {...props}
+      >
+        <InputGroup className="overflow-hidden">{children}</InputGroup>
+      </form>
+    </>
+  );
+
+  return usingProvider ? (
+    inner
+  ) : (
+    <LocalAttachmentsContext.Provider value={ctx}>
+      {inner}
+    </LocalAttachmentsContext.Provider>
+  );
+};
+
+export type PromptInputBodyProps = HTMLAttributes<HTMLDivElement>;
+
+export const PromptInputBody = ({
+  className,
+  ...props
+}: PromptInputBodyProps) => (
+  <div className={cn("contents", className)} {...props} />
+);
+
+export type PromptInputTextareaProps = ComponentProps<
+  typeof InputGroupTextarea
+>;
+
+export const PromptInputTextarea = ({
+  onChange,
+  className,
+  placeholder = "What would you like to know?",
+  ...props
+}: PromptInputTextareaProps) => {
+  const controller = useOptionalPromptInputController();
+  const attachments = usePromptInputAttachments();
+  const [isComposing, setIsComposing] = useState(false);
+
+  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+    if (e.key === "Enter") {
+      if (isComposing || e.nativeEvent.isComposing) {
+        return;
+      }
+      if (e.shiftKey) {
+        return;
+      }
+      e.preventDefault();
+
+      // Check if the submit button is disabled before submitting
+      const form = e.currentTarget.form;
+      const submitButton = form?.querySelector(
+        'button[type="submit"]'
+      ) as HTMLButtonElement | null;
+      if (submitButton?.disabled) {
+        return;
+      }
+
+      form?.requestSubmit();
+    }
+
+    // Remove last attachment when Backspace is pressed and textarea is empty
+    if (
+      e.key === "Backspace" &&
+      e.currentTarget.value === "" &&
+      attachments.files.length > 0
+    ) {
+      e.preventDefault();
+      const lastAttachment = attachments.files.at(-1);
+      if (lastAttachment) {
+        attachments.remove(lastAttachment.id);
+      }
+    }
+  };
+
+  const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = (event) => {
+    const items = event.clipboardData?.items;
+
+    if (!items) {
+      return;
+    }
+
+    const files: File[] = [];
+
+    for (const item of items) {
+      if (item.kind === "file") {
+        const file = item.getAsFile();
+        if (file) {
+          files.push(file);
+        }
+      }
+    }
+
+    if (files.length > 0) {
+      event.preventDefault();
+      attachments.add(files);
+    }
+  };
+
+  const controlledProps = controller
+    ? {
+        value: controller.textInput.value,
+        onChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
+          controller.textInput.setInput(e.currentTarget.value);
+          onChange?.(e);
+        },
+      }
+    : {
+        onChange,
+      };
+
+  return (
+    <InputGroupTextarea
+      className={cn("field-sizing-content max-h-48 min-h-16", className)}
+      name="message"
+      onCompositionEnd={() => setIsComposing(false)}
+      onCompositionStart={() => setIsComposing(true)}
+      onKeyDown={handleKeyDown}
+      onPaste={handlePaste}
+      placeholder={placeholder}
+      {...props}
+      {...controlledProps}
+    />
+  );
+};
+
+export type PromptInputHeaderProps = Omit<
+  ComponentProps<typeof InputGroupAddon>,
+  "align"
+>;
+
+export const PromptInputHeader = ({
+  className,
+  ...props
+}: PromptInputHeaderProps) => (
+  <InputGroupAddon
+    align="block-end"
+    className={cn("order-first flex-wrap gap-1", className)}
+    {...props}
+  />
+);
+
+export type PromptInputFooterProps = Omit<
+  ComponentProps<typeof InputGroupAddon>,
+  "align"
+>;
+
+export const PromptInputFooter = ({
+  className,
+  ...props
+}: PromptInputFooterProps) => (
+  <InputGroupAddon
+    align="block-end"
+    className={cn("justify-between gap-1", className)}
+    {...props}
+  />
+);
+
+export type PromptInputToolsProps = HTMLAttributes<HTMLDivElement>;
+
+export const PromptInputTools = ({
+  className,
+  ...props
+}: PromptInputToolsProps) => (
+  <div className={cn("flex items-center gap-1", className)} {...props} />
+);
+
+export type PromptInputButtonProps = ComponentProps<typeof InputGroupButton>;
+
+export const PromptInputButton = ({
+  variant = "ghost",
+  className,
+  size,
+  ...props
+}: PromptInputButtonProps) => {
+  const newSize =
+    size ?? (Children.count(props.children) > 1 ? "sm" : "icon-sm");
+
+  return (
+    <InputGroupButton
+      className={cn(className)}
+      size={newSize}
+      type="button"
+      variant={variant}
+      {...props}
+    />
+  );
+};
+
+export type PromptInputActionMenuProps = ComponentProps<typeof DropdownMenu>;
+export const PromptInputActionMenu = (props: PromptInputActionMenuProps) => (
+  <DropdownMenu {...props} />
+);
+
+export type PromptInputActionMenuTriggerProps = PromptInputButtonProps;
+
+export const PromptInputActionMenuTrigger = ({
+  className,
+  children,
+  ...props
+}: PromptInputActionMenuTriggerProps) => (
+  <DropdownMenuTrigger asChild>
+    <PromptInputButton className={className} {...props}>
+      {children ?? <PlusIcon className="size-4" />}
+    </PromptInputButton>
+  </DropdownMenuTrigger>
+);
+
+export type PromptInputActionMenuContentProps = ComponentProps<
+  typeof DropdownMenuContent
+>;
+export const PromptInputActionMenuContent = ({
+  className,
+  ...props
+}: PromptInputActionMenuContentProps) => (
+  <DropdownMenuContent align="start" className={cn(className)} {...props} />
+);
+
+export type PromptInputActionMenuItemProps = ComponentProps<
+  typeof DropdownMenuItem
+>;
+export const PromptInputActionMenuItem = ({
+  className,
+  ...props
+}: PromptInputActionMenuItemProps) => (
+  <DropdownMenuItem className={cn(className)} {...props} />
+);
+
+// Note: Actions that perform side-effects (like opening a file dialog)
+// are provided in opt-in modules (e.g., prompt-input-attachments).
+
+export type PromptInputSubmitProps = ComponentProps<typeof InputGroupButton> & {
+  status?: ChatStatus;
+};
+
+export const PromptInputSubmit = ({
+  className,
+  variant = "default",
+  size = "icon-sm",
+  status,
+  children,
+  ...props
+}: PromptInputSubmitProps) => {
+  let Icon = <CornerDownLeftIcon className="size-4" />;
+
+  if (status === "submitted") {
+    Icon = <Loader2Icon className="size-4 animate-spin" />;
+  } else if (status === "streaming") {
+    Icon = <SquareIcon className="size-4" />;
+  } else if (status === "error") {
+    Icon = <XIcon className="size-4" />;
+  }
+
+  return (
+    <InputGroupButton
+      aria-label="Submit"
+      className={cn(className)}
+      size={size}
+      type="submit"
+      variant={variant}
+      {...props}
+    >
+      {children ?? Icon}
+    </InputGroupButton>
+  );
+};
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  onstart: ((this: SpeechRecognition, ev: Event) => any) | null;
+  onend: ((this: SpeechRecognition, ev: Event) => any) | null;
+  onresult:
+    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => any)
+    | null;
+  onerror:
+    | ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => any)
+    | null;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  results: SpeechRecognitionResultList;
+  resultIndex: number;
+}
+
+type SpeechRecognitionResultList = {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+};
+
+type SpeechRecognitionResult = {
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+  isFinal: boolean;
+};
+
+type SpeechRecognitionAlternative = {
+  transcript: string;
+  confidence: number;
+};
+
+interface SpeechRecognitionErrorEvent extends Event {
+  error: string;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition: {
+      new (): SpeechRecognition;
+    };
+    webkitSpeechRecognition: {
+      new (): SpeechRecognition;
+    };
+  }
+}
+
+export type PromptInputSpeechButtonProps = ComponentProps<
+  typeof PromptInputButton
+> & {
+  textareaRef?: RefObject<HTMLTextAreaElement | null>;
+  onTranscriptionChange?: (text: string) => void;
+};
+
+export const PromptInputSpeechButton = ({
+  className,
+  textareaRef,
+  onTranscriptionChange,
+  ...props
+}: PromptInputSpeechButtonProps) => {
+  const [isListening, setIsListening] = useState(false);
+  const [recognition, setRecognition] = useState<SpeechRecognition | null>(
+    null
+  );
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      ("SpeechRecognition" in window || "webkitSpeechRecognition" in window)
+    ) {
+      const SpeechRecognition =
+        window.SpeechRecognition || window.webkitSpeechRecognition;
+      const speechRecognition = new SpeechRecognition();
+
+      speechRecognition.continuous = true;
+      speechRecognition.interimResults = true;
+      speechRecognition.lang = "en-US";
+
+      speechRecognition.onstart = () => {
+        setIsListening(true);
+      };
+
+      speechRecognition.onend = () => {
+        setIsListening(false);
+      };
+
+      speechRecognition.onresult = (event) => {
+        let finalTranscript = "";
+
+        for (let i = event.resultIndex; i < event.results.length; i++) {
+          const result = event.results[i];
+          if (result.isFinal) {
+            finalTranscript += result[0]?.transcript ?? "";
+          }
+        }
+
+        if (finalTranscript && textareaRef?.current) {
+          const textarea = textareaRef.current;
+          const currentValue = textarea.value;
+          const newValue =
+            currentValue + (currentValue ? " " : "") + finalTranscript;
+
+          textarea.value = newValue;
+          textarea.dispatchEvent(new Event("input", { bubbles: true }));
+          onTranscriptionChange?.(newValue);
+        }
+      };
+
+      speechRecognition.onerror = (event) => {
+        console.error("Speech recognition error:", event.error);
+        setIsListening(false);
+      };
+
+      recognitionRef.current = speechRecognition;
+      setRecognition(speechRecognition);
+    }
+
+    return () => {
+      if (recognitionRef.current) {
+        recognitionRef.current.stop();
+      }
+    };
+  }, [textareaRef, onTranscriptionChange]);
+
+  const toggleListening = useCallback(() => {
+    if (!recognition) {
+      return;
+    }
+
+    if (isListening) {
+      recognition.stop();
+    } else {
+      recognition.start();
+    }
+  }, [recognition, isListening]);
+
+  return (
+    <PromptInputButton
+      className={cn(
+        "relative transition-all duration-200",
+        isListening && "animate-pulse bg-accent text-accent-foreground",
+        className
+      )}
+      disabled={!recognition}
+      onClick={toggleListening}
+      {...props}
+    >
+      <MicIcon className="size-4" />
+    </PromptInputButton>
+  );
+};
+
+export type PromptInputSelectProps = ComponentProps<typeof Select>;
+
+export const PromptInputSelect = (props: PromptInputSelectProps) => (
+  <Select {...props} />
+);
+
+export type PromptInputSelectTriggerProps = ComponentProps<
+  typeof SelectTrigger
+>;
+
+export const PromptInputSelectTrigger = ({
+  className,
+  ...props
+}: PromptInputSelectTriggerProps) => (
+  <SelectTrigger
+    className={cn(
+      "border-none bg-transparent font-medium text-muted-foreground shadow-none transition-colors",
+      "hover:bg-accent hover:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground",
+      className
+    )}
+    {...props}
+  />
+);
+
+export type PromptInputSelectContentProps = ComponentProps<
+  typeof SelectContent
+>;
+
+export const PromptInputSelectContent = ({
+  className,
+  ...props
+}: PromptInputSelectContentProps) => (
+  <SelectContent className={cn(className)} {...props} />
+);
+
+export type PromptInputSelectItemProps = ComponentProps<typeof SelectItem>;
+
+export const PromptInputSelectItem = ({
+  className,
+  ...props
+}: PromptInputSelectItemProps) => (
+  <SelectItem className={cn(className)} {...props} />
+);
+
+export type PromptInputSelectValueProps = ComponentProps<typeof SelectValue>;
+
+export const PromptInputSelectValue = ({
+  className,
+  ...props
+}: PromptInputSelectValueProps) => (
+  <SelectValue className={cn(className)} {...props} />
+);
+
+export type PromptInputHoverCardProps = ComponentProps<typeof HoverCard>;
+
+export const PromptInputHoverCard = ({
+  openDelay = 0,
+  closeDelay = 0,
+  ...props
+}: PromptInputHoverCardProps) => (
+  <HoverCard closeDelay={closeDelay} openDelay={openDelay} {...props} />
+);
+
+export type PromptInputHoverCardTriggerProps = ComponentProps<
+  typeof HoverCardTrigger
+>;
+
+export const PromptInputHoverCardTrigger = (
+  props: PromptInputHoverCardTriggerProps
+) => <HoverCardTrigger {...props} />;
+
+export type PromptInputHoverCardContentProps = ComponentProps<
+  typeof HoverCardContent
+>;
+
+export const PromptInputHoverCardContent = ({
+  align = "start",
+  ...props
+}: PromptInputHoverCardContentProps) => (
+  <HoverCardContent align={align} {...props} />
+);
+
+export type PromptInputTabsListProps = HTMLAttributes<HTMLDivElement>;
+
+export const PromptInputTabsList = ({
+  className,
+  ...props
+}: PromptInputTabsListProps) => <div className={cn(className)} {...props} />;
+
+export type PromptInputTabProps = HTMLAttributes<HTMLDivElement>;
+
+export const PromptInputTab = ({
+  className,
+  ...props
+}: PromptInputTabProps) => <div className={cn(className)} {...props} />;
+
+export type PromptInputTabLabelProps = HTMLAttributes<HTMLHeadingElement>;
+
+export const PromptInputTabLabel = ({
+  className,
+  ...props
+}: PromptInputTabLabelProps) => (
+  <h3
+    className={cn(
+      "mb-2 px-3 font-medium text-muted-foreground text-xs",
+      className
+    )}
+    {...props}
+  />
+);
+
+export type PromptInputTabBodyProps = HTMLAttributes<HTMLDivElement>;
+
+export const PromptInputTabBody = ({
+  className,
+  ...props
+}: PromptInputTabBodyProps) => (
+  <div className={cn("space-y-1", className)} {...props} />
+);
+
+export type PromptInputTabItemProps = HTMLAttributes<HTMLDivElement>;
+
+export const PromptInputTabItem = ({
+  className,
+  ...props
+}: PromptInputTabItemProps) => (
+  <div
+    className={cn(
+      "flex items-center gap-2 px-3 py-2 text-xs hover:bg-accent",
+      className
+    )}
+    {...props}
+  />
+);
+
+export type PromptInputCommandProps = ComponentProps<typeof Command>;
+
+export const PromptInputCommand = ({
+  className,
+  ...props
+}: PromptInputCommandProps) => <Command className={cn(className)} {...props} />;
+
+export type PromptInputCommandInputProps = ComponentProps<typeof CommandInput>;
+
+export const PromptInputCommandInput = ({
+  className,
+  ...props
+}: PromptInputCommandInputProps) => (
+  <CommandInput className={cn(className)} {...props} />
+);
+
+export type PromptInputCommandListProps = ComponentProps<typeof CommandList>;
+
+export const PromptInputCommandList = ({
+  className,
+  ...props
+}: PromptInputCommandListProps) => (
+  <CommandList className={cn(className)} {...props} />
+);
+
+export type PromptInputCommandEmptyProps = ComponentProps<typeof CommandEmpty>;
+
+export const PromptInputCommandEmpty = ({
+  className,
+  ...props
+}: PromptInputCommandEmptyProps) => (
+  <CommandEmpty className={cn(className)} {...props} />
+);
+
+export type PromptInputCommandGroupProps = ComponentProps<typeof CommandGroup>;
+
+export const PromptInputCommandGroup = ({
+  className,
+  ...props
+}: PromptInputCommandGroupProps) => (
+  <CommandGroup className={cn(className)} {...props} />
+);
+
+export type PromptInputCommandItemProps = ComponentProps<typeof CommandItem>;
+
+export const PromptInputCommandItem = ({
+  className,
+  ...props
+}: PromptInputCommandItemProps) => (
+  <CommandItem className={cn(className)} {...props} />
+);
+
+export type PromptInputCommandSeparatorProps = ComponentProps<
+  typeof CommandSeparator
+>;
+
+export const PromptInputCommandSeparator = ({
+  className,
+  ...props
+}: PromptInputCommandSeparatorProps) => (
+  <CommandSeparator className={cn(className)} {...props} />
+);

--- a/components/ai-elements/sources.tsx
+++ b/components/ai-elements/sources.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { BookIcon, ChevronDownIcon } from "lucide-react";
+import type { ComponentProps } from "react";
+
+export type SourcesProps = ComponentProps<"div">;
+
+export const Sources = ({ className, ...props }: SourcesProps) => (
+  <Collapsible
+    className={cn("not-prose mb-4 text-primary text-xs", className)}
+    {...props}
+  />
+);
+
+export type SourcesTriggerProps = ComponentProps<typeof CollapsibleTrigger> & {
+  count: number;
+};
+
+export const SourcesTrigger = ({
+  className,
+  count,
+  children,
+  ...props
+}: SourcesTriggerProps) => (
+  <CollapsibleTrigger
+    className={cn("flex items-center gap-2", className)}
+    {...props}
+  >
+    {children ?? (
+      <>
+        <p className="font-medium">Used {count} sources</p>
+        <ChevronDownIcon className="h-4 w-4" />
+      </>
+    )}
+  </CollapsibleTrigger>
+);
+
+export type SourcesContentProps = ComponentProps<typeof CollapsibleContent>;
+
+export const SourcesContent = ({
+  className,
+  ...props
+}: SourcesContentProps) => (
+  <CollapsibleContent
+    className={cn(
+      "mt-3 flex w-fit flex-col gap-2",
+      "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+      className
+    )}
+    {...props}
+  />
+);
+
+export type SourceProps = ComponentProps<"a">;
+
+export const Source = ({ href, title, children, ...props }: SourceProps) => (
+  <a
+    className="flex items-center gap-2"
+    href={href}
+    rel="noreferrer"
+    target="_blank"
+    {...props}
+  >
+    {children ?? (
+      <>
+        <BookIcon className="h-4 w-4" />
+        <span className="block font-medium">{title}</span>
+      </>
+    )}
+  </a>
+);

--- a/components/ai-elements/tool.tsx
+++ b/components/ai-elements/tool.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import type { ToolUIPart } from "ai";
+import {
+  CheckCircleIcon,
+  ChevronDownIcon,
+  CircleIcon,
+  ClockIcon,
+  WrenchIcon,
+  XCircleIcon,
+} from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
+import { isValidElement } from "react";
+import { CodeBlock } from "./code-block";
+
+export type ToolProps = ComponentProps<typeof Collapsible>;
+
+export const Tool = ({ className, ...props }: ToolProps) => (
+  <Collapsible
+    className={cn("not-prose mb-4 w-full rounded-md border", className)}
+    {...props}
+  />
+);
+
+export type ToolHeaderProps = {
+  title?: string;
+  type: ToolUIPart["type"];
+  state: ToolUIPart["state"];
+  className?: string;
+};
+
+const getStatusBadge = (status: ToolUIPart["state"]) => {
+  const labels: Record<ToolUIPart["state"], string> = {
+    "input-streaming": "Pending",
+    "input-available": "Running",
+    // These states exist in AI SDK 7; the upstream directive assumed v6.
+    "approval-requested": "Awaiting Approval",
+    "approval-responded": "Responded",
+    "output-available": "Completed",
+    "output-error": "Error",
+    "output-denied": "Denied",
+  };
+
+  const icons: Record<ToolUIPart["state"], ReactNode> = {
+    "input-streaming": <CircleIcon className="size-4" />,
+    "input-available": <ClockIcon className="size-4 animate-pulse" />,
+    // These states exist in AI SDK 7; the upstream directive assumed v6.
+    "approval-requested": <ClockIcon className="size-4 text-yellow-600" />,
+    "approval-responded": <CheckCircleIcon className="size-4 text-blue-600" />,
+    "output-available": <CheckCircleIcon className="size-4 text-green-600" />,
+    "output-error": <XCircleIcon className="size-4 text-red-600" />,
+    "output-denied": <XCircleIcon className="size-4 text-orange-600" />,
+  };
+
+  return (
+    <Badge className="gap-1.5 rounded-full text-xs" variant="secondary">
+      {icons[status]}
+      {labels[status]}
+    </Badge>
+  );
+};
+
+export const ToolHeader = ({
+  className,
+  title,
+  type,
+  state,
+  ...props
+}: ToolHeaderProps) => (
+  <CollapsibleTrigger
+    className={cn(
+      "flex w-full items-center justify-between gap-4 p-3",
+      className
+    )}
+    {...props}
+  >
+    <div className="flex items-center gap-2">
+      <WrenchIcon className="size-4 text-muted-foreground" />
+      <span className="font-medium text-sm">
+        {title ?? type.split("-").slice(1).join("-")}
+      </span>
+      {getStatusBadge(state)}
+    </div>
+    <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+  </CollapsibleTrigger>
+);
+
+export type ToolContentProps = ComponentProps<typeof CollapsibleContent>;
+
+export const ToolContent = ({ className, ...props }: ToolContentProps) => (
+  <CollapsibleContent
+    className={cn(
+      "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+      className
+    )}
+    {...props}
+  />
+);
+
+export type ToolInputProps = ComponentProps<"div"> & {
+  input: ToolUIPart["input"];
+};
+
+export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
+  <div className={cn("space-y-2 overflow-hidden p-4", className)} {...props}>
+    <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+      Parameters
+    </h4>
+    <div className="rounded-md bg-muted/50">
+      <CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
+    </div>
+  </div>
+);
+
+export type ToolOutputProps = ComponentProps<"div"> & {
+  output: ToolUIPart["output"];
+  errorText: ToolUIPart["errorText"];
+};
+
+export const ToolOutput = ({
+  className,
+  output,
+  errorText,
+  ...props
+}: ToolOutputProps) => {
+  if (!(output || errorText)) {
+    return null;
+  }
+
+  let Output = <div>{output as ReactNode}</div>;
+
+  if (typeof output === "object" && !isValidElement(output)) {
+    Output = (
+      <CodeBlock code={JSON.stringify(output, null, 2)} language="json" />
+    );
+  } else if (typeof output === "string") {
+    Output = <CodeBlock code={output} language="json" />;
+  }
+
+  return (
+    <div className={cn("space-y-2 p-4", className)} {...props}>
+      <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        {errorText ? "Error" : "Result"}
+      </h4>
+      <div
+        className={cn(
+          "overflow-x-auto rounded-md text-xs [&_table]:w-full",
+          errorText
+            ? "bg-destructive/10 text-destructive"
+            : "bg-muted/50 text-foreground"
+        )}
+      >
+        {errorText && <div>{errorText}</div>}
+        {Output}
+      </div>
+    </div>
+  );
+};

--- a/components/chat/chat.css
+++ b/components/chat/chat.css
@@ -1,0 +1,87 @@
+/* ============================================================================
+ * /chat — AI Elements on the site's global theme.
+ *
+ * Colour needs no remapping: the shadcn tokens AI Elements consume
+ * (--background, --foreground, --secondary, --border, --primary …) are already
+ * bound to the Zed palette in app/globals.css, so the components inherit the
+ * site's dark theme as-is.
+ *
+ * What is missing is typography and edge treatment. The stock components are
+ * sans-serif with pill radii; the rest of the site is mono with 7-10px corners.
+ * Everything below is scoped to `.br-chat` so it cannot leak into the docs or
+ * landing pages, and it styles AI Elements from the outside rather than
+ * editing their files — so `shadcn add` can update them later without
+ * clobbering this.
+ * ========================================================================== */
+
+.br-chat {
+  font-family: var(--font-mono);
+}
+
+/* Full-viewport app shell.
+ *
+ * `--fd-nav-height` is only defined by fumadocs' DocsLayout, not the HomeLayout
+ * this page uses — referencing it bare makes the calc() invalid, which drops
+ * the height declaration entirely and lets the shell collapse to its content.
+ * The fallback is the site header: `h-12` plus its 1px bottom border. Keep the
+ * var first so the docs layout still wins if this ever moves there. */
+.br-chat-shell {
+  height: calc(100dvh - var(--fd-nav-height, 49px));
+}
+
+/* Prose inside assistant replies: mono headings/labels, readable body. */
+.br-chat .prose,
+.br-chat [class*="prose"] {
+  font-family: inherit;
+}
+
+.br-chat h1,
+.br-chat h2,
+.br-chat h3,
+.br-chat h4 {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--z-ink-bright, var(--foreground));
+}
+
+/* Streamdown code blocks — match the site's inset code wells. */
+.br-chat pre {
+  background: var(--z-inset, var(--secondary));
+  border: 1px solid var(--z-rule-code, var(--border));
+  border-radius: 8px;
+}
+
+.br-chat :not(pre) > code {
+  font-family: var(--font-mono);
+  color: var(--z-code, var(--primary));
+}
+
+/* User bubbles: inset well + hairline, instead of the stock filled pill. */
+.br-chat .is-user > div {
+  background: var(--z-inset, var(--secondary));
+  border: 1px solid var(--z-rule-code, var(--border));
+  border-radius: 10px;
+}
+
+/* Composer + popovers: square off the stock radii toward the Zed language. */
+.br-chat [data-slot="input-group"] {
+  border-radius: 10px;
+  background: var(--z-inset, var(--secondary));
+  border-color: var(--z-rule-code, var(--border));
+}
+
+.br-chat textarea {
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.br-chat textarea::placeholder {
+  color: var(--z-ink-6, var(--muted-foreground));
+}
+
+/* Links in replies pick up the site's blue rather than the default. */
+.br-chat a {
+  color: var(--z-blue, var(--primary));
+  text-underline-offset: 2px;
+}

--- a/components/chat/playground.tsx
+++ b/components/chat/playground.tsx
@@ -1,0 +1,492 @@
+"use client";
+
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport, getToolName, isStaticToolUIPart } from "ai";
+import { BotIcon, CpuIcon, RefreshCwIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  Conversation,
+  ConversationContent,
+  ConversationEmptyState,
+  ConversationScrollButton,
+} from "@/components/ai-elements/conversation";
+import {
+  Context,
+  ContextCacheUsage,
+  ContextContent,
+  ContextContentBody,
+  ContextContentHeader,
+  ContextInputUsage,
+  ContextOutputUsage,
+  ContextTrigger,
+} from "@/components/ai-elements/context";
+import { Loader } from "@/components/ai-elements/loader";
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from "@/components/ai-elements/message";
+import {
+  PromptInput,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputSelect,
+  PromptInputSelectContent,
+  PromptInputSelectItem,
+  PromptInputSelectTrigger,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputTools,
+} from "@/components/ai-elements/prompt-input";
+import {
+  Tool,
+  ToolContent,
+  ToolHeader,
+  ToolInput,
+  ToolOutput,
+} from "@/components/ai-elements/tool";
+import { ProviderIcon } from "@/components/models/provider-icon";
+import {
+  CHAT_MODELS,
+  type ChatUIMessage,
+  DEFAULT_CHAT_MODEL,
+  getChatModel,
+} from "@/lib/chat-models";
+import { cn } from "@/lib/cn";
+import {
+  DEFAULT_HARNESS,
+  getHarness,
+  type HarnessId,
+  type HarnessOption,
+  resetsHistory,
+} from "@/lib/harnesses";
+
+import { SessionsSidebar } from "./sessions-sidebar";
+import { useSessions } from "./use-sessions";
+
+/** What each harness is, in the words of the empty conversation. */
+const EMPTY_STATE: Record<HarnessId, string> = {
+  "ai-sdk":
+    "The AI SDK's own agent loop. It plans a short sequence of documentation searches, reads the pages it finds, and answers with citations — routed through BitRouter on the model you pick.",
+  pi: "Pi drives its own agent loop with a scratch shell and filesystem, plus BitRouter's documentation tools. It remembers the conversation itself, so switching model starts a new chat.",
+  "claude-code":
+    "Claude Code as an agent runtime, run against Anthropic's own API rather than through the router.",
+  codex:
+    "Codex as an agent runtime, run against OpenAI's own API rather than through the router.",
+  opencode:
+    "OpenCode as an agent runtime, run against its own provider rather than through the router.",
+  "bitrouter-claude-acp":
+    "Claude Code, driven by BitRouter over ACP and routed to the model you pick. Same runtime as the entry above — the difference is whose endpoint it talks to.",
+  "bitrouter-codex-acp":
+    "Codex, driven by BitRouter over ACP and routed to the model you pick. Same runtime as the entry above — the difference is whose endpoint it talks to.",
+  "bitrouter-gemini-cli":
+    "Gemini CLI, driven by BitRouter over ACP and routed to the model you pick.",
+  "bitrouter-pi-acp":
+    "Pi, driven by BitRouter over ACP and routed to the model you pick. Unlike the in-process Pi entry, this one runs in a sandbox VM with a real shell.",
+};
+
+export type PlaygroundConfig = {
+  /**
+   * The harness axis, with per-deployment availability resolved on the server.
+   * Unavailable entries still render, greyed out with their reason.
+   */
+  harnesses: HarnessOption[];
+};
+
+export function ChatPlayground({ harnesses }: PlaygroundConfig) {
+  const store = useSessions(DEFAULT_CHAT_MODEL);
+  const { active, sessions, activeId, ready, setActiveId, startSession } = store;
+
+  const [model, setModel] = useState(DEFAULT_CHAT_MODEL);
+  const [harness, setHarness] = useState<HarnessId>(DEFAULT_HARNESS);
+
+  // Live values for the transport, which is constructed once.
+  const modelRef = useRef(model);
+  modelRef.current = model;
+
+  const harnessRef = useRef(harness);
+  harnessRef.current = harness;
+
+  // Session-backed harnesses key their server-side history off this id. The
+  // stateless loop ignores it.
+  const activeIdRef = useRef(activeId);
+  activeIdRef.current = activeId;
+
+  const { messages, sendMessage, status, stop, error, setMessages, regenerate } =
+    useChat<ChatUIMessage>({
+      transport: new DefaultChatTransport({
+        api: "/api/chat/playground",
+        body: () => ({
+          model: modelRef.current,
+          harness: harnessRef.current,
+          sessionId: activeIdRef.current,
+        }),
+      }),
+    });
+
+  const isBusy = status === "streaming" || status === "submitted";
+
+  // Swapping sessions swaps the transcript and both of its axes together.
+  const loadedId = useRef<string | null>(null);
+  useEffect(() => {
+    if (!ready || activeId === loadedId.current) return;
+    loadedId.current = activeId;
+    setMessages(active?.messages ?? []);
+    if (active) {
+      setModel(active.model);
+      setHarness(active.harness);
+    }
+  }, [active, activeId, ready, setMessages]);
+
+  // Persist the transcript once a turn settles, not on every token.
+  const { saveMessages } = store;
+  useEffect(() => {
+    if (!activeId || isBusy || messages.length === 0) return;
+    saveMessages(messages, { model, harness });
+  }, [activeId, harness, isBusy, messages, model, saveMessages]);
+
+  const activeModel = getChatModel(model);
+  const activeHarness = harnesses.find((h) => h.id === harness);
+
+  const usage = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const meta = messages[i].metadata;
+      if (meta?.usage) return meta.usage;
+    }
+    return undefined;
+  }, [messages]);
+
+  const usedTokens = (usage?.inputTokens ?? 0) + (usage?.outputTokens ?? 0);
+
+  /**
+   * Apply a change to either axis, starting a fresh chat when the current
+   * runtime could not honour it.
+   *
+   * A session-backed harness owns the conversation and binds its model when the
+   * session is built, so changing either axis gives it an empty history — while
+   * the transcript on screen still shows the earlier turns. Rather than leave
+   * the user talking to an agent that remembers none of it, the switch opens a
+   * new chat. The stateless loop replays the transcript every turn, so it can
+   * change model mid-conversation freely.
+   */
+  const applyAxes = useCallback(
+    (next: { model?: string; harness?: HarnessId }) => {
+      const nextModel = next.model ?? model;
+      const nextHarness = next.harness ?? harness;
+
+      setModel(nextModel);
+      setHarness(nextHarness);
+
+      const wouldReset = resetsHistory({
+        fromHarness: harness,
+        toHarness: nextHarness,
+        modelChanged: nextModel !== model,
+      });
+
+      if (wouldReset && messages.length > 0) {
+        setMessages([]);
+        const session = startSession(nextModel, nextHarness);
+        loadedId.current = session.id;
+        activeIdRef.current = session.id;
+      }
+    },
+    [harness, messages.length, model, setMessages, startSession],
+  );
+
+  const onSend = useCallback(
+    (text: string) => {
+      if (!activeId) {
+        const session = startSession(model, harness);
+        // Claim the new session as already-loaded. Without this, the
+        // session-load effect sees activeId change and calls setMessages with
+        // the (empty) stored transcript, wiping the message we are about to
+        // send — the user's turn would vanish and the session would keep its
+        // placeholder title.
+        loadedId.current = session.id;
+        // The transport reads this synchronously on the send below, before
+        // React has re-rendered with the new activeId.
+        activeIdRef.current = session.id;
+      }
+      void sendMessage({ text });
+    },
+    [activeId, harness, model, sendMessage, startSession],
+  );
+
+  return (
+    <div className="br-chat flex min-h-0 flex-1">
+      <SessionsSidebar
+        activeId={activeId}
+        className="hidden md:flex"
+        onDelete={store.deleteSession}
+        onNew={() => {
+          setMessages([]);
+          startSession(model, harness);
+        }}
+        onSelect={setActiveId}
+        sessions={sessions}
+      />
+
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <Conversation className="min-h-0 flex-1">
+          <ConversationContent className="mx-auto w-full max-w-3xl">
+            {messages.length === 0 && !error && (
+              <ConversationEmptyState
+                description={EMPTY_STATE[harness]}
+                icon={<BotIcon className="size-5" />}
+                title={`${activeHarness?.label ?? "Agent"} · ${activeModel?.label ?? "any model"}`}
+              />
+            )}
+
+            {messages.map((message) => (
+              <Message from={message.role} key={message.id}>
+                <MessageContent>
+                  {message.parts.map((part, i) => {
+                    const key = `${message.id}-${i}`;
+
+                    if (part.type === "text") {
+                      return (
+                        <MessageResponse key={key}>{part.text}</MessageResponse>
+                      );
+                    }
+
+                    // Static only: agent tools are declared server-side, so a
+                    // dynamic-tool part would mean something unexpected.
+                    if (isStaticToolUIPart(part)) {
+                      return (
+                        <Tool key={key}>
+                          <ToolHeader
+                            state={part.state}
+                            title={getToolName(part)}
+                            type={part.type}
+                          />
+                          <ToolContent>
+                            <ToolInput input={part.input} />
+                            <ToolOutput
+                              errorText={part.errorText}
+                              output={part.output}
+                            />
+                          </ToolContent>
+                        </Tool>
+                      );
+                    }
+
+                    return null;
+                  })}
+                </MessageContent>
+                {message.role === "assistant" && message.metadata?.model && (
+                  <MessageFooter
+                    harnessId={message.metadata.harness}
+                    modelId={message.metadata.model}
+                  />
+                )}
+              </Message>
+            ))}
+
+            {isBusy && messages.at(-1)?.role === "user" && (
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader size={14} />
+                <span className="font-mono text-[12px]">Planning…</span>
+              </div>
+            )}
+
+            {error && (
+              <div className="rounded-[10px] border border-border bg-secondary p-3">
+                <p className="mb-1 font-mono text-[11px] uppercase tracking-widest text-destructive">
+                  Request failed
+                </p>
+                <p className="text-[13px] text-muted-foreground">
+                  {error.message}
+                </p>
+                <button
+                  className="mt-2 flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                  onClick={() => regenerate()}
+                  type="button"
+                >
+                  <RefreshCwIcon className="size-3.5" />
+                  Retry
+                </button>
+              </div>
+            )}
+          </ConversationContent>
+          <ConversationScrollButton />
+        </Conversation>
+
+        <div className="border-t border-border px-4 py-3 sm:px-6">
+          <PromptInput
+            className="mx-auto w-full max-w-3xl"
+            onSubmit={(message) => {
+              const text = message.text.trim();
+              if (!text || isBusy) return;
+              onSend(text);
+            }}
+          >
+            <PromptInputBody>
+              <PromptInputTextarea placeholder="Ask the agent to research something…" />
+            </PromptInputBody>
+            <PromptInputFooter>
+              <PromptInputTools>
+                <PromptInputSelect
+                  onValueChange={(value) =>
+                    applyAxes({ harness: value as HarnessId })
+                  }
+                  value={harness}
+                >
+                  <PromptInputSelectTrigger className="gap-1.5 font-mono text-[12px]">
+                    <CpuIcon className="size-3.5 text-primary" />
+                    {activeHarness?.label ?? harness}
+                  </PromptInputSelectTrigger>
+                  <PromptInputSelectContent
+                    align="start"
+                    position="popper"
+                    side="top"
+                    sideOffset={6}
+                  >
+                    {harnesses.map((h) => (
+                      // Unavailable harnesses stay listed rather than hidden:
+                      // the picker is the clearest statement of what the
+                      // product is, and the reason tells an operator exactly
+                      // what is missing.
+                      <PromptInputSelectItem
+                        disabled={!h.available}
+                        key={h.id}
+                        value={h.id}
+                      >
+                        <span className="flex w-full items-center gap-2">
+                          <span className="min-w-24 font-mono text-[13px]">
+                            {h.label}
+                          </span>
+                          <span className="font-mono text-[11px] text-muted-foreground">
+                            {h.available ? h.blurb : h.reason}
+                          </span>
+                        </span>
+                      </PromptInputSelectItem>
+                    ))}
+                  </PromptInputSelectContent>
+                </PromptInputSelect>
+
+                <PromptInputSelect
+                  onValueChange={(value) => applyAxes({ model: value })}
+                  value={model}
+                >
+                  {/* The trigger renders the label directly rather than via
+                      PromptInputSelectValue: Radix clones the selected item's
+                      children into the trigger, which would drag the price
+                      column in with it. */}
+                  <PromptInputSelectTrigger className="gap-1.5 font-mono text-[12px]">
+                    {activeModel && (
+                      <>
+                        <ProviderIcon provider={activeModel.provider} size={13} />
+                        {activeModel.label}
+                      </>
+                    )}
+                  </PromptInputSelectTrigger>
+                  {/* `position="popper"` anchors the list to the trigger.
+                      shadcn's SelectContent defaults to "item-aligned", which
+                      tries to place the selected row over the trigger — with
+                      the composer near the bottom of the viewport that shoves
+                      the whole list up over the site header. */}
+                  <PromptInputSelectContent
+                    align="start"
+                    position="popper"
+                    side="top"
+                    sideOffset={6}
+                  >
+                    {CHAT_MODELS.map((m) => (
+                      <PromptInputSelectItem key={m.id} value={m.id}>
+                        {/* Radix shrink-wraps each item box, so `ml-auto`
+                            alone leaves the price column ragged. Pinning the
+                            label width starts every price at the same x. */}
+                        <span className="flex items-center gap-2">
+                          <ProviderIcon provider={m.provider} size={13} />
+                          <span className="min-w-36 font-mono text-[13px]">
+                            {m.label}
+                          </span>
+                          <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                            ${m.inputUsdPerM}/${m.outputUsdPerM} per M
+                          </span>
+                        </span>
+                      </PromptInputSelectItem>
+                    ))}
+                  </PromptInputSelectContent>
+                </PromptInputSelect>
+
+                {usage && activeModel && (
+                  <Context
+                    maxTokens={activeModel.contextWindow}
+                    modelId={activeModel.id}
+                    usage={usage}
+                    usedTokens={usedTokens}
+                  >
+                    <ContextTrigger />
+                    <ContextContent>
+                      <ContextContentHeader />
+                      <ContextContentBody>
+                        <div className="space-y-2">
+                          <ContextInputUsage />
+                          <ContextOutputUsage />
+                          <ContextCacheUsage />
+                        </div>
+                      </ContextContentBody>
+                    </ContextContent>
+                  </Context>
+                )}
+              </PromptInputTools>
+              <PromptInputSubmit
+                onClick={isBusy ? () => stop() : undefined}
+                status={status}
+                type={isBusy ? "button" : "submit"}
+              />
+            </PromptInputFooter>
+          </PromptInput>
+
+          <p className="mx-auto mt-2 w-full max-w-3xl text-center font-mono text-[11px] text-muted-foreground/70">
+            Responses are generated by third-party models routed through
+            BitRouter. Verify anything important.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Both axes, attributed per turn — the transcript can span several of each. */
+function MessageFooter({
+  modelId,
+  harnessId,
+}: {
+  modelId: string;
+  harnessId?: HarnessId;
+}) {
+  const model = getChatModel(modelId);
+  if (!model) return null;
+
+  const harness = harnessId ? getHarness(harnessId) : undefined;
+
+  return (
+    <p className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-muted-foreground/70">
+      <ProviderIcon provider={model.provider} size={11} />
+      {model.label}
+      {harness && (
+        <>
+          <span aria-hidden className="text-muted-foreground/40">
+            ·
+          </span>
+          {harness.label}
+        </>
+      )}
+    </p>
+  );
+}
+
+/** Full-viewport shell: the conversation scrolls, the composer stays pinned. */
+export function ChatShell({
+  className,
+  ...config
+}: { className?: string } & PlaygroundConfig) {
+  return (
+    <div className={cn("br-chat-shell flex flex-col", className)}>
+      <ChatPlayground {...config} />
+    </div>
+  );
+}

--- a/components/chat/playground.tsx
+++ b/components/chat/playground.tsx
@@ -2,7 +2,7 @@
 
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, getToolName, isStaticToolUIPart } from "ai";
-import { BotIcon, CpuIcon, RefreshCwIcon } from "lucide-react";
+import { BotIcon, CpuIcon, LogInIcon, RefreshCwIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -47,6 +47,7 @@ import {
   ToolOutput,
 } from "@/components/ai-elements/tool";
 import { ProviderIcon } from "@/components/models/provider-icon";
+import { authClient } from "@/lib/auth-client";
 import {
   CHAT_MODELS,
   type ChatUIMessage,
@@ -64,6 +65,13 @@ import {
 
 import { SessionsSidebar } from "./sessions-sidebar";
 import { useSessions } from "./use-sessions";
+
+/**
+ * Where a signed-out visitor is sent. Social sign-in auto-creates the account,
+ * so this one route covers sign-in and sign-up — same CTA the header uses.
+ */
+const CONSOLE_URL =
+  process.env.NEXT_PUBLIC_CONSOLE_URL ?? "https://cloud.bitrouter.ai";
 
 /** What each harness is, in the words of the empty conversation. */
 const EMPTY_STATE: Record<HarnessId, string> = {
@@ -92,11 +100,29 @@ export type PlaygroundConfig = {
    * Unavailable entries still render, greyed out with their reason.
    */
   harnesses: HarnessOption[];
+  /**
+   * Whether turns are billed to a signed-in visitor rather than to the site's
+   * own key. Drives the composer's sign-in prompt — which is advisory only, and
+   * exists so a signed-out visitor is told why before they type a paragraph
+   * rather than after. The route handler is what actually refuses.
+   */
+  requiresAuth?: boolean;
 };
 
-export function ChatPlayground({ harnesses }: PlaygroundConfig) {
+export function ChatPlayground({ harnesses, requiresAuth }: PlaygroundConfig) {
   const store = useSessions(DEFAULT_CHAT_MODEL);
   const { active, sessions, activeId, ready, setActiveId, startSession } = store;
+
+  // Read cross-origin from the console, same shared session the header uses.
+  const { data: session, isPending: sessionPending } = authClient.useSession();
+  // Only while we genuinely do not know: `isPending` is false once the console
+  // has answered, so a signed-out visitor is gated rather than left waiting.
+  const needsSignIn = Boolean(requiresAuth) && !sessionPending && !session;
+
+  // Read in an effect, not during render: this component is server-rendered and
+  // `window.location` would differ between the two passes.
+  const [returnTo, setReturnTo] = useState("");
+  useEffect(() => setReturnTo(window.location.href), []);
 
   const [model, setModel] = useState(DEFAULT_CHAT_MODEL);
   const [harness, setHarness] = useState<HarnessId>(DEFAULT_HARNESS);
@@ -196,6 +222,9 @@ export function ChatPlayground({ harnesses }: PlaygroundConfig) {
 
   const onSend = useCallback(
     (text: string) => {
+      // Belt and braces with the disabled composer: the route would 401 anyway,
+      // but sending would burn the typed turn against an error bubble.
+      if (needsSignIn) return;
       if (!activeId) {
         const session = startSession(model, harness);
         // Claim the new session as already-loaded. Without this, the
@@ -210,7 +239,7 @@ export function ChatPlayground({ harnesses }: PlaygroundConfig) {
       }
       void sendMessage({ text });
     },
-    [activeId, harness, model, sendMessage, startSession],
+    [activeId, harness, model, needsSignIn, sendMessage, startSession],
   );
 
   return (
@@ -313,6 +342,21 @@ export function ChatPlayground({ harnesses }: PlaygroundConfig) {
         </Conversation>
 
         <div className="border-t border-border px-4 py-3 sm:px-6">
+          {needsSignIn && (
+            <div className="mx-auto mb-2 flex w-full max-w-3xl flex-wrap items-center gap-x-2 gap-y-1 rounded-[10px] border border-border bg-secondary px-3 py-2">
+              <LogInIcon className="size-3.5 shrink-0 text-primary" />
+              <p className="text-[13px] text-muted-foreground">
+                Sign in to run the playground — turns are billed to your account.
+              </p>
+              <a
+                className="font-mono text-[12px] text-primary underline-offset-4 hover:underline"
+                href={`${CONSOLE_URL}/sign-in?returnTo=${encodeURIComponent(returnTo)}`}
+              >
+                Sign in
+              </a>
+            </div>
+          )}
+
           <PromptInput
             className="mx-auto w-full max-w-3xl"
             onSubmit={(message) => {
@@ -322,7 +366,14 @@ export function ChatPlayground({ harnesses }: PlaygroundConfig) {
             }}
           >
             <PromptInputBody>
-              <PromptInputTextarea placeholder="Ask the agent to research something…" />
+              <PromptInputTextarea
+                disabled={needsSignIn}
+                placeholder={
+                  needsSignIn
+                    ? "Sign in to run the playground…"
+                    : "Ask the agent to research something…"
+                }
+              />
             </PromptInputBody>
             <PromptInputFooter>
               <PromptInputTools>
@@ -433,6 +484,7 @@ export function ChatPlayground({ harnesses }: PlaygroundConfig) {
                 )}
               </PromptInputTools>
               <PromptInputSubmit
+                disabled={needsSignIn}
                 onClick={isBusy ? () => stop() : undefined}
                 status={status}
                 type={isBusy ? "button" : "submit"}

--- a/components/chat/sessions-sidebar.tsx
+++ b/components/chat/sessions-sidebar.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { BotIcon, PlusIcon, Trash2Icon } from "lucide-react";
+
+import type { ChatSession } from "@/lib/chat-sessions";
+import { cn } from "@/lib/cn";
+
+export function SessionsSidebar({
+  sessions,
+  activeId,
+  onSelect,
+  onNew,
+  onDelete,
+  className,
+}: {
+  sessions: ChatSession[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  onDelete: (id: string) => void;
+  className?: string;
+}) {
+  return (
+    <aside
+      className={cn(
+        "flex w-60 shrink-0 flex-col border-r border-border",
+        className,
+      )}
+    >
+      <div className="border-b border-border p-2">
+        <button
+          className="flex w-full items-center gap-2 rounded-[7px] border border-border bg-secondary px-2.5 py-2 font-mono text-[12px] text-foreground transition-colors hover:border-ring/40"
+          onClick={onNew}
+          type="button"
+        >
+          <PlusIcon className="size-3.5" />
+          New chat
+        </button>
+      </div>
+
+      <div className="fd-scroll-container min-h-0 flex-1 overflow-y-auto p-2">
+        {sessions.length === 0 ? (
+          <p className="px-1 py-3 font-mono text-[11px] text-muted-foreground">
+            No saved chats yet.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-0.5">
+            {sessions.map((session) => (
+              <li key={session.id}>
+                <div
+                  className={cn(
+                    "group flex items-center gap-1.5 rounded-[7px] px-2 py-1.5 transition-colors",
+                    session.id === activeId
+                      ? "bg-secondary text-foreground"
+                      : "text-muted-foreground hover:bg-secondary/60",
+                  )}
+                >
+                  <button
+                    className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                    onClick={() => onSelect(session.id)}
+                    type="button"
+                  >
+                    <BotIcon className="size-3.5 shrink-0 text-primary" />
+                    <span className="truncate font-mono text-[12px]">
+                      {session.title}
+                    </span>
+                  </button>
+
+                  <button
+                    aria-label={`Delete ${session.title}`}
+                    className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                    onClick={() => onDelete(session.id)}
+                    type="button"
+                  >
+                    <Trash2Icon className="size-3.5 hover:text-destructive" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <p className="border-t border-border px-3 py-2 font-mono text-[10px] leading-relaxed text-muted-foreground/70">
+        Chats are stored in this browser only.
+      </p>
+    </aside>
+  );
+}

--- a/components/chat/use-sessions.ts
+++ b/components/chat/use-sessions.ts
@@ -1,0 +1,151 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { ChatUIMessage } from "@/lib/chat-models";
+import type { HarnessId } from "@/lib/harnesses";
+import {
+  type ChatSession,
+  createSession,
+  deriveTitle,
+  parseStore,
+  pruneEmptySessions,
+  removeSession,
+  serializeStore,
+  STORAGE_KEY,
+  upsertSession,
+} from "@/lib/chat-sessions";
+
+function newId() {
+  return globalThis.crypto?.randomUUID?.() ?? `s-${Date.now()}`;
+}
+
+/**
+ * Session list backed by `localStorage`.
+ *
+ * Hydration: sessions load in an effect rather than during render, so the
+ * server-rendered markup and the first client render agree. `ready` lets the
+ * UI avoid flashing an empty sidebar before the read completes.
+ */
+export function useSessions(defaultModel: string) {
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const stored = parseStore(localStorage.getItem(STORAGE_KEY)).sessions;
+    setSessions(stored);
+    setActiveId(stored[0]?.id ?? null);
+    setReady(true);
+  }, []);
+
+  const persist = useCallback(
+    (next: ChatSession[]) => {
+      setSessions(next);
+      try {
+        localStorage.setItem(STORAGE_KEY, serializeStore(next));
+      } catch {
+        // Quota exceeded or storage disabled — keep the in-memory list working
+        // rather than breaking the chat.
+      }
+    },
+    [],
+  );
+
+  const active = sessions.find((s) => s.id === activeId) ?? null;
+
+  const startSession = useCallback(
+    (model: string, harness: HarnessId) => {
+      // Reuse an untouched session rather than stacking up empty rows when
+      // "New chat" is clicked repeatedly.
+      const existingEmpty = sessions.find((s) => s.messages.length === 0);
+      if (existingEmpty) {
+        const reused = {
+          ...existingEmpty,
+          model,
+          harness,
+          updatedAt: Date.now(),
+        };
+        setActiveId(reused.id);
+        persist(upsertSession(pruneEmptySessions(sessions, reused.id), reused));
+        return reused;
+      }
+
+      const session = createSession({
+        id: newId(),
+        model,
+        harness,
+        now: Date.now(),
+      });
+      setActiveId(session.id);
+      persist(upsertSession(pruneEmptySessions(sessions), session));
+      return session;
+    },
+    [persist, sessions],
+  );
+
+  /** Writes the live transcript back into the active session. */
+  const saveMessages = useCallback(
+    (messages: ChatUIMessage[], patch?: Partial<ChatSession>) => {
+      setSessions((current) => {
+        const target = current.find((s) => s.id === activeId);
+        if (!target) return current;
+
+        const updated: ChatSession = {
+          ...target,
+          ...patch,
+          messages,
+          title:
+            target.title === "New chat" ? deriveTitle(messages) : target.title,
+          updatedAt: Date.now(),
+        };
+
+        const next = upsertSession(current, updated);
+        try {
+          localStorage.setItem(STORAGE_KEY, serializeStore(next));
+        } catch {
+          // See persist().
+        }
+        return next;
+      });
+    },
+    [activeId],
+  );
+
+  const deleteSession = useCallback(
+    (id: string) => {
+      const next = removeSession(sessions, id);
+      persist(next);
+      if (activeId === id) setActiveId(next[0]?.id ?? null);
+    },
+    [activeId, persist, sessions],
+  );
+
+  const renameSession = useCallback(
+    (id: string, title: string) => {
+      const target = sessions.find((s) => s.id === id);
+      if (!target) return;
+      persist(upsertSession(sessions, { ...target, title }));
+    },
+    [persist, sessions],
+  );
+
+  const clearAll = useCallback(() => {
+    persist([]);
+    setActiveId(null);
+  }, [persist]);
+
+  return {
+    sessions,
+    active,
+    activeId,
+    ready,
+    defaultModel,
+    setActiveId,
+    startSession,
+    saveMessages,
+    deleteSession,
+    renameSession,
+    clearAll,
+  };
+}

--- a/components/ui/button-group.tsx
+++ b/components/ui/button-group.tsx
@@ -1,0 +1,83 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Separator } from "@/components/ui/separator"
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+        vertical:
+          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  }
+)
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupText({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "div"
+
+  return (
+    <Comp
+      className={cn(
+        "flex items-center gap-2 rounded-md border bg-muted px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        "relative m-0! self-stretch bg-input data-[orientation=vertical]:h-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+  buttonGroupVariants,
+}

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/components/ui/hover-card.tsx
+++ b/components/ui/hover-card.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+import { HoverCard as HoverCardPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function HoverCard({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
+}
+
+function HoverCardTrigger({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return (
+    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  )
+}
+
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  )
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/components/ui/input-group.tsx
+++ b/components/ui/input-group.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex w-full items-center rounded-md border border-input shadow-xs transition-[color,box-shadow] outline-none dark:bg-input/30",
+        "h-9 min-w-0 has-[>textarea]:h-auto",
+
+        // Variants based on alignment.
+        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+        "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
+        "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
+
+        // Focus state.
+        "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50",
+
+        // Error state.
+        "has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",
+
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+        "inline-end":
+          "order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]",
+        "block-start":
+          "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3",
+        "block-end":
+          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus()
+      }}
+      {...props}
+    />
+  )
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size"> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { Progress as ProgressPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="h-full w-full flex-1 bg-primary transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+}
+
+export { Progress }

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/docs/bitrouter-acp-harness-plan.md
+++ b/docs/bitrouter-acp-harness-plan.md
@@ -1,0 +1,452 @@
+# BitRouter as an AI SDK harness, via ACP
+
+Plan for exposing BitRouter's agent catalog (`claude-acp`, `codex-acp`,
+`gemini-cli`, `pi-acp`) to the AI SDK through `@ai-sdk/harness-acp`, so the
+`/chat` playground's harness axis is BitRouter's own rather than a wrapper
+around Vercel's four adapters.
+
+Status: **for review, not started.**
+
+---
+
+## 1. Headline
+
+`@ai-sdk/harness-acp` is the AI SDK's generic harness adapter: you declare an
+npm-installable ACP v1 agent and get a `HarnessV1` back. `@ai-sdk/harness-grok-build`
+is nothing but a `createACP()` call, which is the intended pattern.
+
+**BitRouter already satisfies the contract for fresh sessions.** The one
+capability it fails — session restoration — is only checked when the harness is
+*resuming*, not when it opens a new session. So there is a real Phase 1 that
+needs zero Rust changes, and the Rust work is deferred to Phase 2 where it buys
+something concrete (reattach across process restarts).
+
+---
+
+## 2. Verified gap analysis
+
+Checked against `@ai-sdk/harness-acp@1.0.1` (which ships its TypeScript source)
+and the `bitrouter` main tree.
+
+| # | Bridge requires | BitRouter today | Status |
+|---|---|---|---|
+| 1 | Agent resolvable at `node_modules/.bin/<executable>` | npm `bitrouter@1.0.0-alpha.27`, `bin: { bitrouter: "run-bitrouter.js" }` | ✅ |
+| 2 | `initialize` returns **exactly** `protocolVersion: 1` | `down.rs:225` echoes the caller's version back | ✅ |
+| 3 | `authMethods` advertises the configured `methodId` | Not relayed; `authenticate` answers method-not-found (`down.rs:196`) | ✅ *avoidable* |
+| 4 | `sessionCapabilities.resume` or `loadSession: true` | `relayed_caps.load_session = false` (`down.rs:201`), no `session/resume` | ❌ **only on resume** |
+| 5 | `session/new` accepts `cwd` + `mcpServers` | Relayed **verbatim** to upstream (`down.rs:247`) | ✅ |
+| 6 | Emits `session/update`; answers `session/request_permission` | Raw updates forwarded verbatim; permissions plumbed (`up.rs`) | ✅ |
+| 7 | `session/cancel` | `Session::cancel` | ✅ |
+| 8 | `fs/*`, `terminal/*` | Method-not-found — bridge doesn't call them (host tools go via MCP) | ✅ |
+
+Three of these need explanation.
+
+**#2 passes by accident, not by design.** `InitializeResponse::new(req.protocol_version)`
+echoes whatever the client asked for. The bridge demands strict equality
+(`protocol-configuration.ts:85` — *"requested v1, agent selected v0"*), and
+echoing satisfies that. But if `down.rs` ever starts negotiating properly and
+returns a lower version, the bridge breaks. Worth a regression test pinning the
+echo behaviour, or an explicit `V1`.
+
+**#3 is a non-issue if we don't ask for it.** `authentication` is optional in
+`ACPHarnessSettings`; the bridge only calls `authenticate` when it is set
+(`bridge/index.ts:433`). We want credentials to arrive by environment anyway, so
+we simply omit `authentication` and never trip `assertACPAuthenticationMethod`.
+
+**#4 is the only real gap, and it is conditional.** From `bridge/index.ts:470-516`,
+the capability is checked on exactly two paths:
+
+- `recoveryMode: 'lossy-rerun'` → `assertACPResumeCapability` then `session/resume`
+- `recoveryMode: 'cold-restore'` → `resolveACPSessionRestorationMethod`, which
+  throws `HarnessBridgeCapabilityUnsupportedError` unless resume or loadSession
+  is advertised
+- **no `recoveryMode` → plain `buildSession({ cwd, … })`, i.e. `session/new`, no
+  capability check**
+
+A playground that opens a session and never detaches takes the third branch.
+
+Also worth noting: `down.rs` masking `load_session` is **deliberate and tested** —
+`serve_reflects_upstream_capabilities_masking_load_session` (`down.rs:823`)
+asserts it. Any change in Phase 2 has to update that test intentionally.
+
+---
+
+## 3. Phase 1 — BitRouter as a harness, no Rust changes
+
+Goal: `/chat` gets a `bitrouter` harness whose sub-picker chooses the agent
+(`claude-acp`, `codex-acp`, …), all routed through BitRouter, on the model
+picked by the existing model axis.
+
+### 3.1 The adapter wiring
+
+```ts
+createACP({
+  harnessId: 'bitrouter-claude-acp',
+  source: { type: 'npm-simple', packageName: 'bitrouter' },  // tracks latest
+  executable: 'bitrouter',
+  args: ['acp', 'serve', '--agent', 'claude-acp', '--base-url', BITROUTER_API_BASE],
+  forwardEnv: ['BITROUTER_API_KEY'],
+  // no `authentication` — see #3 above
+})
+```
+
+Omitting `packageVersion` tracks the `latest` dist-tag and keeps the version out
+of the implementation identity, so an alpha release does not invalidate existing
+lifecycle state. Given the package is at `1.0.0-alpha.27`, that is what we want.
+
+### 3.2 Sandbox — **decided: Vercel Sandbox now**
+
+`@ai-sdk/sandbox-vercel` (a VM per session, a Vercel account) for this work;
+migrate to a Railway adapter later. `@ai-sdk/sandbox-just-bash` exposes no ports
+and cannot host ACP.
+
+Because the provider is swappable behind `HarnessV1SandboxProvider`, keep every
+sandbox reference behind one module (`lib/harness-sandbox.server.ts`) so the
+later swap is a single edit rather than a sweep.
+
+### 3.3 Two-level bootstrap
+
+A subtlety the adapter does not handle for us: `source` installs exactly one npm
+package. `bitrouter acp serve --agent claude-acp` then spawns the *upstream*
+agent binary, which must also exist in the sandbox. So the sandbox image needs:
+
+1. `bitrouter` (via `source`, plus its `postinstall` which downloads a platform
+   binary from `github.com/bitrouter/bitrouter/releases` — needs egress)
+2. the upstream agent binary for each catalog id we expose
+
+**No `bitrouter.yaml` is required.** `apply_routing` (`acp_cli.rs:175`)
+synthesizes the `agents:` entry for any catalog-known id via
+`crate::harness::by_id`, explicitly so "`bitrouter spawn claude-acp` works with
+no YAML edit", and `serve()` calls it. The CLI help — *"Agent id — must exist
+under `agents:` in the config"* — is stale for catalog ids and should be fixed.
+
+Item 2 belongs in `sandboxConfig.onBootstrap`, which Vercel Sandbox keys a
+persistent template snapshot off, so the cost is paid once rather than per
+session.
+
+Platform check: the npm postinstall table covers `x86_64-unknown-linux-gnu` with
+a `musl-static` fallback when glibc < 2.35, so a standard Linux sandbox is fine.
+
+### 3.4 Routing — **confirmed**
+
+```
+bitrouter acp serve --agent claude-acp \
+  --base-url https://<hosted-bitrouter>/v1 \
+  --model <model-id>
+```
+with `BITROUTER_API_KEY` in the environment (`forwardEnv`).
+
+Verified against `apply_routing` on `origin/main`:
+
+- **`--base-url` alone suppresses the local daemon.** Autostart is gated on
+  `opts.base_url.is_none() && target_is_local` (`acp_cli.rs:285`), so passing a
+  remote base URL skips `ensure_local_daemon` entirely.
+- **The key is then mandatory.** `require_key = !target_is_local || !skip_auth`,
+  so a remote target always requires `BITROUTER_API_KEY` and fails fast with
+  `RoutingError::AuthRequired` rather than 401-ing mid-turn.
+- **`--model` works on this path.** It is dropped only on the direct/unroutable
+  branches; on the routed path it reaches
+  `harness.routing_overlay(&base_url, &auth, model)`. This is what drives the
+  playground's model axis.
+- **`--no-start` is inert here** — it only has effect when `base_url` is unset
+  and the target is local. Do not pass it; it implies a guarantee it is not
+  providing.
+- **`--direct` is wrong.** It returns `Ok(None)` — no routing overlay at all,
+  the harness uses its own provider credentials, and `--model` is discarded.
+
+A preflight `base_url_reachable` probe runs before any session side effect, so
+an unreachable router fails at start rather than mid-stream.
+
+See §7 for the rough edges in this surface and the refactor options.
+
+### 3.5 Playground integration
+
+Extends the registry already built in `lib/harnesses.ts`. **Decided: flat** — one
+registry entry per BitRouter agent rather than a third picker:
+
+```
+bitrouter-claude-acp   BitRouter · Claude Code
+bitrouter-codex-acp    BitRouter · Codex
+bitrouter-gemini-cli   BitRouter · Gemini CLI
+bitrouter-pi-acp       BitRouter · Pi
+```
+
+Each is `transport: 'session'`, `runtime: 'sandbox-vm'`, and maps to one
+`createACP()` call differing only in the `--agent` argument. The existing single
+picker and the model axis both keep working unchanged, and no new UI is needed.
+
+Availability in `lib/harnesses.server.ts` gates on the Vercel Sandbox
+credentials being present, exactly as the other six do today.
+
+Worth noting for the picker copy: these entries read as "BitRouter running
+Claude Code", which is a more accurate description of the product than the
+`@ai-sdk/harness-claude-code` entry sitting next to them — the same runtime, but
+routed.
+
+### 3.6 Phase 1 acceptance
+
+- `acp-conformance.mjs` passes 8/8 against `bitrouter acp serve --agent claude-acp`
+  (the checker exists, is validated against a mock, and catches each deviation
+  in isolation)
+- a `/chat` turn on the `bitrouter` harness produces streamed text with tool
+  calls visible
+- the docs tools reach the agent through the injected MCP server (#5)
+
+---
+
+## 4. Phase 2 — session restoration
+
+Needed the moment we want a chat to survive a detach, a redeploy, or a second
+replica. Without it the constraint matches Pi's today: sessions are
+process-local and evictable.
+
+### 4.1 Recommended: implement `session/resume`, not `session/load`
+
+`agent-client-protocol-schema@1.4` models both. The schema's own doc for
+`session/resume` says it is *"useful for agents that can resume sessions but
+don't implement full session loading"* — which is exactly BitRouter's shape: a
+stable `record_id`, a durable record under `.bitrouter/sessions/<id>.json`, and a
+transcript, but no history-replay semantics.
+
+It is also what the bridge prefers: `resolveACPSessionRestorationMethod`
+(`session-lifecycle.ts:16`) checks `sessionCapabilities.resume` **first** and
+only falls back to `loadSession`.
+
+### 4.2 The honest constraint
+
+BitRouter's down-facing agent proxies an upstream agent. Resuming BitRouter's
+session does **not** resume `claude-acp`'s conversation unless BitRouter drives
+the upstream's own restore. So:
+
+> Advertise `sessionCapabilities.resume` **only when the captured upstream
+> `InitializeResponse` shows the upstream can restore** (`load_session` or its
+> own resume capability), and implement down-`session/resume` by driving that
+> upstream restore.
+
+`up.rs` already captures the upstream handshake and `Session::upstream_init()`
+exposes it (`engine.rs:679`), so the information needed for that decision is
+already in hand. This is a capability-mirroring change of the same kind as the
+existing `relayed_caps.load_session = false` mask — the mask becomes conditional
+rather than hardcoded.
+
+### 4.3 Work items
+
+1. `down.rs`: set `relayed_caps.session_capabilities.resume` conditionally on
+   upstream restore support; stop unconditionally masking.
+2. `down.rs`: add a `session/resume` handler that reopens/reattaches by
+   `record_id` and drives the upstream restore.
+3. `engine.rs`: a rehydrate path — construct a `Session` from a durable record
+   rather than only from `launch`.
+4. Update `serve_reflects_upstream_capabilities_masking_load_session` — it
+   currently asserts the behaviour we are changing.
+5. Regression test pinning `initialize` → `protocolVersion: 1` (see #2).
+
+Helpfully, the bridge **discards replayed history** on restore
+(`setHistoricalUpdatesSuppressed` + `discardCapturedHistory`,
+`session-lifecycle.ts:60`), so a resume that replays is acceptable — we do not
+need to invent a no-replay path to satisfy the AI SDK.
+
+### 4.4 This reverses a deliberate subtraction — read before committing
+
+Resolved against `origin/main`: the `.cli-snapshot.json` in `bitrouter-docs` is
+**stale**, not ahead. `AcpCmd` on main has only `Serve`, `Prompt`, `Sessions`.
+
+The machinery was removed on purpose by
+**`641d3844 refactor(substrate): drop detach/reattach + fleet machinery (#751)`**,
+described as *"Pure-subtraction P0 of the ACP-rightsizing epic (#749)"*. It
+deleted:
+
+- `acp attach`, `--warm`/`--idle-timeout`, `SessionRecord.socket`, `socket_dir`
+- the `session/load` handler, `replay_transcript`, `replay_stop_reason`
+- `transcript.rs` — *"reader-less once session/load replay is gone"*
+- `turn_state.rs`, the fleet registry
+
+So Phase 2 is not filling a gap; it is **re-adding a capability that was
+deliberately cut weeks ago**. That deserves an explicit decision rather than
+being smuggled in under "AI SDK support".
+
+The case for re-adding is narrow but real: the transcript was removed for having
+no reader, and `@ai-sdk/harness-acp`'s cold-restore path is exactly such a
+reader. If that argument does not land, the honest alternative is to **not do
+Phase 2** and accept process-local sessions — the same constraint Pi has today,
+which the playground already models with evictable sessions.
+
+Recommendation: decide Phase 2 against epic #749's goals, not against this plan.
+If ACP-rightsizing intends the substrate to stay lean, keep it lean and let the
+playground own continuity at its own layer.
+
+### 4.5 What the e2e changed — and a bug #751 left behind
+
+Running the real binary in a sandbox (§8) moved this decision.
+
+`bitrouter@1.0.0-alpha.27` answers `initialize` with **both** restore
+capabilities advertised:
+
+```json
+"agentCapabilities": { "loadSession": true,
+                       "sessionCapabilities": { "list": {}, "resume": {} } }
+```
+
+Those are **Claude Code's** capabilities relayed through, not BitRouter's own —
+BitRouter is passing along a promise it does not implement. On `main` that is
+half-corrected: `load_session` is masked to `false` (`down.rs:201`) but
+`session_capabilities.resume` is relayed untouched, and there is **no
+`session/resume` handler** (0 occurrences in `down.rs`).
+
+That combination is a live bug, because of the order the bridge checks in
+(`session-lifecycle.ts:16`): `resume` is tested *first*. A cold restore against
+`main` therefore picks `resume`, calls it, and gets a JSON-RPC
+**method-not-found** — instead of the clean `HarnessBridgeCapabilityUnsupportedError`
+the `load_session` masking exists to produce. #751 removed the handler and left
+the advertisement.
+
+**Fix regardless of the Phase 2 decision:** mask
+`relayed_caps.session_capabilities.resume` alongside `load_session`, so an
+unsupported restore fails legibly. Two lines.
+
+**And the playground does not need Phase 2 at all.** The capability check only
+runs when `start.recoveryMode` is set (`bridge/index.ts:470`), i.e. on
+resume-from-lifecycle-state. `/chat` calls `createSession({ sessionId })`, holds
+the agent in-process, and never calls `detach()`/`stop()` or passes `resumeFrom`
+— so every turn takes the plain `session/new` branch. Phase 2 buys chats that
+survive a redeploy or a second replica, which is the same constraint Pi already
+has and which `harness-sessions.ts` already documents as evictable.
+
+So the real question is not "does the playground need restore" (no) but "should
+BitRouter be a resumable ACP agent for third-party managers such as Zed" — an
+epic #749 call.
+
+**Recommendation: no Phase 2 now; ship the masking fix.** Revisit if the
+playground outgrows one replica, if chats must survive redeploys, or if a real
+ACP manager integration lands — that last one is a far better justification for
+reviving the transcript than our own playground is.
+
+**Untested:** restore is *advertised*; it was never *exercised*. No
+`session/resume` call was made against alpha.27, so whether it is honoured there
+is unknown — and given `main` has no handler, assume the advertisement is at
+least partly hollow. One more probe (`session/new` then `session/resume`) would
+settle it if certainty is wanted before deciding.
+
+---
+
+## 5. Decisions — resolved
+
+1. **Sandbox** → Vercel Sandbox now, Railway later. Keep it behind one module
+   (§3.2).
+2. **Routing flags** → `--base-url` + `BITROUTER_API_KEY`, no `--no-start`, never
+   `--direct`. Confirmed against `apply_routing` (§3.4). Rough edges in §7.
+3. **CLI snapshot** → stale, not ahead. The feature was removed by #751 (§4.4).
+   Regenerate `.cli-snapshot.json` from a current binary.
+4. **Agent axis** → flat, one registry entry per agent (§3.5).
+
+Still open: whether Phase 2 happens at all, given §4.4.
+
+## 6. Risks
+
+- **Alpha surface.** `bitrouter@1.0.0-alpha.27` and `harness-acp@1.0.1` are both
+  early; the harness packages are documented as experimental with breaking
+  changes expected between releases.
+- **Cost.** A VM per session per visitor, on an unauthenticated page. The auth
+  and billing work already flagged for the Pi harness applies here with more
+  force, since these sessions are heavier.
+- **Bootstrap fragility.** Two-level install with a GitHub-releases download
+  inside a sandbox is the most likely thing to break, and it breaks at session
+  start rather than at build time.
+- **Upstream capability variance.** Under §4.2, whether a chat can resume depends
+  on which agent it fronts — `claude-acp` and `codex-acp` may differ. The
+  playground should surface that rather than fail opaquely.
+
+---
+
+## 7. Routing surface — rough edges worth a small refactor
+
+The flags work (§3.4), so nothing here blocks Phase 1. But `acp serve` is about
+to become a scripted interface rather than a human one, and three things read
+badly at that boundary.
+
+**1. The routing mode is implicit.** There are three real modes — route via a
+local daemon, route via a remote gateway, don't route — but they are expressed
+as a boolean (`--direct`) plus an inference from whether `--base-url` happens to
+be set and happens to be non-local. Nothing in `--help` tells you that passing
+`--base-url` disables daemon autostart; you have to read `apply_routing`.
+
+**2. `--no-start` is silently inert** when `--base-url` is remote. Passing it
+alongside looks like a belt-and-braces guarantee and is a no-op.
+
+**3. `--direct` is named backwards for this product.** It reads as "go direct to
+BitRouter" and means "bypass BitRouter routing". In the surface most likely to
+be copied into scripts and CI, that inversion will cost someone an afternoon.
+
+### Option A — an explicit mode flag (recommended)
+
+```
+--route daemon        # local daemon, autostart unless --no-start
+--route gateway       # requires --base-url; never touches a local daemon
+--route off           # today's --direct
+```
+
+`--direct` becomes a deprecated alias for `--route off`. `--no-start` stays
+meaningful only under `--route daemon` and can warn when passed otherwise. The
+inference disappears; each mode's preconditions are checkable up front, which
+also makes the fail-fast errors more precise (`gateway mode requires --base-url`
+beats a daemon-unreachable error pointing at a URL the user never set).
+
+Cost: one enum, a shim for the old flag, and touching the `spawn`/`serve`/`prompt`
+call sites that share `RoutingOptions`.
+
+### Option B — leave the flags, fix the docs
+
+Correct the stale `--agent` help text (§3.3), document that `--base-url` implies
+no daemon, and note that `--no-start` is daemon-mode-only. Zero code risk,
+and the confusing `--direct` name survives.
+
+### Option C — do nothing for now
+
+Phase 1 works. Revisit when the ACP surface stabilises under epic #749.
+
+**Decided: Option C** — leave the flags alone for now, revisit when the ACP
+surface stabilises under epic #749.
+
+---
+
+## 8. What the end-to-end run proved
+
+Run against real Vercel Sandboxes. Scripts in `scratchpad/e2e/`.
+
+| Stage | Result |
+|---|---|
+| 1 — provision | PASS — Amazon Linux 2023, node 24.14.1, glibc 2.34 |
+| 2 — install `bitrouter` | PASS — `1.0.0-alpha.27` runs, ~24s |
+| 3 — ACP handshake | PASS — `protocolVersion: 1`, `agentInfo` "Claude Code" 0.16.2 |
+| 4 — full turn | not run (needs router credentials; spends model tokens) |
+
+### 8.1 `xz` is the bootstrap blocker
+
+The sandbox image has glibc 2.34, below the 2.35 the gnu build needs, so
+bitrouter's installer correctly falls back to its musl-static artifact — a
+`.tar.xz`. The image ships no `xz`, so tar cannot unpack it.
+
+What makes this fixable in `sandboxConfig.onBootstrap` — which runs *after* the
+adapter's own bootstrap — is that **pnpm 10 ignores bitrouter's build script**.
+The adapter's install therefore only writes a bin shim; the binary is fetched
+lazily on first spawn. Verified in production order (adapter bootstrap →
+`sudo dnf install -y xz` → first spawn), after which `bitrouter --version`
+succeeds. Implemented in `lib/bitrouter-acp/agents.ts`.
+
+### 8.2 The env vars were a fiction
+
+`@vercel/sandbox` never reads `VERCEL_TOKEN` / `VERCEL_PROJECT_ID` /
+`VERCEL_TEAM_ID`; they appear only in its README as values a caller passes
+explicitly. Its own resolution is the Vercel CLI's `auth.json` plus
+`.vercel/project.json`, or OIDC. `lib/harness-sandbox.server.ts` now threads the
+trio through explicitly and recognises the local OIDC path.
+
+### 8.3 Smaller findings
+
+- `@zed-industries/claude-code-acp` is **deprecated**, renamed to
+  `@agentclientprotocol/claude-agent-acp`. BitRouter's catalog still points at
+  the old name. It resolves and runs; worth updating upstream.
+- The `--agent` help text (*"must exist under `agents:` in the config"*) is
+  wrong for catalog ids — `apply_routing` synthesizes the entry.
+- `acp serve` runs until the manager disconnects, so a probe must hold stdin
+  open; a pipe that EOFs after the request makes it exit before replying.

--- a/docs/bitrouter-acp-harness-plan.md
+++ b/docs/bitrouter-acp-harness-plan.md
@@ -418,7 +418,7 @@ Run against real Vercel Sandboxes. Scripts in `scratchpad/e2e/`.
 | 1 — provision | PASS — Amazon Linux 2023, node 24.14.1, glibc 2.34 |
 | 2 — install `bitrouter` | PASS — `1.0.0-alpha.27` runs, ~24s |
 | 3 — ACP handshake | PASS — `protocolVersion: 1`, `agentInfo` "Claude Code" 0.16.2 |
-| 4 — full turn | not run (needs router credentials; spends model tokens) |
+| 4 — full turn | **PASS on `codex-acp`** — `stop_reason=EndTurn`, 4.7s; fails on `claude-acp` (§8.4) |
 
 ### 8.1 `xz` is the bootstrap blocker
 
@@ -450,3 +450,72 @@ trio through explicitly and recognises the local OIDC path.
   wrong for catalog ids — `apply_routing` synthesizes the entry.
 - `acp serve` runs until the manager disconnects, so a probe must hold stdin
   open; a pipe that EOFs after the request makes it exit before replying.
+
+### 8.4 Stage 4 — a turn completes, on one agent
+
+`codex-acp` on `deepseek/deepseek-v4-flash` completed a full turn end to end:
+
+```
+acp turn completed agent=codex-acp stop_reason=EndTurn latency_ms=4666
+```
+
+That settles the three assumptions the plan carried: the **routed path**
+(`--base-url` + `BITROUTER_API_KEY`) works, `--model` **accepts a raw
+`CHAT_MODELS` id**, and the bridge's **WebSocket dial** into the sandbox works.
+
+Three separate blockers surfaced getting there, none of them in the AI SDK
+integration:
+
+**a. Two catalog models cannot do tools.** `POST /v1/messages` with a `tools`
+array returns:
+
+```
+400 bad request: model 'anthropic/claude-haiku-4.5' has no provider
+    that supports the requested capability: tools
+```
+
+Same for `qwen/qwen3.8-max`. The other six in `CHAT_MODELS` are fine. Since
+every coding agent sends tools, those two models cannot back **any** ACP
+harness. The playground should reflect that rather than offering a pairing that
+always 400s.
+
+**b. `--model` does not take effect for `claude-acp`.** BitRouter sets
+`ANTHROPIC_MODEL` (`harness.rs`, `Routing::Env`), and the catalog comment
+asserts claude-code-acp "passes process env through to the SDK-spawned CLI,
+which honors these exactly as interactive Claude Code does". It does not — with
+`--model deepseek/deepseek-v4-flash` the agent still used its own default:
+
+```
+There's an issue with the selected model (claude-sonnet-4-5-20250929)
+```
+
+The base URL *did* apply (the request reached BitRouter, which rejected an id it
+does not know), so this is specifically the model pin. `codex-acp` is unaffected
+because `Routing::CodexArgs` passes the model as an argument rather than an env
+var. Worth re-testing against the renamed
+`@agentclientprotocol/claude-agent-acp` before concluding it is unfixable.
+
+**c. Host tools reach the sandbox but not the model's toolset.** With `tools`
+set, `claude-acp` fails the bridge's catalog gate outright:
+
+> The ACP implementation did not load the active harness-owned MCP tool catalog
+> to revision 1
+
+`codex-acp` passes that gate — so it does spawn the injected MCP server and call
+`tools/list` (which is what advances `servedRevision`,
+`host-tool-mcp-server.ts:58`) — but the tool still never reaches the model:
+
+> I don't have a `bitrouter_probe_code` tool available in my current toolset,
+> and there are no MCP resources configured.
+
+So the relay works and the catalog is served, but the tool is not surfaced into
+the agent's tool list. **This is the blocker for shipping**, because the
+playground passes `agentTools` — as it stands the BitRouter ACP harnesses cannot
+offer the documentation tools, which is most of their value.
+
+### 8.5 Method note
+
+Two runs were wasted guessing at causes (a doubled `/v1`, a cross-vendor model)
+before enabling `debug: { enabled: true }`, which surfaced the real error
+immediately from `acp.agent.stderr`. Turn diagnostics on at the *first* failure,
+not the third.

--- a/docs/playground-auth-billing-plan.md
+++ b/docs/playground-auth-billing-plan.md
@@ -1,0 +1,481 @@
+# Auth and billing for the public playground
+
+Status: **draft, for review**
+Repos: `bitrouter-docs` (public), `bitrouter-cloud` (private)
+Related: [`bitrouter-acp-harness-plan.md`](./bitrouter-acp-harness-plan.md)
+
+---
+
+## 1. Headline
+
+The `/chat` playground in this repo becomes the product's only playground. The
+console's `(app)/playground` is deprecated once this reaches production.
+
+That raises two problems this plan solves:
+
+1. **Credential.** A public repo cannot hold the console's database or its
+   Better Auth secret, but the playground must spend on behalf of a signed-in
+   user. Solved by having the console mint a narrow, short-lived credential and
+   the docs app hold nothing else.
+2. **Feature parity.** The console playground has multi-model comparison,
+   branching, and saved sessions. This one has none of them. Deprecation is not
+   free.
+
+Everything in §3–§5 is additive and reversible. §6 (the deprecation) is not, and
+is deliberately staged last.
+
+---
+
+## 2. What already exists
+
+Verified by reading the code, not assumed.
+
+### 2.1 Cross-origin session — **already working**
+
+`bitrouter-docs` runs **no Better Auth server**. [`lib/auth-client.ts`](../lib/auth-client.ts)
+is a client pointed at the console:
+
+```ts
+createAuthClient({
+  baseURL: process.env.NEXT_PUBLIC_CONSOLE_URL ?? "https://cloud.bitrouter.ai",
+  fetchOptions: { credentials: "include" },
+});
+```
+
+It works because two things are already configured on the console side:
+
+- `BETTER_AUTH_COOKIE_DOMAIN` set to the bare apex, so the session cookie is
+  readable on both `bitrouter.ai` and `cloud.bitrouter.ai`
+  (`console/src/lib/auth.ts` → `readCookieDomain`).
+- `console/src/lib/auth-cors.ts` reflects allowlisted origins on `/api/auth/*`
+  with `Access-Control-Allow-Credentials: true`. Better Auth's `trustedOrigins`
+  is a CSRF allowlist only and emits no CORS headers, so this layer is what
+  makes the credentialed read possible.
+
+`components/site-header-wired.tsx` already renders the signed-in user from it.
+**No new auth infrastructure is needed to know who the visitor is.**
+
+### 2.2 The credential gap
+
+The console's own chat route reads the token off the session row:
+
+```ts
+// console/src/app/api/chat/route.ts
+const apiKey = await getOrRefreshRustToken(session.session.id);
+```
+
+`getOrRefreshRustToken` queries `schema.session.bitrouterAccessToken` in the
+console Postgres. That requires `DATABASE_URL` and — for the mint/rotate paths —
+`BETTER_AUTH_SECRET`. Neither can exist in a public repo. A direct port of
+`/api/chat` into `bitrouter-docs` is therefore impossible, and that is the
+entire problem.
+
+### 2.3 The primitive that closes it
+
+The auth-authority split (P3) changed what a `bra_` is. Per
+`console/src/lib/credentials/bra-jwt.ts`, it is now a **signed EdDSA JWT** that
+the Routing Core verifies against the console JWKS with **zero RPC**
+(`src/auth/jwt_resolver.rs`). Claims: `sub`, `nsid`, `scope`, `kind`, `jti`,
+`exp`. `mintBraJwtWithMeta` accepts arbitrary `scope` and `ttlSeconds`.
+
+So the console can mint a purpose-built credential and hand it over. The docs
+app holds a bearer token that expires on its own and nothing else.
+
+### 2.4 The scope taxonomy supports real narrowing
+
+`src/auth/scope.rs` models `Exact(Resource::Inference, Action::Invoke)`. A
+playground token can carry **`inference:invoke` alone**, against the nine
+wildcards a web session gets today (`WEB_SESSION_SCOPE` in
+`console/src/lib/session-exchange.ts`):
+
+```
+inference:*  keys:*  billing:*  usage:*  policy:*  byok:*  namespace:*  clients:*  user:*
+```
+
+A leaked playground token can spend credits and do nothing else — no key
+issuance, no billing surface, no BYOK material, no namespace management.
+
+### 2.5 Billing layers that already exist
+
+| Layer | Implementation | Enforces |
+|---|---|---|
+| Credit balance | `src/service/redis_balance.rs`, `debit_drainer.rs` | Inference refused when the account is dry |
+| Budget policy | `policies` rows `kind='budget'`; `/v1/namespaces/{nsid}/budgets` | `{window: Day\|Month\|Total, limit_micro_usd}` |
+| Rate limit policy | `RateLimitSpec {window_secs, max_requests, max_tokens}`, Redis counters per principal | Request/token frequency |
+
+No new billing primitives are required. §5 composes these.
+
+---
+
+## 3. Phase 1 — the credential seam
+
+### 3.1 One interface, two implementations
+
+The whole auth surface in this repo is one module. This is what keeps the
+playground genuinely open-source: the *contract* is public, the *policy* lives
+in the console.
+
+```ts
+// lib/playground-credential.ts   (new, public)
+
+export type CredentialMode = "session" | "byo-key";
+
+export interface PlaygroundCredential {
+  /** Bearer for api.bitrouter.ai. */
+  token: string;
+  expiresAt: Date;
+  /** Null in byo-key mode — nothing to attribute to. */
+  attribution: { userId: string; namespaceId: string } | null;
+  mode: CredentialMode;
+}
+
+export async function resolveCredential(
+  req: Request,
+): Promise<PlaygroundCredential | null>;
+```
+
+- **`byo-key` mode** — `BITROUTER_API_KEY` from env. Exactly today's behaviour.
+  What a fork, a local dev, or a self-hoster gets with zero console dependency.
+  `expiresAt` is a far-future sentinel; `attribution` is `null`.
+- **`session` mode** — the docs *server* forwards the incoming `Cookie` header
+  to the console token endpoint (§3.2) and receives a minted `bra_`.
+
+Mode is selected by `PLAYGROUND_CREDENTIAL_MODE`, defaulting to `byo-key` so a
+clone of this repo works unchanged.
+
+**Server-side forward, not browser-held.** The alternative — the browser calls
+the console directly over credentialed CORS and passes the token to our route —
+would put a spendable bearer in page JS. Given §4.1 (these tokens cannot be
+revoked), keeping it server-side is worth the extra hop.
+
+### 3.2 The console endpoint (bitrouter-cloud)
+
+```
+POST cloud.bitrouter.ai/api/playground/token
+
+  auth   Better Auth session cookie (already rides cross-origin)
+  CORS   reuse the auth-cors.ts allowlist; extend it beyond /api/auth/*
+  CSRF   enforceCsrf — this endpoint hands out a spendable credential
+  body   { purpose: "chat" | "harness" }
+
+  200    { token, expiresAt, namespaceId }
+  401    no session
+  402    grant exhausted and balance is zero
+```
+
+Minting policy, per purpose:
+
+| purpose | credential | scope | TTL | revocable |
+|---|---|---|---|---|
+| `chat` | `bra_` JWT via `mintBraJwtWithMeta` | `inference:invoke` | 15 min | no (§4.1) |
+| `harness` | `brk_` via `credentials/issue.ts` | `inference:invoke` | session-bound | **yes** |
+
+`nsid` points at the user's playground namespace (§5.1), never their default.
+
+### 3.3 Route changes in this repo
+
+`app/api/chat/playground/route.ts` currently reads `BITROUTER_API_KEY` directly.
+It gains a `resolveCredential(req)` call at the top and threads the token down
+through both dispatch arms. `lib/bitrouter-provider.ts` takes the token as an
+argument rather than reading env.
+
+`lib/bitrouter-acp/agents.ts` currently does:
+
+```ts
+requireEnv("BITROUTER_API_KEY");
+// …
+forwardEnv: ["BITROUTER_API_KEY"],
+```
+
+This becomes an explicit per-session credential injected into the sandbox env
+rather than inherited from the server process. See §4.2 — this is the case that
+does not work with a 15-minute token.
+
+### 3.4 Phase 1 acceptance
+
+- [x] `byo-key` mode behaves identically to today with no console reachable.
+      Verified locally: no sign-in gate, composer enabled, and the turn reaches
+      `api.bitrouter.ai/v1/chat/completions` carrying the env key.
+- [ ] `session` mode: signed-in visitor's turn is attributed to their user and
+      playground namespace in the console's usage view. **Blocked on Phase 2** —
+      this repo's half is done and unit-tested against a stubbed console, but
+      nothing mints yet.
+- [ ] ~~Signed-out visitor in `session` mode gets the anonymous path (§5.2), not
+      a 500.~~ **Diverged — see below.** Today they get a 401 and a sign-in
+      prompt. Not a 500, but not the anonymous path either.
+- [ ] The minted token is rejected by `/v1/keys` and `/v1/billing/*` — proving
+      the scope narrowing is real, not decorative. Blocked on Phase 2.
+- [x] No console DB URL, Better Auth secret, or pepper appears anywhere in this
+      repo's env surface. The only additions are
+      `PLAYGROUND_CREDENTIAL_MODE` and the already-present public URLs.
+
+#### Divergence from §5.2: signed-out visitors are gated, not degraded
+
+Phase 1 ships **gate, don't degrade** — the opposite of §5.2's recommendation.
+In `session` mode a signed-out visitor gets a 401 from `resolveCredential` and a
+sign-in prompt on the composer; there is no anonymous house-key fallback.
+
+This is deliberate sequencing, not a reversal. The anonymous tier needs an IP
+rate limit and a restricted model set to be safe (§5.2), and both are Phase 4
+work that blocks on Phase 3. Shipping the fallback *before* those exist would
+mean an uncapped house key on an unauthenticated page — exactly what this plan
+is trying to end. Gating is the conservative state to hold in the meantime.
+
+Reopening it in Phase 4 is a change to two places: the `401` branch in
+`mintFromConsole` becomes a fallthrough to `fromEnvironment`, and `requiresAuth`
+in `app/(chat)/chat/page.tsx` becomes per-harness rather than per-deployment.
+The `harnesses.server.ts` tiering §5.2 describes is unchanged by this.
+
+---
+
+## 4. Three things that do not fall out for free
+
+### 4.1 A JWT `bra_` cannot be revoked
+
+`bra-jwt.ts` documents an "emergency jti deny-list key". **It is not
+implemented.** `src/auth/jwt_resolver.rs` verifies claims and maps them to a
+`Principal` with no deny-list check, and the `auth.revoke` machinery
+(`src/auth/revoke_event.rs`) only evicts the *introspection* cache — which a
+0-RPC JWT never consults. Grepping `jti` across `src/` finds only the claim
+read and test fixtures.
+
+Consequence: a minted playground token is live until `exp`, full stop. Ban,
+sign-out, and credential revocation all fail to stop it.
+
+Mitigations, in preference order:
+
+1. **Short TTL** (15 min) plus `inference:invoke`-only scope. The blast radius
+   is "can spend the user's own credits for 15 minutes", bounded further by the
+   budget policy in §5.1.
+2. **Use `brk_` where the window is long** (§4.2). Those are introspected, so
+   `auth.revoke` evicts them within cache TTL.
+3. **Implement the deny-list.** A Redis `SISMEMBER` on `jti` in `jwt_resolver`,
+   fed by the existing `auth.revoke` subscriber. Real work in the Rust repo.
+
+**Decision needed:** is (1)+(2) acceptable for launch, or is (3) a prerequisite?
+Recommendation: (1)+(2) is proportionate at this scope. Worth filing (3) as a
+tracked issue rather than leaving it as a stale comment that overstates what the
+system does.
+
+### 4.2 The harness sandboxes break the short-TTL model
+
+In [`lib/bitrouter-acp/agents.ts`](../lib/bitrouter-acp/agents.ts) the credential
+is baked into the sandbox process environment at spawn (`forwardEnv:
+["BITROUTER_API_KEY"]`) and the ACP session lives as long as the visitor keeps
+chatting. A 15-minute token dies mid-conversation with no refresh path — the
+sandboxed process holds a string, not a token manager.
+
+Use a **different credential for that path**: `console/src/lib/credentials/issue.ts`
+mints `brk_` keys taking `expiresAt`, `nsid`, and `scopes`. One ephemeral key
+per sandbox session, `expiresAt` matched to the session TTL (30 min, per
+`lib/harness-sessions.ts`), revoked on `session.destroy()`.
+
+This is better than a longer-lived JWT on three counts: it is revocable, it
+gives per-session audit granularity on the expensive path, and it fails closed
+if the teardown hook runs.
+
+### 4.3 Sandbox VMs are not priced in tokens
+
+A Vercel Sandbox costs money whether or not the model is ever called. Nothing in
+the billing stack models VM-seconds — budget policies count micro-USD of
+inference, so opening 50 harness sessions and typing nothing is free to the
+visitor and expensive to us.
+
+This needs a gate the token layer cannot provide:
+
+- Rate-limit **session creation**, not just inference (`RateLimitSpec` is
+  per-principal and counts admitted requests — it does not see a sandbox boot).
+- And/or restrict ACP harnesses to accounts with a positive balance.
+
+Given the three open blockers on the harness path
+([#783](https://github.com/bitrouter/bitrouter/issues/783),
+[#784](https://github.com/bitrouter/bitrouter/issues/784),
+[#785](https://github.com/bitrouter/bitrouter/issues/785)), the launch position
+should be the restrictive one regardless: signed-in, positive balance, one
+concurrent sandbox session per user.
+
+---
+
+## 5. Billing
+
+### 5.1 The free grant is a namespace with a budget policy
+
+Rather than playground-specific accounting, express the grant in the product's
+own primitives:
+
+1. On first playground use, provision a `playground` namespace for the user
+   (the console already JIT-provisions namespaces; this is the same path with a
+   fixed name).
+2. Attach a budget policy: `{ kind: "budget", window: "total",
+   limit_micro_usd: 1_000_000 }` — $1, lifetime.
+3. Mint playground tokens with `nsid` pointing at it.
+
+Properties this buys for free:
+
+- Exhaustion is enforced by the router, not by us — the visitor gets a clean
+  denial, not a surprise bill.
+- The grant appears in the user's own usage dashboard as a namespace they can
+  inspect.
+- Spend past the grant falls through to their real balance, which is the honest
+  default and needs no code.
+- The grant size is an operational knob (a policy row), not a deploy.
+
+### 5.2 The anonymous tier
+
+The playground is a top-of-funnel surface; requiring sign-in before the first
+token is a conversion tax. Proposal — degrade, don't gate:
+
+| Visitor | Harness | Credential | Cap |
+|---|---|---|---|
+| Anonymous | `ai-sdk` only | House key (`BITROUTER_API_KEY`) | IP rate limit, small model set |
+| Signed in | `ai-sdk`, `pi` | Minted `bra_`, playground ns | $1 lifetime grant, then own balance |
+| Signed in + balance | all, incl. ACP | Minted `brk_` per session | Own balance, 1 concurrent sandbox |
+
+`lib/harnesses.server.ts` already returns `HarnessOption[]` with `available` and
+`reason`, and the picker already renders unavailable entries greyed out with the
+reason. **The tiering is a change to that one function's inputs**, not new UI:
+it takes the resolved credential alongside the env checks it does today. The
+harness axis stays fully visible to anonymous visitors, which is the point of
+the page.
+
+The anonymous house key is the one piece of unattributed spend. It is bounded
+by IP rate limit and model set, and it is what the page does today for everyone.
+
+---
+
+## 6. Deprecating the console playground
+
+Staged last, because it is the only irreversible part.
+
+### 6.1 What is actually there
+
+| Piece | Notes |
+|---|---|
+| `console/src/app/(app)/playground/{page,layout}.tsx` | Signed-in gate + shell |
+| `components/playground-{multi-session,chat-runner,config,empty,nav}.tsx` | ~5 components |
+| `lib/playground-db.ts` (378 lines) | Dexie/IndexedDB store |
+| `lib/chat-session.ts` | `PlaygroundConfig` type |
+| `app/api/chat/route.ts` | The `bra_`-authenticated chat route |
+| `lib/nav.ts:49` | Nav entry |
+
+### 6.2 The feature gap is real
+
+The console playground has three things this one does not:
+
+- **Multi-model comparison.** `ChatSessionRow.models: string[]` with
+  `threads: Record<string, UIMessage[]>` kept in lockstep — the user messages
+  are shared and each model answers in its own column.
+- **Branching.** `ModelBranches` / `BranchSlots`, keyed by anchor message id,
+  with per-slot version history.
+- **Saved sessions.** Titled, pinned, persisted.
+
+Deprecating without these is a feature regression for existing users. Options:
+
+- **(a) Port all three** before deprecating. Largest scope; the branching model
+  is non-trivial and is entangled with the multi-model layout.
+- **(b) Port saved sessions only**, drop multi-model and branching. The docs
+  playground's axis is *harness × model*, not *model × model* — arguably a
+  different product, and side-by-side comparison belongs on `/models`.
+- **(c) Deprecate with no port.** Fastest, and a straight loss.
+
+Recommendation: **(b)**, with multi-model reconsidered after launch based on
+whether anyone asks. The harness axis is the differentiated thing; model
+comparison is table stakes that `/models` may serve better.
+
+**This is the largest open question in the plan and the one most worth your
+input.**
+
+### 6.3 The data is browser-local
+
+`playground-db.ts` is Dexie over IndexedDB — **there is no server-side
+playground data**. Nothing is stranded in Postgres, and there is no migration
+job. But the user's saved chats live in one browser's IndexedDB and cannot be
+moved for them.
+
+If saved sessions are ported (option b), the honest path is a
+**user-initiated export/import**: a JSON download from the console playground
+during the deprecation window, and an import on this side. Anything automatic
+would require reading another origin's IndexedDB, which is not possible.
+
+### 6.4 Deprecation sequence
+
+1. Public playground reaches production with §3–§5 shipped and the §6.2 port
+   decided.
+2. Console playground shows a banner: pointer to the new URL, export button,
+   removal date.
+3. One release later: nav entry removed, route 302s to
+   `bitrouter.ai/chat`. Code stays in place.
+4. After the window: delete the components, `playground-db.ts`,
+   `chat-session.ts`, and `app/api/chat/route.ts`.
+
+Step 4 removes the console's only consumer of `getOrRefreshRustToken` on an
+inference path. Check for other callers before deleting — the function is also
+used by the `/v1` management proxies.
+
+---
+
+## 7. What lives where
+
+| Concern | Repo | Why |
+|---|---|---|
+| Playground UI, harness registry, ACP wiring | `bitrouter-docs` (public) | The product surface; nothing secret |
+| `resolveCredential` + the two modes | `bitrouter-docs` (public) | A published contract |
+| Token endpoint, minting policy, grant size | `bitrouter-cloud` (private) | Product policy, belongs with billing |
+| `BETTER_AUTH_SECRET`, JWKS keys, pepper, DB | `bitrouter-cloud` (private) | Never leaves |
+
+A third party self-hosting this repo points `NEXT_PUBLIC_CONSOLE_URL` at their
+own console, or stays in `byo-key` mode. Neither path needs anything withheld.
+
+---
+
+## 8. Sequencing
+
+| Phase | Scope | Blocks on |
+|---|---|---|
+| 1 ✅ | `resolveCredential` + `byo-key` mode; routes take a token argument | — |
+| 2 | Console `POST /api/playground/token`, `chat` purpose only; CORS extension | Phase 1 |
+| 3 | Playground namespace + budget policy provisioning | Phase 2 |
+| 4 | Tiering in `harnesses.server.ts`; anonymous rate limit | Phase 3 |
+| 5 | `brk_` per-sandbox-session credential + teardown revoke | Phase 2; harness blockers #783–#785 |
+| 6 | Saved-session port (pending §6.2 decision) | Phase 4 |
+| 7 | Console playground deprecation sequence | Phase 6 |
+
+Phase 1 is worth doing on its own merits — it removes the module-level env read
+from the ACP path, which is a latent problem regardless of auth.
+
+**Phase 1 landed.** What shipped in this repo, and the one thing worth knowing:
+
+| File | Role |
+|---|---|
+| `lib/playground-credential.ts` | The whole seam. `resolveCredential`, `CredentialError`, `revokePlaygroundCredential`, both modes |
+| `lib/bitrouter-provider.ts` | `createBitrouterProvider(credential)`; house-key singleton kept for docs "Ask AI" |
+| `app/api/chat/playground/route.ts` | Resolves before dispatch; maps `CredentialError` to its status |
+| `lib/harness-stream.ts`, `lib/harness-sessions.ts` | Thread the credential; revoke on teardown; rebuild on expiry |
+| `lib/pi-harness/agent.ts` | Token via Pi's `customEnv` |
+| `lib/bitrouter-acp/agents.ts` | Token via the ACP adapter's `env`, **not** `forwardEnv` |
+| `lib/harnesses.server.ts` | Availability is mode-aware — session mode needs no `BITROUTER_API_KEY` |
+| `components/chat/playground.tsx` | Advisory sign-in prompt, gated on the shared console session |
+
+The ACP change is the subtle one. `forwardEnv` names variables on *this* process,
+so it can only ever forward the house key — it cannot carry a per-visitor token.
+The adapter's `env` option can, and it is documented as persisting values "in
+bootstrap and lifecycle compatibility identity", which reads alarming. In
+practice the value lands only in `implementationIdentity`, a hash gating
+resume-compatibility *within* one session, where the credential is fixed. It does
+**not** reach `implementation.json` in the sandbox (env keys only) or the
+bootstrap file set, so the snapshot `BOOTSTRAP_HASH` gates stays shared across
+visitors rather than paying a cold `dnf install xz` per session. The adapter also
+rejects a key present in both options, so the swap had to be a swap.
+
+---
+
+## 9. Open decisions
+
+1. **§6.2 — how much to port.** Recommendation: saved sessions only.
+2. **§4.1 — jti deny-list.** Prerequisite, or file-and-accept? Recommendation:
+   file-and-accept, and correct the overstated comment in `bra-jwt.ts`.
+3. **§5.2 — anonymous tier.** Keep the house key, or require sign-in from the
+   first token? Recommendation: keep it; it is what ships today.
+4. **§5.1 — grant size.** $1 lifetime is a placeholder.
+5. **Naming.** Two "Playground" nav entries coexist during the window. Rename
+   this one (Agent Playground?) or accept the overlap for one release.

--- a/lib/bitrouter-acp/agents.ts
+++ b/lib/bitrouter-acp/agents.ts
@@ -1,0 +1,147 @@
+import "server-only";
+
+import { HarnessAgent } from "@ai-sdk/harness/agent";
+import { createACP } from "@ai-sdk/harness-acp";
+
+import {
+  BITROUTER_ACP_AGENTS,
+  getBitrouterAcpAgent,
+} from "@/lib/bitrouter-acp/catalog";
+import { agentTools } from "@/lib/chat-agent";
+import {
+  createHarnessSandbox,
+  hasSandboxCredentials,
+} from "@/lib/harness-sandbox.server";
+
+/**
+ * BitRouter's own agent catalog, exposed to the AI SDK over ACP.
+ *
+ * `@ai-sdk/harness-acp` is the AI SDK's generic harness adapter: declare an
+ * npm-installable ACP v1 agent and it returns a `HarnessV1`. BitRouter's CLI is
+ * on npm and `bitrouter acp serve` speaks vanilla ACP over stdio, so one
+ * `createACP()` per catalog id turns the whole catalog into AI SDK harnesses —
+ * each still routing its model traffic through BitRouter.
+ *
+ * The distinction worth keeping in view: `@ai-sdk/harness-claude-code` runs
+ * Claude Code against Anthropic. These entries run the *same* runtimes with
+ * their traffic routed, which is the product.
+ */
+
+const INSTRUCTIONS = `You are BitRouter's research agent.
+
+Answer questions about BitRouter's docs, models, and pricing. When a question needs facts, call the documentation tools and then answer. Do not ask permission to search.
+
+Rules:
+- Ground every factual claim about BitRouter in a tool result. Never guess at pricing, model ids, or config syntax.
+- Cite the pages you used, as Markdown links.
+- Prefer lookup_model for anything about model cost, context window, or modalities.
+- Be concise. Use Markdown, and fenced code blocks for config or commands.
+
+You are running in a disposable sandbox, not on the user's machine. Its filesystem starts empty and nothing you do there is visible to the user unless you say so. Use the shell for work that genuinely benefits from it and the documentation tools for anything about BitRouter itself.`;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is not set`);
+  return value;
+}
+
+/**
+ * Bump when the bootstrap's side effects change.
+ *
+ * The provider keys a reusable sandbox snapshot off this, so a stale value
+ * silently serves the old image — including an old set of pre-warmed agents.
+ */
+const BOOTSTRAP_HASH = "bitrouter-acp-v2-xz";
+
+/**
+ * Build a `HarnessAgent` for one catalog agent on one model.
+ *
+ * Both axes are fixed at construction: `--model` only takes effect when the
+ * routed path applies its overlay, so it is an argument to the spawned process
+ * rather than something switchable mid-session.
+ */
+export async function createBitrouterAcpAgent({
+  harnessId,
+  modelId,
+}: {
+  harnessId: string;
+  modelId: string;
+}) {
+  const agent = getBitrouterAcpAgent(harnessId);
+  if (!agent) throw new Error(`Unknown BitRouter ACP harness: ${harnessId}`);
+  if (!hasSandboxCredentials()) {
+    throw new Error("Sandbox credentials are not configured");
+  }
+
+  const baseUrl = requireEnv("BITROUTER_API_BASE");
+  // Present so `forwardEnv` has something to forward; the spawned CLI reads it
+  // from its own environment rather than from an argument, keeping the key off
+  // the process command line.
+  requireEnv("BITROUTER_API_KEY");
+
+  return new HarnessAgent({
+    harness: createACP({
+      harnessId: agent.harnessId,
+      // No `packageVersion`: this tracks the `latest` dist-tag and keeps the
+      // version out of the implementation identity, so an alpha release does
+      // not invalidate existing lifecycle state.
+      source: { type: "npm-simple", packageName: "bitrouter" },
+      executable: "bitrouter",
+      // `--base-url` alone is what suppresses the local daemon: autostart is
+      // gated on `base_url.is_none() && target_is_local`, so a remote URL skips
+      // it entirely. `--no-start` would be inert here and `--direct` would
+      // disable routing altogether (and discard `--model`).
+      args: [
+        "acp",
+        "serve",
+        "--agent",
+        agent.agentId,
+        "--base-url",
+        baseUrl,
+        "--model",
+        modelId,
+      ],
+      forwardEnv: ["BITROUTER_API_KEY"],
+      // Deliberately no `authentication`: the bridge only performs the ACP
+      // `authenticate` round trip when this is set, and BitRouter's down-facing
+      // endpoint does not relay upstream auth methods — it answers
+      // `authenticate` with method-not-found. Credentials travel by
+      // environment instead.
+    }),
+    id: agent.harnessId,
+    sandbox: createHarnessSandbox(),
+    sandboxConfig: {
+      bootstrapHash: BOOTSTRAP_HASH,
+      onBootstrap: async ({ session }) => {
+        // `xz` is required and absent from the image, and this is the only
+        // place it can be installed in time. Verified on Vercel Sandbox
+        // `node24` (Amazon Linux 2023, glibc 2.34):
+        //
+        //   - glibc 2.34 < the 2.35 the gnu build needs, so bitrouter's
+        //     installer falls back to its musl-static artifact, a `.tar.xz`
+        //   - the image ships no `xz`, so tar cannot unpack it
+        //   - but pnpm 10 ignores bitrouter's build script during the adapter's
+        //     own bootstrap, so nothing is downloaded then — the fetch is
+        //     deferred to the first spawn of the bin shim
+        //
+        // That deferral is what makes this hook early enough: the adapter's
+        // bootstrap runs before us, but it only writes the shim. Confirmed
+        // end-to-end — `bitrouter --version` returns 1.0.0-alpha.27 afterwards.
+        await session.run({ command: "sudo dnf install -y xz" });
+
+        // BitRouter's catalog spawns each agent as `npx -y <pkg>@latest`.
+        // Warming the npm cache into the snapshot keeps that from being a cold
+        // download on a visitor's first turn. `npx` still resolves `@latest`
+        // at spawn time, so this is a latency optimisation, not a pin.
+        for (const { npmPackage } of BITROUTER_ACP_AGENTS) {
+          await session.run({ command: `npm cache add ${npmPackage}@latest` });
+        }
+      },
+    },
+    instructions: INSTRUCTIONS,
+    // Reach the agent as an MCP server the bridge injects into `session/new`.
+    // BitRouter relays `mcpServers` verbatim to the upstream agent, so the docs
+    // tools survive the extra hop.
+    tools: agentTools,
+  });
+}

--- a/lib/bitrouter-acp/agents.ts
+++ b/lib/bitrouter-acp/agents.ts
@@ -12,6 +12,7 @@ import {
   createHarnessSandbox,
   hasSandboxCredentials,
 } from "@/lib/harness-sandbox.server";
+import type { PlaygroundCredential } from "@/lib/playground-credential";
 
 /**
  * BitRouter's own agent catalog, exposed to the AI SDK over ACP.
@@ -39,12 +40,6 @@ Rules:
 
 You are running in a disposable sandbox, not on the user's machine. Its filesystem starts empty and nothing you do there is visible to the user unless you say so. Use the shell for work that genuinely benefits from it and the documentation tools for anything about BitRouter itself.`;
 
-function requireEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) throw new Error(`${name} is not set`);
-  return value;
-}
-
 /**
  * Bump when the bootstrap's side effects change.
  *
@@ -54,30 +49,28 @@ function requireEnv(name: string): string {
 const BOOTSTRAP_HASH = "bitrouter-acp-v2-xz";
 
 /**
- * Build a `HarnessAgent` for one catalog agent on one model.
+ * Build a `HarnessAgent` for one catalog agent on one model, spending on
+ * `credential`.
  *
- * Both axes are fixed at construction: `--model` only takes effect when the
- * routed path applies its overlay, so it is an argument to the spawned process
- * rather than something switchable mid-session.
+ * All three axes are fixed at construction: `--model` only takes effect when
+ * the routed path applies its overlay, so it is an argument to the spawned
+ * process rather than something switchable mid-session, and the credential is
+ * baked into the sandbox's environment with no way to refresh it.
  */
 export async function createBitrouterAcpAgent({
   harnessId,
   modelId,
+  credential,
 }: {
   harnessId: string;
   modelId: string;
+  credential: PlaygroundCredential;
 }) {
   const agent = getBitrouterAcpAgent(harnessId);
   if (!agent) throw new Error(`Unknown BitRouter ACP harness: ${harnessId}`);
   if (!hasSandboxCredentials()) {
     throw new Error("Sandbox credentials are not configured");
   }
-
-  const baseUrl = requireEnv("BITROUTER_API_BASE");
-  // Present so `forwardEnv` has something to forward; the spawned CLI reads it
-  // from its own environment rather than from an argument, keeping the key off
-  // the process command line.
-  requireEnv("BITROUTER_API_KEY");
 
   return new HarnessAgent({
     harness: createACP({
@@ -97,11 +90,23 @@ export async function createBitrouterAcpAgent({
         "--agent",
         agent.agentId,
         "--base-url",
-        baseUrl,
+        credential.baseUrl,
         "--model",
         modelId,
       ],
-      forwardEnv: ["BITROUTER_API_KEY"],
+      // `env`, not `forwardEnv`: the token is now per-visitor, and `forwardEnv`
+      // can only name variables on *this* process — it would forward the house
+      // key to everyone. The adapter rejects a key present in both.
+      //
+      // Safe despite the "values persist in identity" warning on this option.
+      // The value lands in `implementationIdentity`, a hash that gates only
+      // resume-compatibility *within* one session, where the credential is
+      // fixed (the pool rebuilds on expiry rather than swapping). It does not
+      // reach the sandbox's `implementation.json`, which records env *keys*
+      // only, nor the bootstrap file set — so the snapshot `BOOTSTRAP_HASH`
+      // gates stays shared across visitors instead of paying a cold `dnf
+      // install xz` per session.
+      env: { BITROUTER_API_KEY: credential.token },
       // Deliberately no `authentication`: the bridge only performs the ACP
       // `authenticate` round trip when this is set, and BitRouter's down-facing
       // endpoint does not relay upstream auth methods — it answers

--- a/lib/bitrouter-acp/catalog.test.ts
+++ b/lib/bitrouter-acp/catalog.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BITROUTER_ACP_AGENTS,
+  getBitrouterAcpAgent,
+  isBitrouterAcpHarness,
+} from "./catalog";
+import { getHarness, HARNESSES } from "../harnesses";
+
+describe("BitRouter ACP catalog", () => {
+  it("has an entry in the harness registry for every agent", () => {
+    // The two lists are maintained separately — the registry drives the picker,
+    // this one drives the spawn. A drift here is a harness that renders but
+    // cannot start, or starts but never renders.
+    for (const agent of BITROUTER_ACP_AGENTS) {
+      expect(getHarness(agent.harnessId), agent.harnessId).toBeDefined();
+    }
+  });
+
+  it("covers every bitrouter-prefixed registry entry", () => {
+    const registryIds = HARNESSES.map((h) => h.id).filter((id) =>
+      id.startsWith("bitrouter-"),
+    );
+    const catalogIds = BITROUTER_ACP_AGENTS.map((a) => a.harnessId);
+    expect([...registryIds].sort()).toEqual([...catalogIds].sort());
+  });
+
+  it("declares every agent as a sandbox-backed session", () => {
+    // The ACP bridge runs inside the sandbox and is dialled over an exposed
+    // port, and the runtime owns its own history.
+    for (const agent of BITROUTER_ACP_AGENTS) {
+      const harness = getHarness(agent.harnessId);
+      expect(harness?.runtime, agent.harnessId).toBe("sandbox-vm");
+      expect(harness?.transport, agent.harnessId).toBe("session");
+    }
+  });
+
+  it("uses distinct agent ids", () => {
+    const ids = BITROUTER_ACP_AGENTS.map((a) => a.agentId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("getBitrouterAcpAgent", () => {
+  it("resolves a known harness to its BitRouter catalog id", () => {
+    expect(getBitrouterAcpAgent("bitrouter-claude-acp")?.agentId).toBe(
+      "claude-acp",
+    );
+  });
+
+  it("returns undefined for harnesses that are not BitRouter-fronted", () => {
+    // `claude-code` is the AI SDK's own adapter talking to Anthropic directly —
+    // deliberately a different entry from `bitrouter-claude-acp`.
+    for (const id of ["pi", "ai-sdk", "claude-code", "nope", ""]) {
+      expect(getBitrouterAcpAgent(id), id).toBeUndefined();
+      expect(isBitrouterAcpHarness(id), id).toBe(false);
+    }
+  });
+});

--- a/lib/bitrouter-acp/catalog.ts
+++ b/lib/bitrouter-acp/catalog.ts
@@ -1,0 +1,66 @@
+import type { HarnessId } from "@/lib/harnesses";
+
+/**
+ * Which BitRouter catalog agents the playground fronts.
+ *
+ * Kept separate from `agents.ts` because that module is `server-only` and pulls
+ * in the harness runtime; this is plain data that the registry, the tests, and
+ * any client-side copy can read freely.
+ *
+ * `npmPackage` is what BitRouter's own catalog spawns for the id (via
+ * `npx -y <pkg>@latest`). It is pre-warmed into the sandbox snapshot so a
+ * visitor's first turn is not also a package install.
+ */
+export type BitrouterAcpAgent = {
+  harnessId: HarnessId;
+  agentId: string;
+  /**
+   * What BitRouter's catalog spawns for this id (via `npx -y <pkg>@latest`).
+   * Pre-warmed into the sandbox snapshot so a visitor's first turn is not also
+   * a package install.
+   */
+  npmPackage: string;
+  /** Set when this agent cannot currently work in our routed configuration. */
+  knownIssue?: string;
+};
+
+export const BITROUTER_ACP_AGENTS = [
+  {
+    harnessId: "bitrouter-claude-acp",
+    agentId: "claude-acp",
+    npmPackage: "@zed-industries/claude-code-acp",
+  },
+  {
+    harnessId: "bitrouter-codex-acp",
+    agentId: "codex-acp",
+    npmPackage: "@agentclientprotocol/codex-acp",
+  },
+  {
+    harnessId: "bitrouter-gemini-cli",
+    agentId: "gemini-cli",
+    npmPackage: "@google/gemini-cli",
+    // BitRouter's own catalog notes that gemini-cli sends its key as
+    // `x-goog-api-key` rather than a Bearer token, and `apply_routing` warns
+    // that such a harness "will likely 401" whenever a key is required — which
+    // it always is against a remote base URL like ours. Upstream has also
+    // deprecated it in favour of Antigravity. Listed so the axis stays honest,
+    // but not offered as working.
+    knownIssue:
+      "Sends a non-Bearer API key the router rejects; deprecated upstream.",
+  },
+  {
+    harnessId: "bitrouter-pi-acp",
+    agentId: "pi-acp",
+    npmPackage: "pi-acp",
+  },
+] as const satisfies ReadonlyArray<BitrouterAcpAgent>;
+
+export function getBitrouterAcpAgent(
+  harnessId: string,
+): BitrouterAcpAgent | undefined {
+  return BITROUTER_ACP_AGENTS.find((a) => a.harnessId === harnessId);
+}
+
+export function isBitrouterAcpHarness(harnessId: string): boolean {
+  return getBitrouterAcpAgent(harnessId) !== undefined;
+}

--- a/lib/bitrouter-provider.ts
+++ b/lib/bitrouter-provider.ts
@@ -1,17 +1,42 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
+import type { PlaygroundCredential } from "@/lib/playground-credential";
+
 /**
- * Shared AI SDK provider pointed at the BitRouter router.
+ * AI SDK providers pointed at the BitRouter router.
  *
  * BitRouter speaks the OpenAI wire format, so `@ai-sdk/openai-compatible` is
  * the right adapter — `bitrouter("<vendor>/<model>")` passes the model id
  * through untouched and the router resolves it to an upstream provider.
  *
- * This uses the site's own server-side key. It is never exposed to the client;
- * every call goes through a route handler under `app/api/`.
+ * There are two, because the site spends on two different things:
+ *
+ * - {@link bitrouter} is the house account. It backs the docs "Ask AI" search,
+ *   which is site functionality rather than something a visitor is billed for.
+ * - {@link createBitrouterProvider} is per-request, built from a credential the
+ *   playground resolved for whoever is signed in, so their turns are attributed
+ *   and capped against their own grant.
+ *
+ * Neither key reaches the client; every call goes through a route handler under
+ * `app/api/`.
  */
 export const bitrouter = createOpenAICompatible({
   name: "bitrouter",
   baseURL: process.env.BITROUTER_API_BASE!,
   apiKey: process.env.BITROUTER_API_KEY,
 });
+
+/**
+ * A provider bound to one resolved credential.
+ *
+ * Built per request rather than memoised: in session mode the token is minted
+ * for a single visitor and expires within minutes, so caching it across
+ * requests would leak one user's spend authority into another's turn.
+ */
+export function createBitrouterProvider(credential: PlaygroundCredential) {
+  return createOpenAICompatible({
+    name: "bitrouter",
+    baseURL: credential.baseUrl,
+    apiKey: credential.token,
+  });
+}

--- a/lib/bitrouter-provider.ts
+++ b/lib/bitrouter-provider.ts
@@ -1,0 +1,17 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+
+/**
+ * Shared AI SDK provider pointed at the BitRouter router.
+ *
+ * BitRouter speaks the OpenAI wire format, so `@ai-sdk/openai-compatible` is
+ * the right adapter — `bitrouter("<vendor>/<model>")` passes the model id
+ * through untouched and the router resolves it to an upstream provider.
+ *
+ * This uses the site's own server-side key. It is never exposed to the client;
+ * every call goes through a route handler under `app/api/`.
+ */
+export const bitrouter = createOpenAICompatible({
+  name: "bitrouter",
+  baseURL: process.env.BITROUTER_API_BASE!,
+  apiKey: process.env.BITROUTER_API_KEY,
+});

--- a/lib/chat-agent.ts
+++ b/lib/chat-agent.ts
@@ -1,0 +1,82 @@
+import "server-only";
+
+import { tool } from "ai";
+import { z } from "zod";
+
+import { getDoc, lookupModel, searchDocs } from "@/lib/mcp/tools";
+
+/**
+ * Tools for `/chat` agent mode.
+ *
+ * These are the same read-only capabilities the public MCP server at `/mcp`
+ * exposes (`lib/mcp/tools.ts`) — docs search, doc read, model lookup. Agent
+ * mode deliberately has no sandbox, shell, file write, or outbound web fetch:
+ * the endpoint is unauthenticated and spends the site's shared key, so every
+ * tool here has to be safe to run unattended for an anonymous visitor.
+ */
+export const agentTools = {
+  search_docs: tool({
+    description:
+      "Search BitRouter's documentation. Returns titled hits, each with a canonical URL and a `path` to pass to read_doc. Use this first to find relevant pages.",
+    inputSchema: z.object({
+      query: z.string().describe("Search query, e.g. 'provider fallback'"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .optional()
+        .describe("Max hits (default 6)"),
+    }),
+    execute: ({ query, limit }) => searchDocs(query, { limit: limit ?? 6 }),
+  }),
+
+  read_doc: tool({
+    description:
+      "Read one BitRouter documentation page as Markdown. Pass the `path` returned by search_docs, e.g. 'guides/routing/model-fallback'.",
+    inputSchema: z.object({
+      path: z.string().describe("Doc slug path or full URL"),
+    }),
+    execute: ({ path }) => getDoc(path),
+  }),
+
+  lookup_model: tool({
+    description:
+      "Look up models in BitRouter's catalog by name, vendor, or capability. Returns pricing, context window, and modalities. Use this for any question about what a model costs or supports.",
+    inputSchema: z.object({
+      query: z
+        .string()
+        .describe("Model name, vendor, or capability, e.g. 'cheap vision'"),
+    }),
+    execute: ({ query }) => lookupModel(query),
+  }),
+} as const;
+
+export const AGENT_INSTRUCTIONS = `You are BitRouter's research agent.
+
+Work autonomously: when a question needs facts about BitRouter's docs, models, or pricing, plan a short sequence of tool calls, run them, and then answer. Do not ask the user for permission to search.
+
+Rules:
+- Ground every factual claim about BitRouter in a tool result. Never guess at pricing, model ids, or config syntax.
+- Cite the pages you used, as Markdown links.
+- Prefer lookup_model for anything about model cost, context window, or modalities.
+- If the tools return nothing relevant, say so plainly rather than inventing an answer.
+- Be concise. Use Markdown, and fenced code blocks for config or commands.`;
+
+/**
+ * Hard ceiling on agent steps.
+ *
+ * Agent mode multiplies token spend per user message, and this endpoint runs
+ * on the site's shared key with no auth in front of it. This cap is the only
+ * thing bounding the cost of a single request.
+ */
+export const AGENT_MAX_STEPS = 6;
+
+/**
+ * Model used for the agent's tool-calling steps.
+ *
+ * The point of routing: intermediate steps are mostly "decide which tool to
+ * call next", which a cheap model does fine. The user's selected model is
+ * reserved for the final synthesis, where quality actually shows.
+ */
+export const AGENT_STEP_MODEL = "deepseek/deepseek-v4-flash";

--- a/lib/chat-models.test.ts
+++ b/lib/chat-models.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CHAT_MODELS,
+  DEFAULT_CHAT_MODEL,
+  estimateCostUsd,
+  getChatModel,
+  isAllowedChatModel,
+} from "./chat-models";
+
+describe("isAllowedChatModel", () => {
+  it("accepts every allowlisted id", () => {
+    for (const model of CHAT_MODELS) {
+      expect(isAllowedChatModel(model.id)).toBe(true);
+    }
+  });
+
+  it("rejects ids that are not on the allowlist", () => {
+    // The route spends the site's shared key, so anything not allowlisted
+    // must fall back rather than reach the router.
+    expect(isAllowedChatModel("anthropic/claude-opus-5")).toBe(false);
+    expect(isAllowedChatModel("")).toBe(false);
+    expect(isAllowedChatModel(undefined)).toBe(false);
+    expect(isAllowedChatModel({ id: "x" })).toBe(false);
+  });
+
+  it("has a default that is itself allowlisted", () => {
+    expect(isAllowedChatModel(DEFAULT_CHAT_MODEL)).toBe(true);
+  });
+});
+
+describe("estimateCostUsd", () => {
+  it("prices a million input tokens at the model's input rate", () => {
+    // Claude Haiku 4.5 is $1/M in, $5/M out.
+    expect(
+      estimateCostUsd({
+        modelId: "anthropic/claude-haiku-4.5",
+        inputTokens: 1_000_000,
+      }),
+    ).toBeCloseTo(1);
+
+    expect(
+      estimateCostUsd({
+        modelId: "anthropic/claude-haiku-4.5",
+        outputTokens: 1_000_000,
+      }),
+    ).toBeCloseTo(5);
+  });
+
+  it("sums input and output", () => {
+    expect(
+      estimateCostUsd({
+        modelId: "anthropic/claude-haiku-4.5",
+        inputTokens: 500_000,
+        outputTokens: 200_000,
+      }),
+    ).toBeCloseTo(0.5 + 1);
+  });
+
+  it("returns undefined for unknown models rather than a misleading zero", () => {
+    // The reason this helper exists instead of tokenlens: an unknown model
+    // must not render as "$0.00".
+    expect(estimateCostUsd({ modelId: "who/knows", inputTokens: 1000 })).toBe(
+      undefined,
+    );
+    expect(estimateCostUsd({ inputTokens: 1000 })).toBe(undefined);
+  });
+
+  it("treats missing token counts as zero", () => {
+    expect(estimateCostUsd({ modelId: DEFAULT_CHAT_MODEL })).toBe(0);
+  });
+});
+
+describe("model catalog", () => {
+  it("gives every model a provider icon key and a context window", () => {
+    for (const model of CHAT_MODELS) {
+      expect(model.provider).toBeTruthy();
+      // The vendor prefix of the id is what ProviderIcon is keyed on.
+      expect(model.id.startsWith(`${model.provider}/`)).toBe(true);
+      expect(model.contextWindow).toBeGreaterThan(0);
+    }
+  });
+
+  it("resolves models by id", () => {
+    expect(getChatModel(DEFAULT_CHAT_MODEL)?.id).toBe(DEFAULT_CHAT_MODEL);
+    expect(getChatModel("nope/nope")).toBe(undefined);
+  });
+});

--- a/lib/chat-models.ts
+++ b/lib/chat-models.ts
@@ -1,0 +1,153 @@
+import type { LanguageModelUsage, UIMessage } from "ai";
+
+import type { HarnessId } from "@/lib/harnesses";
+
+/**
+ * Models offered in the `/chat` playground.
+ *
+ * This is a deliberate allowlist, not the full `/v1/models` catalog: the page
+ * runs on the site's shared BitRouter key, so the route handler must never
+ * forward an arbitrary client-supplied model id. Keep the set small, cheap to
+ * serve, and spread across vendors — the point is to show that one endpoint
+ * reaches every provider.
+ *
+ * Prices are USD per million tokens, mirrored from `.models-snapshot.json`
+ * for display only; the router is the source of truth for billing.
+ */
+export type ChatModel = {
+  id: string;
+  label: string;
+  vendor: string;
+  /** Key for `ProviderIcon` — matches the vendor prefix of `id`. */
+  provider: string;
+  inputUsdPerM: number;
+  outputUsdPerM: number;
+  /** Context window in tokens, used by the `Context` usage meter. */
+  contextWindow: number;
+};
+
+export const CHAT_MODELS: ChatModel[] = [
+  {
+    id: "deepseek/deepseek-v4-flash",
+    label: "DeepSeek V4 Flash",
+    vendor: "DeepSeek",
+    provider: "deepseek",
+    inputUsdPerM: 0.112,
+    outputUsdPerM: 0.224,
+    contextWindow: 262144,
+  },
+  {
+    id: "minimax/minimax-m3",
+    label: "MiniMax M3",
+    vendor: "MiniMax",
+    provider: "minimax",
+    inputUsdPerM: 0.3,
+    outputUsdPerM: 1.2,
+    contextWindow: 1048576,
+  },
+  {
+    id: "deepseek/deepseek-v4-pro",
+    label: "DeepSeek V4 Pro",
+    vendor: "DeepSeek",
+    provider: "deepseek",
+    inputUsdPerM: 0.435,
+    outputUsdPerM: 0.87,
+    contextWindow: 256000,
+  },
+  {
+    id: "z-ai/glm-5.2",
+    label: "GLM 5.2",
+    vendor: "Z.ai",
+    provider: "z-ai",
+    inputUsdPerM: 0.979,
+    outputUsdPerM: 3.08,
+    contextWindow: 1000000,
+  },
+  {
+    id: "anthropic/claude-haiku-4.5",
+    label: "Claude Haiku 4.5",
+    vendor: "Anthropic",
+    provider: "anthropic",
+    inputUsdPerM: 1,
+    outputUsdPerM: 5,
+    contextWindow: 200000,
+  },
+  {
+    id: "openai/gpt-5.4-mini",
+    label: "GPT-5.4 mini",
+    vendor: "OpenAI",
+    provider: "openai",
+    inputUsdPerM: 0.75,
+    outputUsdPerM: 4.5,
+    contextWindow: 128000,
+  },
+  {
+    id: "x-ai/grok-4.5",
+    label: "Grok 4.5",
+    vendor: "xAI",
+    provider: "x-ai",
+    inputUsdPerM: 2,
+    outputUsdPerM: 6,
+    contextWindow: 500000,
+  },
+  {
+    id: "qwen/qwen3.8-max",
+    label: "Qwen 3.8 Max",
+    vendor: "Qwen",
+    provider: "qwen",
+    inputUsdPerM: 2,
+    outputUsdPerM: 6,
+    contextWindow: 1000000,
+  },
+];
+
+export const DEFAULT_CHAT_MODEL = CHAT_MODELS[0].id;
+
+export function isAllowedChatModel(id: unknown): id is string {
+  return typeof id === "string" && CHAT_MODELS.some((m) => m.id === id);
+}
+
+export function getChatModel(id: string): ChatModel | undefined {
+  return CHAT_MODELS.find((m) => m.id === id);
+}
+
+/**
+ * Per-message metadata the route streams back on `finish`, so the client can
+ * render real token usage instead of estimating it.
+ */
+export type ChatMetadata = {
+  model?: string;
+  /** Which harness produced the turn — both axes are shown per message. */
+  harness?: HarnessId;
+  usage?: LanguageModelUsage;
+};
+
+export type ChatUIMessage = UIMessage<ChatMetadata>;
+
+/**
+ * Cost in USD for a token count on a given model.
+ *
+ * Deliberately not `tokenlens` (which AI Elements' `Context` ships with by
+ * default): tokenlens resolves prices from its own catalog, which does not
+ * know BitRouter's model ids — it returns an empty `costUSD`, and the
+ * component then renders a confident `$0.00`. Our prices are the ones in
+ * `.models-snapshot.json`, so use those and return `undefined` when a model
+ * is unknown, so callers can omit the figure rather than print a wrong zero.
+ */
+export function estimateCostUsd({
+  modelId,
+  inputTokens = 0,
+  outputTokens = 0,
+}: {
+  modelId?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}): number | undefined {
+  const model = modelId ? getChatModel(modelId) : undefined;
+  if (!model) return undefined;
+
+  return (
+    (inputTokens / 1_000_000) * model.inputUsdPerM +
+    (outputTokens / 1_000_000) * model.outputUsdPerM
+  );
+}

--- a/lib/chat-sessions.test.ts
+++ b/lib/chat-sessions.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatUIMessage } from "./chat-models";
+import { DEFAULT_HARNESS } from "./harnesses";
+import {
+  createSession,
+  deriveTitle,
+  MAX_SESSIONS,
+  parseStore,
+  pruneEmptySessions,
+  removeSession,
+  serializeStore,
+  sortSessions,
+  upsertSession,
+  type ChatSession,
+} from "./chat-sessions";
+
+function userMessage(text: string): ChatUIMessage {
+  return { id: "u1", role: "user", parts: [{ type: "text", text }] };
+}
+
+function session(id: string, updatedAt: number): ChatSession {
+  return {
+    ...createSession({ id, model: "deepseek/deepseek-v4-flash", now: 0 }),
+    updatedAt,
+  };
+}
+
+describe("deriveTitle", () => {
+  it("uses the first user message", () => {
+    expect(deriveTitle([userMessage("How does fallback routing work?")])).toBe(
+      "How does fallback routing work?",
+    );
+  });
+
+  it("truncates long prompts", () => {
+    const title = deriveTitle([userMessage("a".repeat(200))]);
+    expect(title.endsWith("…")).toBe(true);
+    expect(title.length).toBeLessThanOrEqual(49);
+  });
+
+  it("collapses whitespace", () => {
+    expect(deriveTitle([userMessage("  hello\n\n  world  ")])).toBe(
+      "hello world",
+    );
+  });
+
+  it("falls back when there is no user text", () => {
+    expect(deriveTitle([])).toBe("New chat");
+    expect(deriveTitle([userMessage("   ")])).toBe("New chat");
+    expect(
+      deriveTitle([{ id: "a1", role: "assistant", parts: [] }]),
+    ).toBe("New chat");
+  });
+});
+
+describe("upsertSession", () => {
+  it("adds a new session and keeps newest first", () => {
+    const result = upsertSession([session("a", 1)], session("b", 2));
+    expect(result.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("replaces an existing session rather than duplicating it", () => {
+    const existing = session("a", 1);
+    const updated = { ...existing, title: "renamed", updatedAt: 5 };
+    const result = upsertSession([existing, session("b", 2)], updated);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("a");
+    expect(result[0].title).toBe("renamed");
+  });
+
+  it("caps stored sessions", () => {
+    const many = Array.from({ length: MAX_SESSIONS + 10 }, (_, i) =>
+      session(`s${i}`, i),
+    );
+    expect(upsertSession(many, session("new", 9999))).toHaveLength(
+      MAX_SESSIONS,
+    );
+  });
+});
+
+describe("removeSession", () => {
+  it("drops only the named session", () => {
+    const result = removeSession([session("a", 1), session("b", 2)], "a");
+    expect(result.map((s) => s.id)).toEqual(["b"]);
+  });
+});
+
+describe("pruneEmptySessions", () => {
+  function withMessages(id: string): ChatSession {
+    return { ...session(id, 1), messages: [userMessage("hi")] };
+  }
+
+  it("drops sessions that never received a message", () => {
+    const result = pruneEmptySessions([
+      withMessages("used"),
+      session("empty", 2),
+    ]);
+    expect(result.map((s) => s.id)).toEqual(["used"]);
+  });
+
+  it("keeps the session being reused", () => {
+    const result = pruneEmptySessions(
+      [withMessages("used"), session("draft", 2), session("stale", 3)],
+      "draft",
+    );
+    expect(result.map((s) => s.id).sort()).toEqual(["draft", "used"]);
+  });
+});
+
+describe("sortSessions", () => {
+  it("does not mutate its input", () => {
+    const input = [session("a", 1), session("b", 2)];
+    sortSessions(input);
+    expect(input.map((s) => s.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("parseStore", () => {
+  it("round-trips through serializeStore", () => {
+    const sessions = [session("a", 2), session("b", 1)];
+    expect(parseStore(serializeStore(sessions)).sessions.map((s) => s.id)).toEqual(
+      ["a", "b"],
+    );
+  });
+
+  it("degrades to empty rather than throwing on bad input", () => {
+    // A corrupt or foreign localStorage value must not break the page.
+    expect(parseStore(null).sessions).toEqual([]);
+    expect(parseStore("not json").sessions).toEqual([]);
+    expect(parseStore('{"sessions":"nope"}').sessions).toEqual([]);
+    expect(parseStore("[]").sessions).toEqual([]);
+  });
+
+  it("filters out entries that are not sessions", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      sessions: [session("good", 1), { id: 42 }, null, { id: "x" }],
+    });
+    expect(parseStore(raw).sessions.map((s) => s.id)).toEqual(["good"]);
+  });
+
+  it("keeps sessions stored before the harness picker existed", () => {
+    // Dropping a transcript over a field that did not exist when it was
+    // written would be a worse trade than reopening it on the default.
+    const { harness: _omitted, ...legacy } = session("legacy", 1);
+    const raw = JSON.stringify({ version: 1, sessions: [legacy] });
+
+    const [restored] = parseStore(raw).sessions;
+    expect(restored.id).toBe("legacy");
+    expect(restored.harness).toBe(DEFAULT_HARNESS);
+  });
+
+  it("repairs a harness id that is no longer known", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      sessions: [{ ...session("stale", 1), harness: "retired-runtime" }],
+    });
+    expect(parseStore(raw).sessions[0].harness).toBe(DEFAULT_HARNESS);
+  });
+});

--- a/lib/chat-sessions.ts
+++ b/lib/chat-sessions.ts
@@ -1,0 +1,171 @@
+import type { ChatUIMessage } from "@/lib/chat-models";
+// Relative, not aliased: this module is covered by a pure-logic vitest suite
+// that resolves no path aliases (see vitest.config.ts).
+import { DEFAULT_HARNESS, type HarnessId, isHarnessId } from "./harnesses";
+
+/**
+ * Client-side session store for `/chat`.
+ *
+ * Sessions live in `localStorage` only. That is a deliberate scope choice: the
+ * playground is unauthenticated, so there is no user to hang server-side
+ * history off. The trade is that history is per-device and clearing site data
+ * loses it. Moving to server-side storage is a later step that depends on the
+ * auth decision, and `ChatSession` is shaped to survive that move.
+ */
+
+export type ChatSession = {
+  id: string;
+  title: string;
+  model: string;
+  /**
+   * The harness this conversation belongs to.
+   *
+   * Stored per session rather than globally because a session-backed harness
+   * keys its server-side history off `id` — reopening a transcript has to
+   * address the same runtime that produced it.
+   */
+  harness: HarnessId;
+  messages: ChatUIMessage[];
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type SessionStore = {
+  version: 1;
+  sessions: ChatSession[];
+};
+
+export const STORAGE_KEY = "__bitrouter_chat_sessions";
+
+/** Cap on stored sessions — localStorage is ~5MB and transcripts are chunky. */
+export const MAX_SESSIONS = 50;
+
+const UNTITLED = "New chat";
+
+export function createSession({
+  id,
+  model,
+  harness = DEFAULT_HARNESS,
+  now,
+}: {
+  id: string;
+  model: string;
+  harness?: HarnessId;
+  now: number;
+}): ChatSession {
+  return {
+    id,
+    title: UNTITLED,
+    model,
+    harness,
+    messages: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Derives a session title from its first user message.
+ *
+ * Sessions are titled lazily rather than by asking a model: a title round-trip
+ * would spend tokens on the shared key for every new conversation.
+ */
+export function deriveTitle(messages: ChatUIMessage[]): string {
+  const firstUser = messages.find((m) => m.role === "user");
+  if (!firstUser) return UNTITLED;
+
+  const text = firstUser.parts
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!text) return UNTITLED;
+  return text.length > 48 ? `${text.slice(0, 48).trimEnd()}…` : text;
+}
+
+/** Newest first, so the sidebar reads top-down as most-recent-first. */
+export function sortSessions(sessions: ChatSession[]): ChatSession[] {
+  return [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export function upsertSession(
+  sessions: ChatSession[],
+  session: ChatSession,
+): ChatSession[] {
+  const index = sessions.findIndex((s) => s.id === session.id);
+  const next =
+    index === -1
+      ? [session, ...sessions]
+      : sessions.map((s) => (s.id === session.id ? session : s));
+
+  return sortSessions(next).slice(0, MAX_SESSIONS);
+}
+
+export function removeSession(
+  sessions: ChatSession[],
+  id: string,
+): ChatSession[] {
+  return sessions.filter((s) => s.id !== id);
+}
+
+/**
+ * Drops sessions that never received a message.
+ *
+ * "New chat" opens a session eagerly so the composer has something to write
+ * into, but an unused one should not linger in the sidebar — otherwise
+ * clicking the button twice leaves a trail of empty "New chat" rows.
+ */
+export function pruneEmptySessions(
+  sessions: ChatSession[],
+  keepId?: string,
+): ChatSession[] {
+  return sessions.filter((s) => s.messages.length > 0 || s.id === keepId);
+}
+
+/**
+ * Reads the store, tolerating anything malformed.
+ *
+ * Never throws: a corrupt or foreign `localStorage` value must not take down
+ * the whole page, so unparseable input degrades to an empty history.
+ */
+export function parseStore(raw: string | null): SessionStore {
+  const empty: SessionStore = { version: 1, sessions: [] };
+  if (!raw) return empty;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !Array.isArray((parsed as SessionStore).sessions)
+    ) {
+      return empty;
+    }
+
+    const sessions = (parsed as SessionStore).sessions
+      .filter(
+        (s): s is ChatSession =>
+          typeof s?.id === "string" &&
+          typeof s?.title === "string" &&
+          Array.isArray(s?.messages),
+      )
+      // Sessions written before the harness picker existed have no `harness`,
+      // as do any whose stored value no longer names a known harness. Both
+      // read as the default rather than being dropped — losing a transcript
+      // over a missing field would be a worse trade than reopening it on the
+      // stateless loop.
+      .map((s) => ({
+        ...s,
+        harness: isHarnessId(s.harness) ? s.harness : DEFAULT_HARNESS,
+      }));
+
+    return { version: 1, sessions: sortSessions(sessions) };
+  } catch {
+    return empty;
+  }
+}
+
+export function serializeStore(sessions: ChatSession[]): string {
+  return JSON.stringify({ version: 1, sessions } satisfies SessionStore);
+}

--- a/lib/harness-sandbox.server.ts
+++ b/lib/harness-sandbox.server.ts
@@ -1,0 +1,73 @@
+import "server-only";
+
+import { createVercelSandbox } from "@ai-sdk/sandbox-vercel";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The sandbox the bridge-backed harnesses run in.
+ *
+ * Every sandbox reference in the app goes through this module. The choice is
+ * expected to change — Railway Sandboxes are the intended destination once an
+ * `HarnessV1SandboxProvider` adapter exists for them — and keeping it behind one
+ * export makes that swap a single edit instead of a sweep.
+ *
+ * Why a VM at all: Claude Code, Codex, OpenCode and ACP each install a bridge
+ * *inside* the sandbox and dial back into it over a WebSocket resolved through
+ * `getPortUrl`. `@ai-sdk/sandbox-just-bash` — which Pi uses — exposes no ports,
+ * so it cannot host any of them.
+ */
+
+/** The port the harness bridge binds inside the sandbox. */
+const BRIDGE_PORT = 4000;
+
+/**
+ * Explicit credentials, when the deployment supplies them.
+ *
+ * `@vercel/sandbox` does **not** read these from the environment itself — its
+ * own resolution is the Vercel CLI's `auth.json` plus a `.vercel/project.json`
+ * link, neither of which exists on Railway. The env vars are our convention and
+ * have to be threaded through explicitly, which is what `createHarnessSandbox`
+ * does below. (The SDK's README shows the same pattern.)
+ */
+function explicitCredentials() {
+  const token = process.env.VERCEL_TOKEN;
+  const teamId = process.env.VERCEL_TEAM_ID;
+  const projectId = process.env.VERCEL_PROJECT_ID;
+  if (!token || !teamId || !projectId) return undefined;
+  return { token, teamId, projectId };
+}
+
+/**
+ * Whether a sandbox can be provisioned here.
+ *
+ * Two paths. A deployment sets the explicit trio above. Locally the SDK
+ * authenticates over OIDC instead: `vercel link` writes `.vercel/project.json`
+ * and `vercel env pull` puts a `VERCEL_OIDC_TOKEN` in `.env.local`, which Next
+ * loads into the environment. Both parts are needed — a link without a token
+ * fails at provision time with `LocalOidcContextError`.
+ */
+export function hasSandboxCredentials(): boolean {
+  if (explicitCredentials()) return true;
+  return (
+    Boolean(process.env.VERCEL_OIDC_TOKEN) &&
+    existsSync(join(process.cwd(), ".vercel", "project.json"))
+  );
+}
+
+/**
+ * Build the sandbox provider.
+ *
+ * Created per agent rather than shared at module scope: the provider mints a
+ * sandbox per session, and constructing it eagerly would run before we know
+ * whether credentials exist.
+ */
+export function createHarnessSandbox() {
+  return createVercelSandbox({
+    runtime: "node24",
+    ports: [BRIDGE_PORT],
+    // Omitted entirely when unset so the SDK falls back to its own ambient
+    // resolution rather than receiving explicit `undefined`s.
+    ...explicitCredentials(),
+  });
+}

--- a/lib/harness-sessions.ts
+++ b/lib/harness-sessions.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
 import type { HarnessId } from "@/lib/harnesses";
+import {
+  type PlaygroundCredential,
+  revokePlaygroundCredential,
+} from "@/lib/playground-credential";
 
 /**
  * Live harness sessions, shared by every session-backed harness.
@@ -29,6 +33,12 @@ type Entry<TAgent extends HarnessLike> = {
   session: Awaited<ReturnType<TAgent["createSession"]>>;
   modelId: string;
   harnessId: HarnessId;
+  /**
+   * The credential this session spends on. Held so it can be handed back when
+   * the session ends — a harness credential is minted per session precisely so
+   * that teardown can revoke it.
+   */
+  credential: PlaygroundCredential;
   lastUsedAt: number;
   busy: boolean;
 };
@@ -64,6 +74,9 @@ async function disposeEntry(key: string, entry: Entry<HarnessLike>) {
     // Best-effort: a session that fails to tear down must not fail the request
     // that triggered the sweep.
   }
+  // Hand the credential back even if the teardown above threw — the sandbox
+  // may be gone while the token it held is still live.
+  await revokePlaygroundCredential(entry.credential);
 }
 
 async function sweep() {
@@ -97,11 +110,13 @@ export async function acquireSession<TAgent extends HarnessLike>({
   sessionId,
   modelId,
   harnessId,
+  credential,
   createAgent,
 }: {
   sessionId: string;
   modelId: string;
   harnessId: HarnessId;
+  credential: PlaygroundCredential;
   createAgent: () => Promise<TAgent>;
 }): Promise<Entry<TAgent>> {
   await sweep();
@@ -112,7 +127,13 @@ export async function acquireSession<TAgent extends HarnessLike>({
 
   if (
     existing &&
-    (existing.modelId !== modelId || existing.harnessId !== harnessId)
+    (existing.modelId !== modelId ||
+      existing.harnessId !== harnessId ||
+      // The runtime holds its token in a process environment with no way to
+      // refresh it, so an expired credential makes the session useless. Rebuild
+      // rather than hand back a session whose next turn would 401. Credentials
+      // are minted to outlive the session TTL, so this is the rare case.
+      existing.credential.expiresAt.getTime() <= Date.now())
   ) {
     await disposeEntry(sessionId, existing);
   } else if (existing) {
@@ -130,6 +151,7 @@ export async function acquireSession<TAgent extends HarnessLike>({
     session,
     modelId,
     harnessId,
+    credential,
     lastUsedAt: Date.now(),
     busy: true,
   };

--- a/lib/harness-sessions.ts
+++ b/lib/harness-sessions.ts
@@ -1,0 +1,145 @@
+import "server-only";
+
+import type { HarnessId } from "@/lib/harnesses";
+
+/**
+ * Live harness sessions, shared by every session-backed harness.
+ *
+ * Session-backed runtimes own their conversation history, so a chat maps to a
+ * long-lived server object rather than a replayed transcript. This pool is the
+ * one place that lifecycle is managed.
+ *
+ * It is process-local on purpose. Pi parks sessions in a module-level Map and
+ * keeps working state under the host `tmpdir()`; a sandbox-backed harness holds
+ * a live VM. Neither can outlive the process that created it. That is workable
+ * because the site runs as one long-lived `next start` on Railway — but it does
+ * mean sessions are **evictable, not durable**: a redeploy or a second replica
+ * drops them and the next turn transparently starts a fresh one.
+ */
+
+/** The shape both Pi and the ACP harnesses satisfy. */
+type HarnessLike = {
+  createSession: (options?: { sessionId?: string }) => Promise<{
+    destroy: () => Promise<void>;
+  }>;
+};
+
+type Entry<TAgent extends HarnessLike> = {
+  agent: TAgent;
+  session: Awaited<ReturnType<TAgent["createSession"]>>;
+  modelId: string;
+  harnessId: HarnessId;
+  lastUsedAt: number;
+  busy: boolean;
+};
+
+// The pool is keyed across harnesses whose agent types differ, so the stored
+// entry is deliberately unnarrowed; `acquireSession` re-applies the caller's
+// type on read, where the agent and its session are known to be a matched pair.
+const sessions = new Map<string, Entry<HarnessLike>>();
+
+const SESSION_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Ceiling on concurrent live sessions.
+ *
+ * Deliberately low: a sandbox-backed session is a VM, so this bounds real spend
+ * as well as memory. Sessions evicted here are recreated on the owner's next
+ * turn, minus their history.
+ */
+const MAX_SESSIONS = 25;
+
+export class HarnessSessionBusyError extends Error {
+  constructor() {
+    super("This chat already has a turn in flight.");
+    this.name = "HarnessSessionBusyError";
+  }
+}
+
+async function disposeEntry(key: string, entry: Entry<HarnessLike>) {
+  sessions.delete(key);
+  try {
+    await entry.session.destroy();
+  } catch {
+    // Best-effort: a session that fails to tear down must not fail the request
+    // that triggered the sweep.
+  }
+}
+
+async function sweep() {
+  const now = Date.now();
+  for (const [key, entry] of [...sessions]) {
+    if (!entry.busy && now - entry.lastUsedAt > SESSION_TTL_MS) {
+      await disposeEntry(key, entry);
+    }
+  }
+
+  // Bound total sandboxes regardless of age, oldest idle first.
+  const idle = [...sessions]
+    .filter(([, e]) => !e.busy)
+    .sort((a, b) => a[1].lastUsedAt - b[1].lastUsedAt);
+  while (sessions.size > MAX_SESSIONS && idle.length > 0) {
+    const [key, entry] = idle.shift()!;
+    await disposeEntry(key, entry);
+  }
+}
+
+/**
+ * Get the live session for `sessionId`, building one via `createAgent` if there
+ * is no usable existing one.
+ *
+ * Changing either axis rebuilds the session. These runtimes bind their model
+ * when the agent is constructed and own the conversation history, so there is
+ * no way to swap model or harness underneath an existing transcript — the
+ * client mirrors this by starting a new chat (see `resetsHistory`).
+ */
+export async function acquireSession<TAgent extends HarnessLike>({
+  sessionId,
+  modelId,
+  harnessId,
+  createAgent,
+}: {
+  sessionId: string;
+  modelId: string;
+  harnessId: HarnessId;
+  createAgent: () => Promise<TAgent>;
+}): Promise<Entry<TAgent>> {
+  await sweep();
+
+  const existing = sessions.get(sessionId) as Entry<TAgent> | undefined;
+
+  if (existing?.busy) throw new HarnessSessionBusyError();
+
+  if (
+    existing &&
+    (existing.modelId !== modelId || existing.harnessId !== harnessId)
+  ) {
+    await disposeEntry(sessionId, existing);
+  } else if (existing) {
+    existing.busy = true;
+    existing.lastUsedAt = Date.now();
+    return existing;
+  }
+
+  const agent = await createAgent();
+  const session = (await agent.createSession({ sessionId })) as Awaited<
+    ReturnType<TAgent["createSession"]>
+  >;
+  const entry: Entry<TAgent> = {
+    agent,
+    session,
+    modelId,
+    harnessId,
+    lastUsedAt: Date.now(),
+    busy: true,
+  };
+  sessions.set(sessionId, entry);
+  return entry;
+}
+
+export function releaseSession(sessionId: string) {
+  const entry = sessions.get(sessionId);
+  if (!entry) return;
+  entry.busy = false;
+  entry.lastUsedAt = Date.now();
+}

--- a/lib/harness-stream.ts
+++ b/lib/harness-stream.ts
@@ -16,6 +16,7 @@ import {
 } from "@/lib/harness-sessions";
 import { type HarnessId, isHarnessId } from "@/lib/harnesses";
 import { createPiAgent } from "@/lib/pi-harness/agent";
+import type { PlaygroundCredential } from "@/lib/playground-credential";
 import { getPostHogClient } from "@/lib/posthog-server";
 
 /**
@@ -37,9 +38,13 @@ function latestUserText(messages: UIMessage[]): string {
 }
 
 /** Which builder backs a harness id. */
-function agentFactory(harnessId: HarnessId, modelId: string) {
-  if (harnessId === "pi") return () => createPiAgent(modelId);
-  return () => createBitrouterAcpAgent({ harnessId, modelId });
+function agentFactory(
+  harnessId: HarnessId,
+  modelId: string,
+  credential: PlaygroundCredential,
+) {
+  if (harnessId === "pi") return () => createPiAgent(modelId, credential);
+  return () => createBitrouterAcpAgent({ harnessId, modelId, credential });
 }
 
 export async function streamHarnessTurn({
@@ -48,6 +53,7 @@ export async function streamHarnessTurn({
   harnessId,
   sessionId,
   distinctId,
+  credential,
   abortSignal,
 }: {
   messages: UIMessage[];
@@ -55,6 +61,12 @@ export async function streamHarnessTurn({
   harnessId: HarnessId;
   sessionId?: string;
   distinctId: string;
+  /**
+   * Who is paying for this session. Bound to the session when the agent is
+   * built — these runtimes hold the token in a process environment with no
+   * refresh path, so it cannot be swapped mid-session (see `acquireSession`).
+   */
+  credential: PlaygroundCredential;
   /** The request's signal — a client that navigates away mid-turn would
    * otherwise leave the session checked out until the TTL sweep. */
   abortSignal?: AbortSignal;
@@ -74,7 +86,8 @@ export async function streamHarnessTurn({
     sessionId,
     modelId,
     harnessId,
-    createAgent: agentFactory(harnessId, modelId),
+    credential,
+    createAgent: agentFactory(harnessId, modelId, credential),
   }).catch((err: unknown) => {
     if (err instanceof HarnessSessionBusyError) return err;
     throw err;

--- a/lib/harness-stream.ts
+++ b/lib/harness-stream.ts
@@ -1,0 +1,133 @@
+import "server-only";
+
+import {
+  createUIMessageStreamResponse,
+  type ToolSet,
+  toUIMessageStream,
+  type UIMessage,
+} from "ai";
+
+import { createBitrouterAcpAgent } from "@/lib/bitrouter-acp/agents";
+import type { ChatUIMessage } from "@/lib/chat-models";
+import {
+  acquireSession,
+  HarnessSessionBusyError,
+  releaseSession,
+} from "@/lib/harness-sessions";
+import { type HarnessId, isHarnessId } from "@/lib/harnesses";
+import { createPiAgent } from "@/lib/pi-harness/agent";
+import { getPostHogClient } from "@/lib/posthog-server";
+
+/**
+ * Turn-serving for every session-backed harness.
+ *
+ * These runtimes own their conversation history, so unlike the stateless loop
+ * this does not replay the transcript — it sends only the newest user turn and
+ * lets the runtime remember the rest.
+ */
+
+function latestUserText(messages: UIMessage[]): string {
+  const last = [...messages].reverse().find((m) => m.role === "user");
+  if (!last) return "";
+  return last.parts
+    .filter((p): p is { type: "text"; text: string } => p.type === "text")
+    .map((p) => p.text)
+    .join("\n")
+    .trim();
+}
+
+/** Which builder backs a harness id. */
+function agentFactory(harnessId: HarnessId, modelId: string) {
+  if (harnessId === "pi") return () => createPiAgent(modelId);
+  return () => createBitrouterAcpAgent({ harnessId, modelId });
+}
+
+export async function streamHarnessTurn({
+  messages,
+  modelId,
+  harnessId,
+  sessionId,
+  distinctId,
+  abortSignal,
+}: {
+  messages: UIMessage[];
+  modelId: string;
+  harnessId: HarnessId;
+  sessionId?: string;
+  distinctId: string;
+  /** The request's signal — a client that navigates away mid-turn would
+   * otherwise leave the session checked out until the TTL sweep. */
+  abortSignal?: AbortSignal;
+}): Promise<Response> {
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    return Response.json({ error: "sessionId is required" }, { status: 400 });
+  }
+
+  const prompt = latestUserText(messages ?? []);
+  if (!prompt) {
+    return Response.json({ error: "No user message" }, { status: 400 });
+  }
+
+  // Caught rather than annotated so the pool's generic survives: annotating
+  // `entry` up front would collapse it to the pool's minimal agent shape.
+  const entry = await acquireSession({
+    sessionId,
+    modelId,
+    harnessId,
+    createAgent: agentFactory(harnessId, modelId),
+  }).catch((err: unknown) => {
+    if (err instanceof HarnessSessionBusyError) return err;
+    throw err;
+  });
+
+  if (entry instanceof HarnessSessionBusyError) {
+    return Response.json({ error: entry.message }, { status: 409 });
+  }
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    releaseSession(sessionId);
+  };
+
+  abortSignal?.addEventListener("abort", release);
+
+  try {
+    const result = await entry.agent.stream({ session: entry.session, prompt });
+
+    const stream = toUIMessageStream<ToolSet, ChatUIMessage>({
+      stream: result.stream,
+      tools: entry.agent.tools,
+      messageMetadata: ({ part }) => {
+        if (part.type !== "finish") return undefined;
+
+        getPostHogClient().capture({
+          distinctId,
+          event: "chat_playground_completion",
+          properties: {
+            model: modelId,
+            harness: harnessId,
+            input_tokens: part.totalUsage?.inputTokens,
+            output_tokens: part.totalUsage?.outputTokens,
+          },
+        });
+
+        return {
+          model: modelId,
+          harness: isHarnessId(harnessId) ? harnessId : undefined,
+          usage: part.totalUsage,
+        };
+      },
+    }).pipeThrough(
+      // The session stays checked out until the stream is done, so a second
+      // turn on the same chat gets a 409 instead of interleaving with this one.
+      new TransformStream({ flush: release }),
+    );
+
+    return createUIMessageStreamResponse({ stream });
+  } catch (err) {
+    release();
+    throw err;
+  }
+}

--- a/lib/harnesses.server.ts
+++ b/lib/harnesses.server.ts
@@ -8,6 +8,7 @@ import {
   HARNESSES,
   type HarnessOption,
 } from "@/lib/harnesses";
+import { credentialMode } from "@/lib/playground-credential";
 
 /**
  * Which harnesses this deployment can actually run.
@@ -17,18 +18,34 @@ import {
  * harnesses drag ~165MB of dependencies behind them.
  */
 
+/** What a deployment needs configured before it can spend on the router. */
+const ROUTER_CREDENTIAL_REQUIREMENT =
+  credentialMode() === "session"
+    ? "Needs BITROUTER_API_BASE and NEXT_PUBLIC_CONSOLE_URL."
+    : "Needs BITROUTER_API_KEY and BITROUTER_API_BASE.";
+
+/**
+ * Whether this deployment can obtain a router credential at all.
+ *
+ * Mode-dependent: `byo-key` needs the key in the environment, while `session`
+ * needs a console to mint against and gets no key of its own. Note this is a
+ * question about the *deployment*, not the visitor — in session mode a signed-out
+ * visitor still sees an available harness and is turned away by the 401 from
+ * `resolveCredential`, because the picker is rendered before we know who they are.
+ */
 function hasRouterCredentials(): boolean {
-  return (
-    Boolean(process.env.BITROUTER_API_KEY) &&
-    Boolean(process.env.BITROUTER_API_BASE)
-  );
+  if (!process.env.BITROUTER_API_BASE) return false;
+  return credentialMode() === "session"
+    ? Boolean(process.env.NEXT_PUBLIC_CONSOLE_URL)
+    : Boolean(process.env.BITROUTER_API_KEY);
 }
 
 /**
  * Whether the Pi harness is switched on.
  *
- * It holds a live agent session per visitor and spends the site's shared key,
- * so it stays dark unless a deployment opts in explicitly.
+ * It holds a live agent session per visitor, so it stays dark unless a
+ * deployment opts in explicitly — in `byo-key` mode that session spends the
+ * site's shared key with nothing to cap it.
  */
 export function isPiHarnessEnabled(): boolean {
   return process.env.ENABLE_PI_HARNESS === "1" && hasRouterCredentials();
@@ -46,7 +63,7 @@ function availabilityFor(harness: Harness): HarnessOption {
         available: false,
         reason: hasRouterCredentials()
           ? "Set ENABLE_PI_HARNESS=1 to switch it on."
-          : "Needs BITROUTER_API_KEY and BITROUTER_API_BASE.",
+          : ROUTER_CREDENTIAL_REQUIREMENT,
       };
 
     // BitRouter's own catalog over ACP. Needs a port-capable sandbox (the ACP
@@ -74,7 +91,7 @@ function availabilityFor(harness: Harness): HarnessOption {
         return {
           ...harness,
           available: false,
-          reason: "Needs BITROUTER_API_KEY and BITROUTER_API_BASE.",
+          reason: ROUTER_CREDENTIAL_REQUIREMENT,
         };
       }
       return { ...harness, available: true };

--- a/lib/harnesses.server.ts
+++ b/lib/harnesses.server.ts
@@ -1,0 +1,104 @@
+import "server-only";
+
+import { getBitrouterAcpAgent } from "@/lib/bitrouter-acp/catalog";
+import { hasSandboxCredentials } from "@/lib/harness-sandbox.server";
+import {
+  type Harness,
+  type HarnessId,
+  HARNESSES,
+  type HarnessOption,
+} from "@/lib/harnesses";
+
+/**
+ * Which harnesses this deployment can actually run.
+ *
+ * Kept separate from the registry so the client can render the picker without
+ * pulling in the runtimes: this module reads environment, and the packaged
+ * harnesses drag ~165MB of dependencies behind them.
+ */
+
+function hasRouterCredentials(): boolean {
+  return (
+    Boolean(process.env.BITROUTER_API_KEY) &&
+    Boolean(process.env.BITROUTER_API_BASE)
+  );
+}
+
+/**
+ * Whether the Pi harness is switched on.
+ *
+ * It holds a live agent session per visitor and spends the site's shared key,
+ * so it stays dark unless a deployment opts in explicitly.
+ */
+export function isPiHarnessEnabled(): boolean {
+  return process.env.ENABLE_PI_HARNESS === "1" && hasRouterCredentials();
+}
+
+function availabilityFor(harness: Harness): HarnessOption {
+  switch (harness.id) {
+    case "ai-sdk":
+      return { ...harness, available: true };
+
+    case "pi":
+      if (isPiHarnessEnabled()) return { ...harness, available: true };
+      return {
+        ...harness,
+        available: false,
+        reason: hasRouterCredentials()
+          ? "Set ENABLE_PI_HARNESS=1 to switch it on."
+          : "Needs BITROUTER_API_KEY and BITROUTER_API_BASE.",
+      };
+
+    // BitRouter's own catalog over ACP. Needs a port-capable sandbox (the ACP
+    // bridge runs inside it and is dialled over `getPortUrl`) and router
+    // credentials for the `--base-url` route the spawned CLI takes.
+    case "bitrouter-claude-acp":
+    case "bitrouter-codex-acp":
+    case "bitrouter-gemini-cli":
+    case "bitrouter-pi-acp": {
+      // An agent we know cannot work in this routed configuration stays listed
+      // but is never offered — a harness that reliably 401s is worse than one
+      // that is honestly greyed out.
+      const knownIssue = getBitrouterAcpAgent(harness.id)?.knownIssue;
+      if (knownIssue) {
+        return { ...harness, available: false, reason: knownIssue };
+      }
+      if (!hasSandboxCredentials()) {
+        return {
+          ...harness,
+          available: false,
+          reason: "Needs sandbox credentials (VERCEL_TOKEN and friends).",
+        };
+      }
+      if (!hasRouterCredentials()) {
+        return {
+          ...harness,
+          available: false,
+          reason: "Needs BITROUTER_API_KEY and BITROUTER_API_BASE.",
+        };
+      }
+      return { ...harness, available: true };
+    }
+
+    // Claude Code, Codex and OpenCode each install a bridge inside the sandbox
+    // and open a WebSocket back to it via the sandbox's `getPortUrl`. Unlike the
+    // BitRouter entries above, these run against their vendor's own API rather
+    // than through the router, so they also need that vendor's credentials —
+    // which this deployment deliberately does not hold.
+    default:
+      return {
+        ...harness,
+        available: false,
+        reason: "Runs against the vendor's own API; no credentials configured.",
+      };
+  }
+}
+
+export function getHarnessAvailability(): HarnessOption[] {
+  return HARNESSES.map(availabilityFor);
+}
+
+export function isHarnessAvailable(id: HarnessId): boolean {
+  const harness = HARNESSES.find((h) => h.id === id);
+  return harness ? availabilityFor(harness).available : false;
+}

--- a/lib/harnesses.test.ts
+++ b/lib/harnesses.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_HARNESS,
+  getHarness,
+  HARNESSES,
+  isHarnessId,
+  resetsHistory,
+} from "./harnesses";
+
+describe("registry", () => {
+  it("has unique ids", () => {
+    const ids = HARNESSES.map((h) => h.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("defaults to a harness that needs no sandbox and no flag", () => {
+    const fallback = getHarness(DEFAULT_HARNESS);
+    expect(fallback?.runtime).toBe("in-process");
+    expect(fallback?.transport).toBe("stateless");
+  });
+
+  it("marks every sandbox-vm harness as session-backed", () => {
+    // A bridge-backed runtime always owns its own history; a stateless one
+    // would have no reason to pay for a VM.
+    for (const harness of HARNESSES.filter((h) => h.runtime === "sandbox-vm")) {
+      expect(harness.transport).toBe("session");
+    }
+  });
+});
+
+describe("isHarnessId", () => {
+  it("accepts known ids", () => {
+    expect(isHarnessId("pi")).toBe(true);
+    expect(isHarnessId("ai-sdk")).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    for (const value of ["", "PI", "gpt", null, undefined, 7, {}]) {
+      expect(isHarnessId(value)).toBe(false);
+    }
+  });
+});
+
+describe("resetsHistory", () => {
+  it("resets whenever the harness changes", () => {
+    expect(
+      resetsHistory({
+        fromHarness: "ai-sdk",
+        toHarness: "pi",
+        modelChanged: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("resets when a session-backed harness changes model", () => {
+    // Pi binds its model when the session is built, so the runtime would come
+    // back with an empty history while the transcript still shows the old turns.
+    expect(
+      resetsHistory({ fromHarness: "pi", toHarness: "pi", modelChanged: true }),
+    ).toBe(true);
+  });
+
+  it("keeps history when the stateless loop changes model", () => {
+    // The whole transcript is replayed every turn, so nothing is lost.
+    expect(
+      resetsHistory({
+        fromHarness: "ai-sdk",
+        toHarness: "ai-sdk",
+        modelChanged: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps history when nothing changed", () => {
+    expect(
+      resetsHistory({ fromHarness: "pi", toHarness: "pi", modelChanged: false }),
+    ).toBe(false);
+  });
+});

--- a/lib/harnesses.ts
+++ b/lib/harnesses.ts
@@ -1,0 +1,169 @@
+/**
+ * The harness axis of the playground.
+ *
+ * BitRouter's pitch is a cross product — any model, any harness — so the
+ * playground picks one of each rather than shipping a surface per harness. A
+ * "harness" here is whatever drives the agent loop: the AI SDK's own
+ * `streamText` loop is one entry, alongside the packaged runtimes
+ * (`@ai-sdk/harness-*`) that own their own history, tools, and sandbox.
+ *
+ * This module is imported by both the client and the route handler, so it holds
+ * no secrets and reads no environment. Whether a harness can actually run on a
+ * given deployment lives in `harnesses.server.ts`.
+ */
+
+export type HarnessId =
+  | "ai-sdk"
+  | "pi"
+  | "claude-code"
+  | "codex"
+  | "opencode"
+  // BitRouter's own catalog, over ACP. Flat rather than a nested agent picker:
+  // the pair (runtime, routed-through-BitRouter) is the thing being chosen, and
+  // one list keeps the existing single picker and model axis unchanged.
+  | "bitrouter-claude-acp"
+  | "bitrouter-codex-acp"
+  | "bitrouter-gemini-cli"
+  | "bitrouter-pi-acp";
+
+/**
+ * How a turn is sent to the backend.
+ *
+ * - `stateless` — the route replays the whole transcript every turn.
+ * - `session` — the runtime owns the conversation, so the route sends only the
+ *   newest user turn and addresses the session by id.
+ *
+ * The client needs this to know when switching a control would desync the
+ * visible transcript from what the runtime actually remembers.
+ */
+export type HarnessTransport = "stateless" | "session";
+
+export type Harness = {
+  id: HarnessId;
+  label: string;
+  /** One line for the picker. */
+  blurb: string;
+  transport: HarnessTransport;
+  /**
+   * `in-process` runs inside the web server. `sandbox-vm` needs a sandbox
+   * provider that can expose a port, because the adapter installs a bridge in
+   * the sandbox and dials back into it.
+   */
+  runtime: "in-process" | "sandbox-vm";
+};
+
+export const HARNESSES: Harness[] = [
+  {
+    id: "ai-sdk",
+    label: "AI SDK",
+    blurb: "streamText loop, docs tools",
+    transport: "stateless",
+    runtime: "in-process",
+  },
+  {
+    id: "pi",
+    label: "Pi",
+    blurb: "agent runtime, shell + filesystem",
+    transport: "session",
+    runtime: "in-process",
+  },
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    blurb: "agent runtime, needs a sandbox VM",
+    transport: "session",
+    runtime: "sandbox-vm",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    blurb: "agent runtime, needs a sandbox VM",
+    transport: "session",
+    runtime: "sandbox-vm",
+  },
+  {
+    id: "opencode",
+    label: "OpenCode",
+    blurb: "agent runtime, needs a sandbox VM",
+    transport: "session",
+    runtime: "sandbox-vm",
+  },
+  {
+    id: "bitrouter-claude-acp",
+    label: "BitRouter · Claude Code",
+    blurb: "Claude Code, routed through BitRouter",
+    transport: "session",
+    runtime: "sandbox-vm",
+  },
+  {
+    id: "bitrouter-codex-acp",
+    label: "BitRouter · Codex",
+    blurb: "Codex, routed through BitRouter",
+    transport: "session",
+    runtime: "sandbox-vm",
+  },
+  {
+    id: "bitrouter-gemini-cli",
+    label: "BitRouter · Gemini CLI",
+    blurb: "Gemini CLI, routed through BitRouter",
+    transport: "session",
+    runtime: "sandbox-vm",
+  },
+  {
+    id: "bitrouter-pi-acp",
+    label: "BitRouter · Pi",
+    blurb: "Pi, routed through BitRouter",
+    transport: "session",
+    runtime: "sandbox-vm",
+  },
+];
+
+/**
+ * A harness plus whether the current deployment can run it.
+ *
+ * Computed on the server (see `harnesses.server.ts`) and passed to the client,
+ * which renders unavailable entries greyed out with their reason rather than
+ * hiding them — the picker is the clearest statement of the product's shape, so
+ * an option that is merely unconfigured should still be visible.
+ */
+export type HarnessOption = Harness & {
+  available: boolean;
+  reason?: string;
+};
+
+/**
+ * The stateless loop is the default: it is the only entry with no server-side
+ * session, no sandbox, and no deployment flag, so it works everywhere.
+ */
+export const DEFAULT_HARNESS: HarnessId = "ai-sdk";
+
+export function getHarness(id: string): Harness | undefined {
+  return HARNESSES.find((h) => h.id === id);
+}
+
+export function isHarnessId(value: unknown): value is HarnessId {
+  return typeof value === "string" && HARNESSES.some((h) => h.id === value);
+}
+
+/**
+ * Whether swapping `from` → `to` mid-conversation would leave the runtime
+ * remembering something different from what the user can see.
+ *
+ * Session-backed runtimes key their history off the session id and bind their
+ * model at construction, so changing either the harness or the model rebuilds
+ * them with an empty history — while the transcript on screen still shows the
+ * earlier turns. The client starts a fresh chat instead of showing a
+ * conversation the agent has no memory of.
+ */
+export function resetsHistory({
+  fromHarness,
+  toHarness,
+  modelChanged,
+}: {
+  fromHarness: HarnessId;
+  toHarness: HarnessId;
+  modelChanged: boolean;
+}): boolean {
+  if (fromHarness !== toHarness) return true;
+  return modelChanged && getHarness(toHarness)?.transport === "session";
+}

--- a/lib/pi-harness/agent.ts
+++ b/lib/pi-harness/agent.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 
 import { agentTools } from "@/lib/chat-agent";
 import { buildPiModelsJson, piAlias } from "@/lib/pi-harness/models-json";
+import type { PlaygroundCredential } from "@/lib/playground-credential";
 
 /**
  * Pi agent runtime for the harness playground.
@@ -48,8 +49,10 @@ function requireEnv(name: string): string {
 /**
  * Write Pi's catalog once per process.
  *
- * `agentDir` also holds Pi's `auth.json`, which stays empty: the API key is
- * passed through `customEnv` and never touches disk.
+ * `agentDir` also holds Pi's `auth.json`, which stays empty: the token is
+ * passed through `customEnv` and never touches disk. That split is what lets
+ * this be memoized across visitors — the catalog is the same for everyone, and
+ * only the credential differs.
  */
 let agentDirPromise: Promise<string> | undefined;
 
@@ -57,6 +60,9 @@ function ensureAgentDir(): Promise<string> {
   agentDirPromise ??= (async () => {
     const dir = path.join(tmpdir(), "bitrouter-pi-agent");
     await mkdir(dir, { recursive: true, mode: 0o700 });
+    // Read from the environment rather than the caller's credential: this is
+    // memoized per process, so a per-request value would freeze whichever
+    // request happened to be first. `credential.baseUrl` is this same variable.
     const models = buildPiModelsJson({
       baseUrl: requireEnv("BITROUTER_API_BASE"),
     });
@@ -70,7 +76,17 @@ function ensureAgentDir(): Promise<string> {
   return agentDirPromise;
 }
 
-export async function createPiAgent(modelId: string) {
+/**
+ * Build a Pi agent that spends on `credential`.
+ *
+ * The token is baked into the runtime's environment at construction and there
+ * is no path to refresh it, so the credential is fixed for the life of the
+ * session — `acquireSession` rebuilds rather than swapping it.
+ */
+export async function createPiAgent(
+  modelId: string,
+  credential: PlaygroundCredential,
+) {
   const agentDir = await ensureAgentDir();
 
   return new HarnessAgent({
@@ -80,8 +96,8 @@ export async function createPiAgent(modelId: string) {
       agentDir,
       auth: {
         customEnv: {
-          BITROUTER_API_KEY: requireEnv("BITROUTER_API_KEY"),
-          BITROUTER_BASE_URL: requireEnv("BITROUTER_API_BASE"),
+          BITROUTER_API_KEY: credential.token,
+          BITROUTER_BASE_URL: credential.baseUrl,
         },
       },
     }),

--- a/lib/pi-harness/agent.ts
+++ b/lib/pi-harness/agent.ts
@@ -1,0 +1,107 @@
+import "server-only";
+
+import { HarnessAgent } from "@ai-sdk/harness/agent";
+import { createPi } from "@ai-sdk/harness-pi";
+import { createJustBashSandbox } from "@ai-sdk/sandbox-just-bash";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { agentTools } from "@/lib/chat-agent";
+import { buildPiModelsJson, piAlias } from "@/lib/pi-harness/models-json";
+
+/**
+ * Pi agent runtime for the harness playground.
+ *
+ * Pi is the only adapter that runs in-process: every other harness installs a
+ * bridge inside the sandbox and waits for it to advertise a port, which forces
+ * a real sandbox VM per session. Pi needs neither, so this runs against
+ * `@ai-sdk/sandbox-just-bash` — an in-process JS bash over a virtual
+ * filesystem — with no VM, no port, and no cold start.
+ *
+ * The tradeoff: sessions are process-local (see `sessions` below).
+ */
+
+export const HARNESS_INSTRUCTIONS = `You are BitRouter's research agent, running on the Pi harness.
+
+Answer questions about BitRouter's docs, models, and pricing. When a question needs facts, call the documentation tools and then answer. Do not ask permission to search.
+
+Rules:
+- Ground every factual claim about BitRouter in a tool result. Never guess at pricing, model ids, or config syntax.
+- Cite the pages you used, as Markdown links.
+- Prefer lookup_model for anything about model cost, context window, or modalities.
+- Be concise. Use Markdown, and fenced code blocks for config or commands.
+
+Your shell is a sandboxed, in-process bash with a scratch filesystem. It is not the user's machine and nothing you do there is visible to them unless you say so. Know its shape before you reach for it:
+- Available: POSIX shell (pipes, redirects, loops, conditionals, heredocs, arithmetic), ~83 commands including grep, sed, awk, cut, sort, find, xargs, tr, diff, tar, jq, yq, rg, sqlite3, and column.
+- Not available: any interpreter (no node, no python), any network access (no curl, wget, or DNS), and no git.
+- Some GNU flags are missing (for example \`sort -g\`, \`xargs -I\`) and process substitution \`<(...)\` does not parse. Failures are loud — a non-zero exit and a message on stderr — so read the error and try a different formulation rather than repeating the command.
+
+Use the shell when it genuinely helps: arithmetic, reshaping data, or checking your own work. Use the documentation tools for anything about BitRouter itself.`;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is not set`);
+  return value;
+}
+
+/**
+ * Write Pi's catalog once per process.
+ *
+ * `agentDir` also holds Pi's `auth.json`, which stays empty: the API key is
+ * passed through `customEnv` and never touches disk.
+ */
+let agentDirPromise: Promise<string> | undefined;
+
+function ensureAgentDir(): Promise<string> {
+  agentDirPromise ??= (async () => {
+    const dir = path.join(tmpdir(), "bitrouter-pi-agent");
+    await mkdir(dir, { recursive: true, mode: 0o700 });
+    const models = buildPiModelsJson({
+      baseUrl: requireEnv("BITROUTER_API_BASE"),
+    });
+    await writeFile(
+      path.join(dir, "models.json"),
+      JSON.stringify(models, null, 2),
+      { mode: 0o600 },
+    );
+    return dir;
+  })();
+  return agentDirPromise;
+}
+
+export async function createPiAgent(modelId: string) {
+  const agentDir = await ensureAgentDir();
+
+  return new HarnessAgent({
+    harness: createPi({
+      // Address by alias, not by the bare id — see PI_ALIAS_PREFIX.
+      model: piAlias(modelId),
+      agentDir,
+      auth: {
+        customEnv: {
+          BITROUTER_API_KEY: requireEnv("BITROUTER_API_KEY"),
+          BITROUTER_BASE_URL: requireEnv("BITROUTER_API_BASE"),
+        },
+      },
+    }),
+    id: "bitrouter-pi",
+    sandbox: createJustBashSandbox({ cwd: "/work" }),
+    sandboxConfig: {
+      // Workaround for @ai-sdk/sandbox-just-bash@1.0.64: it drops the `env`
+      // option on run(), so the framework's own `mkdir -p "$WORK_DIR"` (with
+      // WORK_DIR passed via env) expands to `mkdir -p ""` — exit code 0, but
+      // nothing created. Pi then fails to start with `cd: ... No such file or
+      // directory`. onSession runs after that mkdir and before Pi starts.
+      onSession: async ({ session, sessionWorkDir }) => {
+        await session.run({ command: `mkdir -p '${sessionWorkDir}'` });
+      },
+    },
+    instructions: HARNESS_INSTRUCTIONS,
+    // The site's docs tools, executed here on the host. Pi's own builtins
+    // (read/write/edit/bash/grep/glob/ls) stay enabled and run inside the
+    // just-bash VFS, which interprets bash in JS rather than spawning host
+    // processes.
+    tools: agentTools,
+  });
+}

--- a/lib/pi-harness/models-json.test.ts
+++ b/lib/pi-harness/models-json.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { CHAT_MODELS } from "../chat-models";
+import {
+  buildPiModelsJson,
+  PI_ALIAS_PREFIX,
+  piAlias,
+  piAliasToModelId,
+} from "./models-json";
+
+const baseUrl = "https://api.bitrouter.ai/v1";
+
+describe("buildPiModelsJson", () => {
+  it("nests providers under the `providers` key Pi's schema requires", () => {
+    const json = buildPiModelsJson({ baseUrl });
+    // A bare provider map fails Pi's validation, and the error surfaces only on
+    // ModelConfig.error — the catalog silently ends up empty.
+    expect(Object.keys(json)).toEqual(["providers"]);
+    expect(json.providers.bitrouter.baseUrl).toBe(baseUrl);
+    expect(json.providers.bitrouter.api).toBe("openai-completions");
+    expect(json.providers.bitrouter.authHeader).toBe(true);
+  });
+
+  it("keeps the bare model id as the wire value", () => {
+    const json = buildPiModelsJson({ baseUrl });
+    const ids = json.providers.bitrouter.models.map((m) => m.id);
+    expect(ids).toEqual(CHAT_MODELS.map((m) => m.id));
+  });
+
+  it("gives every model a prefixed name so builtin ids cannot win", () => {
+    // Pi ships ~1,070 builtin models whose ids are also `vendor/model` shaped;
+    // `deepseek/deepseek-v4-flash` exists there under openrouter. Its resolver
+    // matches id-or-name and takes the first hit, so an unprefixed entry routes
+    // to the builtin provider instead of BitRouter.
+    const json = buildPiModelsJson({ baseUrl });
+    for (const model of json.providers.bitrouter.models) {
+      expect(model.name).toBe(`${PI_ALIAS_PREFIX}${model.id}`);
+      expect(model.name).not.toBe(model.id);
+    }
+  });
+
+  it("carries the display cost and context window across", () => {
+    const [first] = buildPiModelsJson({
+      baseUrl,
+      models: [
+        {
+          id: "vendor/model",
+          label: "Model",
+          vendor: "Vendor",
+          provider: "vendor",
+          inputUsdPerM: 1.5,
+          outputUsdPerM: 6,
+          contextWindow: 128000,
+        },
+      ],
+    }).providers.bitrouter.models;
+
+    expect(first).toEqual({
+      id: "vendor/model",
+      name: "bitrouter:vendor/model",
+      contextWindow: 128000,
+      cost: { input: 1.5, output: 6, cacheRead: 0, cacheWrite: 0 },
+    });
+  });
+});
+
+describe("piAlias", () => {
+  it("round-trips", () => {
+    for (const model of CHAT_MODELS) {
+      expect(piAliasToModelId(piAlias(model.id))).toBe(model.id);
+    }
+  });
+
+  it("leaves an unprefixed id alone", () => {
+    expect(piAliasToModelId("deepseek/deepseek-v4-flash")).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+  });
+});

--- a/lib/pi-harness/models-json.ts
+++ b/lib/pi-harness/models-json.ts
@@ -1,0 +1,99 @@
+// Relative, not `@/` — vitest runs this file without path aliases and
+// CHAT_MODELS is a value import, so an alias here breaks the test run.
+import { CHAT_MODELS, type ChatModel } from "../chat-models";
+
+/**
+ * Pi's `models.json`, generated from the `/chat` allowlist.
+ *
+ * Pi never discovers models over the network — `@ai-sdk/harness-pi` hardcodes
+ * `allowModelNetwork: false`, so BitRouter's `/v1/models` is never consulted
+ * and a catalog file is the only way Pi learns our ids exist. Without one it
+ * silently resolves nothing and falls back to its own default model.
+ */
+
+/**
+ * Alias prefix for every BitRouter model id.
+ *
+ * Pi ships a builtin catalog of ~1,070 models across ~34 providers, and its
+ * ids are `vendor/model` shaped — exactly like ours. `deepseek/deepseek-v4-flash`
+ * already exists there under both `openrouter` and `vercel-ai-gateway`, so the
+ * bare id is ambiguous.
+ *
+ * Pi's resolver matches `model.id === query || model.name === query` and takes
+ * the *first* hit, which is a builtin — meaning a bare id routes to OpenRouter
+ * and fails with "No API key found for openrouter", naming a provider we never
+ * configured. Addressing models by a prefixed `name` disambiguates, while `id`
+ * stays the value that goes out on the wire so BitRouter receives what we mean.
+ */
+export const PI_ALIAS_PREFIX = "bitrouter:";
+
+export function piAlias(modelId: string): string {
+  return `${PI_ALIAS_PREFIX}${modelId}`;
+}
+
+export function piAliasToModelId(alias: string): string {
+  return alias.startsWith(PI_ALIAS_PREFIX)
+    ? alias.slice(PI_ALIAS_PREFIX.length)
+    : alias;
+}
+
+export type PiModelsJson = {
+  providers: {
+    bitrouter: {
+      name: string;
+      baseUrl: string;
+      api: "openai-completions";
+      /** Send `Authorization: Bearer <key>`. */
+      authHeader: true;
+      models: {
+        id: string;
+        name: string;
+        contextWindow: number;
+        cost: {
+          input: number;
+          output: number;
+          cacheRead: number;
+          cacheWrite: number;
+        };
+      }[];
+    };
+  };
+};
+
+/**
+ * Build the catalog Pi reads at startup.
+ *
+ * The `providers` wrapper is required — Pi validates against a schema whose
+ * root object needs it, and a bare provider map is rejected with the error
+ * buried on `ModelConfig.error` rather than thrown.
+ */
+export function buildPiModelsJson({
+  baseUrl,
+  models = CHAT_MODELS,
+}: {
+  baseUrl: string;
+  models?: ChatModel[];
+}): PiModelsJson {
+  return {
+    providers: {
+      bitrouter: {
+        name: "BitRouter",
+        baseUrl,
+        api: "openai-completions",
+        authHeader: true,
+        models: models.map((m) => ({
+          id: m.id,
+          name: piAlias(m.id),
+          contextWindow: m.contextWindow,
+          // Display only — the router bills, not Pi.
+          cost: {
+            input: m.inputUsdPerM,
+            output: m.outputUsdPerM,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+        })),
+      },
+    },
+  };
+}

--- a/lib/playground-credential.test.ts
+++ b/lib/playground-credential.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CredentialError,
+  credentialMode,
+  resolveCredential,
+  revokePlaygroundCredential,
+} from "./playground-credential";
+
+/**
+ * The playground's auth seam.
+ *
+ * These assertions are about who pays and how a refusal is reported — the two
+ * things every other module takes on trust, since everything downstream just
+ * receives a resolved credential.
+ */
+
+const ENV_KEYS = [
+  "PLAYGROUND_CREDENTIAL_MODE",
+  "BITROUTER_API_KEY",
+  "BITROUTER_API_BASE",
+  "NEXT_PUBLIC_CONSOLE_URL",
+  "NEXT_PUBLIC_WEB_URL",
+] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  vi.unstubAllGlobals();
+});
+
+/** A request carrying (or not carrying) the console's shared session cookie. */
+function request(cookie?: string): Request {
+  return new Request("https://bitrouter.ai/api/chat/playground", {
+    method: "POST",
+    headers: cookie ? { cookie } : {},
+  });
+}
+
+/** Capture what the module sends to the console, and answer with `response`. */
+function stubFetch(response: Response | Error) {
+  const fetchMock = vi.fn(async () => {
+    if (response instanceof Error) throw response;
+    return response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function tokenResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const MINTED = {
+  token: "bra_minted",
+  expiresAt: "2030-01-01T00:00:00.000Z",
+  userId: "user_1",
+  namespaceId: "ns_1",
+};
+
+describe("credentialMode", () => {
+  it("defaults to byo-key so an unconfigured clone behaves as before", () => {
+    expect(credentialMode()).toBe("byo-key");
+  });
+
+  it("only opts into session mode on an exact match", () => {
+    for (const value of ["", "Session", "session ", "1", "true"]) {
+      process.env.PLAYGROUND_CREDENTIAL_MODE = value;
+      expect(credentialMode()).toBe("byo-key");
+    }
+    process.env.PLAYGROUND_CREDENTIAL_MODE = "session";
+    expect(credentialMode()).toBe("session");
+  });
+});
+
+describe("byo-key mode", () => {
+  beforeEach(() => {
+    process.env.BITROUTER_API_KEY = "brk_house";
+    process.env.BITROUTER_API_BASE = "https://api.bitrouter.ai/v1";
+  });
+
+  it("resolves the environment key with no attribution", async () => {
+    const credential = await resolveCredential(request(), "chat");
+
+    expect(credential.token).toBe("brk_house");
+    expect(credential.baseUrl).toBe("https://api.bitrouter.ai/v1");
+    expect(credential.mode).toBe("byo-key");
+    expect(credential.attribution).toBeNull();
+    expect(credential.revocationId).toBeUndefined();
+  });
+
+  it("never calls the console", async () => {
+    const fetchMock = stubFetch(tokenResponse(MINTED));
+    await resolveCredential(request("session=abc"), "harness");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing key as misconfiguration, not as a signed-out visitor", async () => {
+    delete process.env.BITROUTER_API_KEY;
+    await expect(resolveCredential(request(), "chat")).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+
+  it("reports a missing router endpoint as misconfiguration", async () => {
+    delete process.env.BITROUTER_API_BASE;
+    await expect(resolveCredential(request(), "chat")).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+
+  it("has nothing to revoke", async () => {
+    const fetchMock = stubFetch(new Response(null, { status: 204 }));
+    const credential = await resolveCredential(request(), "harness");
+    await revokePlaygroundCredential(credential);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("session mode", () => {
+  beforeEach(() => {
+    process.env.PLAYGROUND_CREDENTIAL_MODE = "session";
+    process.env.BITROUTER_API_BASE = "https://api.bitrouter.ai/v1";
+    process.env.NEXT_PUBLIC_CONSOLE_URL = "https://cloud.bitrouter.ai";
+    process.env.NEXT_PUBLIC_WEB_URL = "https://bitrouter.ai";
+    // Present, and deliberately never used: session mode must not fall back to
+    // the house key when the console turns a visitor away.
+    process.env.BITROUTER_API_KEY = "brk_house";
+  });
+
+  it("mints against the console and attributes the credential", async () => {
+    const fetchMock = stubFetch(
+      tokenResponse({ ...MINTED, revocationId: "rev_1" }),
+    );
+
+    const credential = await resolveCredential(request("session=abc"), "harness");
+
+    expect(credential.token).toBe("bra_minted");
+    expect(credential.mode).toBe("session");
+    expect(credential.attribution).toEqual({
+      userId: "user_1",
+      namespaceId: "ns_1",
+    });
+    expect(credential.revocationId).toBe("rev_1");
+    expect(credential.expiresAt.toISOString()).toBe(MINTED.expiresAt);
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("https://cloud.bitrouter.ai/api/playground/token");
+    const headers = init.headers as Record<string, string>;
+    // The visitor's cookie is what authenticates the mint, and the origin is
+    // what gets it past the console's CSRF gate.
+    expect(headers.cookie).toBe("session=abc");
+    expect(headers.origin).toBe("https://bitrouter.ai");
+    expect(JSON.parse(init.body as string)).toEqual({ purpose: "harness" });
+  });
+
+  it("asks for the purpose it was given", async () => {
+    const fetchMock = stubFetch(tokenResponse(MINTED));
+    await resolveCredential(request("session=abc"), "chat");
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ purpose: "chat" });
+  });
+
+  it("trims a trailing slash off the console URL", async () => {
+    process.env.NEXT_PUBLIC_CONSOLE_URL = "https://cloud.bitrouter.ai///";
+    const fetchMock = stubFetch(tokenResponse(MINTED));
+    await resolveCredential(request("session=abc"), "chat");
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(url).toBe("https://cloud.bitrouter.ai/api/playground/token");
+  });
+
+  it("401s a visitor with no cookie, without calling the console", async () => {
+    const fetchMock = stubFetch(tokenResponse(MINTED));
+    await expect(resolveCredential(request(), "chat")).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("passes the console's 401 through", async () => {
+    stubFetch(new Response("no session", { status: 401 }));
+    await expect(
+      resolveCredential(request("session=stale"), "chat"),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("passes the console's 402 through in the console's own words", async () => {
+    stubFetch(new Response("Your $5 trial grant is spent.", { status: 402 }));
+    const err = await resolveCredential(
+      request("session=abc"),
+      "chat",
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(CredentialError);
+    expect((err as CredentialError).status).toBe(402);
+    expect((err as CredentialError).message).toBe(
+      "Your $5 trial grant is spent.",
+    );
+  });
+
+  it("reports an unreachable console as 503, not as a signed-out visitor", async () => {
+    stubFetch(new TypeError("fetch failed"));
+    await expect(
+      resolveCredential(request("session=abc"), "chat"),
+    ).rejects.toMatchObject({ status: 503 });
+  });
+
+  it("rejects a malformed mint rather than returning a partial credential", async () => {
+    for (const body of [
+      { ...MINTED, token: undefined },
+      { ...MINTED, userId: undefined },
+      { ...MINTED, namespaceId: undefined },
+      { ...MINTED, expiresAt: "not a date" },
+    ]) {
+      stubFetch(tokenResponse(body));
+      await expect(
+        resolveCredential(request("session=abc"), "chat"),
+      ).rejects.toMatchObject({ status: 503 });
+    }
+  });
+
+  it("reports a missing console URL as misconfiguration before it fetches", async () => {
+    delete process.env.NEXT_PUBLIC_CONSOLE_URL;
+    const fetchMock = stubFetch(tokenResponse(MINTED));
+    await expect(
+      resolveCredential(request("session=abc"), "chat"),
+    ).rejects.toMatchObject({ status: 500 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing web URL as misconfiguration before it fetches", async () => {
+    delete process.env.NEXT_PUBLIC_WEB_URL;
+    const fetchMock = stubFetch(tokenResponse(MINTED));
+    await expect(
+      resolveCredential(request("session=abc"), "chat"),
+    ).rejects.toMatchObject({ status: 500 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("revokePlaygroundCredential", () => {
+  beforeEach(() => {
+    process.env.PLAYGROUND_CREDENTIAL_MODE = "session";
+    process.env.BITROUTER_API_BASE = "https://api.bitrouter.ai/v1";
+    process.env.NEXT_PUBLIC_CONSOLE_URL = "https://cloud.bitrouter.ai";
+    process.env.NEXT_PUBLIC_WEB_URL = "https://bitrouter.ai";
+  });
+
+  it("hands back a revocable credential, authenticating with the token itself", async () => {
+    stubFetch(tokenResponse({ ...MINTED, revocationId: "rev_1" }));
+    const credential = await resolveCredential(request("session=abc"), "harness");
+
+    const fetchMock = stubFetch(new Response(null, { status: 204 }));
+    await revokePlaygroundCredential(credential);
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("https://cloud.bitrouter.ai/api/playground/token");
+    expect(init.method).toBe("DELETE");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer bra_minted");
+    // The minting session may be long gone by teardown; the revocation id is
+    // the capability, so no cookie is forwarded.
+    expect(headers.cookie).toBeUndefined();
+    expect(JSON.parse(init.body as string)).toEqual({ revocationId: "rev_1" });
+  });
+
+  it("skips a credential the console gave no revocation id for", async () => {
+    stubFetch(tokenResponse(MINTED));
+    const credential = await resolveCredential(request("session=abc"), "chat");
+
+    const fetchMock = stubFetch(new Response(null, { status: 204 }));
+    await revokePlaygroundCredential(credential);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows a failed teardown so it cannot fail the sweep that triggered it", async () => {
+    stubFetch(tokenResponse({ ...MINTED, revocationId: "rev_1" }));
+    const credential = await resolveCredential(request("session=abc"), "harness");
+
+    stubFetch(new TypeError("console down"));
+    await expect(revokePlaygroundCredential(credential)).resolves.toBeUndefined();
+  });
+});

--- a/lib/playground-credential.ts
+++ b/lib/playground-credential.ts
@@ -1,0 +1,298 @@
+import "server-only";
+
+/**
+ * Where the playground's spend authority comes from.
+ *
+ * This is the only place the playground learns who is paying, and it is
+ * deliberately the whole auth surface of this repo: everything else takes a
+ * resolved credential as an argument. There are two implementations.
+ *
+ * - `byo-key` — a `BITROUTER_API_KEY` from the environment. No console, no
+ *   sign-in, no attribution. This is what a fork, a local checkout, or a
+ *   self-hoster gets, and it is the default so cloning this repo works
+ *   unchanged.
+ * - `session` — what bitrouter.ai runs. The visitor is signed in to the console
+ *   on the sibling subdomain; this forwards their cookie to the console's token
+ *   endpoint and receives a narrowly-scoped, short-lived credential minted for
+ *   them. The console owns the minting policy (scope, TTL, free grant); this
+ *   repo only knows the contract.
+ *
+ * The forward happens **server-side**. The alternative — the browser calling
+ * the console directly over credentialed CORS and handing us the token — would
+ * put a spendable bearer in page JavaScript. A minted `bra_` is a signed JWT
+ * the router verifies with no round trip, so nothing can revoke it before it
+ * expires; keeping it off the client is worth the extra hop.
+ */
+
+/** The credential source this deployment is configured for. */
+export type CredentialMode = "session" | "byo-key";
+
+/**
+ * What the credential is for. The console mints a different kind per purpose:
+ * a short-lived signed `bra_` for a stateless turn, and a revocable `brk_` for
+ * a harness session that outlives it (the token is baked into a sandbox's
+ * environment at spawn and has no refresh path).
+ */
+export type CredentialPurpose = "chat" | "harness";
+
+export interface PlaygroundCredential {
+  /** Bearer for the BitRouter router. */
+  token: string;
+  /** The router endpoint this token is good for. */
+  baseUrl: string;
+  expiresAt: Date;
+  /** Null in `byo-key` mode — there is no user to attribute spend to. */
+  attribution: { userId: string; namespaceId: string } | null;
+  mode: CredentialMode;
+  purpose: CredentialPurpose;
+  /**
+   * Present only when the credential is independently revocable (the `harness`
+   * purpose in `session` mode). Passed back to {@link revokePlaygroundCredential}.
+   */
+  revocationId?: string;
+}
+
+/**
+ * A credential could not be resolved. `status` is the response the caller
+ * should send: 401 when the visitor is not signed in, 402 when their grant is
+ * spent, 503 when the console is unreachable, 500 when this deployment is
+ * misconfigured.
+ */
+export class CredentialError extends Error {
+  constructor(
+    message: string,
+    readonly status: 401 | 402 | 500 | 503,
+  ) {
+    super(message);
+    this.name = "CredentialError";
+  }
+}
+
+/** `byo-key` tokens do not expire on their own. */
+const NEVER = new Date("9999-12-31T23:59:59.000Z");
+
+/** How long to wait on the console before giving up and reporting 503. */
+const TOKEN_ENDPOINT_TIMEOUT_MS = 10_000;
+
+/**
+ * Which mode this deployment runs in.
+ *
+ * Defaults to `byo-key` so a clone with nothing but `BITROUTER_API_KEY` set
+ * behaves exactly as it did before auth existed. Production sets
+ * `PLAYGROUND_CREDENTIAL_MODE=session`.
+ */
+export function credentialMode(): CredentialMode {
+  return process.env.PLAYGROUND_CREDENTIAL_MODE === "session"
+    ? "session"
+    : "byo-key";
+}
+
+function routerBaseUrl(): string {
+  const baseUrl = process.env.BITROUTER_API_BASE;
+  if (!baseUrl) {
+    throw new CredentialError("BITROUTER_API_BASE is not set.", 500);
+  }
+  return baseUrl;
+}
+
+function consoleBaseUrl(): string {
+  const url = process.env.NEXT_PUBLIC_CONSOLE_URL;
+  if (!url) {
+    throw new CredentialError(
+      "NEXT_PUBLIC_CONSOLE_URL is not set; session mode needs a console to mint against.",
+      500,
+    );
+  }
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * The origin we present to the console's CSRF gate.
+ *
+ * A server-to-server fetch carries no browser `Origin`, and the console's
+ * `enforceCsrf` rejects a state-changing request without one. Ours must be on
+ * the console's `BETTER_AUTH_TRUSTED_ORIGINS` — the same allowlist that already
+ * lets this site read the shared session.
+ */
+function selfOrigin(): string {
+  const url = process.env.NEXT_PUBLIC_WEB_URL;
+  if (!url) {
+    throw new CredentialError(
+      "NEXT_PUBLIC_WEB_URL is not set; session mode needs it for the console's CSRF check.",
+      500,
+    );
+  }
+  return new URL(url).origin;
+}
+
+/** The console's token-endpoint response. */
+type TokenResponse = {
+  token?: unknown;
+  expiresAt?: unknown;
+  namespaceId?: unknown;
+  userId?: unknown;
+  revocationId?: unknown;
+};
+
+function parseTokenResponse(
+  body: TokenResponse,
+  purpose: CredentialPurpose,
+): PlaygroundCredential {
+  const { token, expiresAt, namespaceId, userId, revocationId } = body;
+  if (
+    typeof token !== "string" ||
+    typeof expiresAt !== "string" ||
+    typeof namespaceId !== "string" ||
+    typeof userId !== "string"
+  ) {
+    throw new CredentialError(
+      "The console returned a malformed playground token.",
+      503,
+    );
+  }
+  const expiry = new Date(expiresAt);
+  if (Number.isNaN(expiry.getTime())) {
+    throw new CredentialError(
+      "The console returned an unparseable token expiry.",
+      503,
+    );
+  }
+  return {
+    token,
+    baseUrl: routerBaseUrl(),
+    expiresAt: expiry,
+    attribution: { userId, namespaceId },
+    mode: "session",
+    purpose,
+    revocationId: typeof revocationId === "string" ? revocationId : undefined,
+  };
+}
+
+/**
+ * Mint against the console on behalf of whoever owns the request's cookie.
+ *
+ * The cookie is parent-domain scoped (`bitrouter.ai`), so a request to this
+ * site already carries the console's session cookie — forwarding the header
+ * verbatim is enough to authenticate as that visitor.
+ */
+async function mintFromConsole(
+  req: Request,
+  purpose: CredentialPurpose,
+): Promise<PlaygroundCredential> {
+  const cookie = req.headers.get("cookie");
+  if (!cookie) {
+    throw new CredentialError("Sign in to use the playground.", 401);
+  }
+
+  // Resolve config before the fetch so a misconfigured deployment reports 500
+  // rather than a confusing 503 from a request that was never going to work.
+  const endpoint = `${consoleBaseUrl()}/api/playground/token`;
+  const origin = selfOrigin();
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie,
+        origin,
+      },
+      body: JSON.stringify({ purpose }),
+      signal: AbortSignal.timeout(TOKEN_ENDPOINT_TIMEOUT_MS),
+      cache: "no-store",
+    });
+  } catch (err) {
+    throw new CredentialError(
+      `Could not reach the console to mint a playground token: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      503,
+    );
+  }
+
+  if (response.status === 401) {
+    throw new CredentialError("Sign in to use the playground.", 401);
+  }
+  if (response.status === 402) {
+    // The console's own words — it knows what the grant was and whether the
+    // account has a balance to fall through to.
+    const detail = await response.text().catch(() => "");
+    throw new CredentialError(
+      detail.slice(0, 200) || "Your playground credit is used up.",
+      402,
+    );
+  }
+  if (!response.ok) {
+    throw new CredentialError(
+      `The console refused to mint a playground token (${response.status}).`,
+      503,
+    );
+  }
+
+  return parseTokenResponse((await response.json()) as TokenResponse, purpose);
+}
+
+/** The environment key, for deployments that run without a console. */
+function fromEnvironment(purpose: CredentialPurpose): PlaygroundCredential {
+  const token = process.env.BITROUTER_API_KEY;
+  if (!token) {
+    throw new CredentialError("BITROUTER_API_KEY is not set.", 500);
+  }
+  return {
+    token,
+    baseUrl: routerBaseUrl(),
+    expiresAt: NEVER,
+    attribution: null,
+    mode: "byo-key",
+    purpose,
+  };
+}
+
+/**
+ * Resolve the credential this request should spend on.
+ *
+ * Throws {@link CredentialError} rather than returning null so the caller can
+ * distinguish "not signed in" from "out of credit" from "console down" — three
+ * cases the playground must report differently.
+ */
+export async function resolveCredential(
+  req: Request,
+  purpose: CredentialPurpose,
+): Promise<PlaygroundCredential> {
+  return credentialMode() === "session"
+    ? mintFromConsole(req, purpose)
+    : fromEnvironment(purpose);
+}
+
+/**
+ * Hand a harness credential back when its session ends.
+ *
+ * Only the revocable kind has anything to return; everything else is a no-op.
+ * Best-effort by construction — a credential that outlives its session until
+ * `expiresAt` is a bounded cost, but a failed teardown must never fail the
+ * sweep that triggered it.
+ */
+export async function revokePlaygroundCredential(
+  credential: PlaygroundCredential,
+): Promise<void> {
+  if (credential.mode !== "session" || !credential.revocationId) return;
+
+  try {
+    await fetch(`${consoleBaseUrl()}/api/playground/token`, {
+      method: "DELETE",
+      headers: {
+        "content-type": "application/json",
+        origin: selfOrigin(),
+        // No cookie: the session that minted this may be long gone. The
+        // revocation id is the capability, and it only ever revokes itself.
+        authorization: `Bearer ${credential.token}`,
+      },
+      body: JSON.stringify({ revocationId: credential.revocationId }),
+      signal: AbortSignal.timeout(TOKEN_ENDPOINT_TIMEOUT_MS),
+      cache: "no-store",
+    });
+  } catch {
+    // Swallowed deliberately — see the doc comment.
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "bitrouter-docs",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -20,8 +23,13 @@
     "lint:tables": "node scripts/generate-supported-tables.mjs --check"
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "^2.0.35",
-    "@ai-sdk/react": "^3.0.118",
+    "@ai-sdk/harness": "1.0.64",
+    "@ai-sdk/harness-acp": "1.0.1",
+    "@ai-sdk/harness-pi": "1.0.64",
+    "@ai-sdk/openai-compatible": "^3.0.27",
+    "@ai-sdk/react": "^4.0.61",
+    "@ai-sdk/sandbox-just-bash": "1.0.64",
+    "@ai-sdk/sandbox-vercel": "1.0.64",
     "@calcom/embed-react": "^1.5.3",
     "@hackernoon/pixel-icon-library": "^1.1.0",
     "@lobehub/icons": "^5.8.0",
@@ -32,12 +40,14 @@
     "@radix-ui/react-presence": "^1.1.5",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-use-controllable-state": "^1.2.6",
     "@tanstack/react-table": "^8.21.3",
     "@types/mdx": "^2.0.13",
-    "ai": "^6.0.116",
+    "ai": "^7.0.58",
     "better-auth": "1.6.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "cobe": "^0.6.3",
     "feed": "^5.2.1",
     "fumadocs-core": "16.11.1",
@@ -50,6 +60,7 @@
     "markdown-draft-js": "^2.4.0",
     "mcp-handler": "^1.1.0",
     "motion": "^12.38.0",
+    "nanoid": "^6.0.1",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "octokit": "^5.0.5",
@@ -66,9 +77,11 @@
     "remark-mdx": "^3.1.1",
     "remark-rehype": "^11.1.2",
     "shiki": "^4.0.1",
+    "streamdown": "^2.5.0",
     "svg-dotted-map": "^2.1.0",
     "tailwind-merge": "^3.5.0",
     "unist-util-visit": "^5.1.0",
+    "use-stick-to-bottom": "^1.1.6",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,27 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/harness':
+        specifier: 1.0.64
+        version: 1.0.64(ws@8.21.3)(zod@4.4.3)
+      '@ai-sdk/harness-acp':
+        specifier: 1.0.1
+        version: 1.0.1(zod@4.4.3)
+      '@ai-sdk/harness-pi':
+        specifier: 1.0.64
+        version: 1.0.64(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
-        specifier: ^2.0.35
-        version: 2.0.51(zod@4.4.3)
+        specifier: ^3.0.27
+        version: 3.0.27(zod@4.4.3)
       '@ai-sdk/react':
-        specifier: ^3.0.118
-        version: 3.0.210(react@19.2.3)(zod@4.4.3)
+        specifier: ^4.0.61
+        version: 4.0.61(react@19.2.3)(zod@4.4.3)
+      '@ai-sdk/sandbox-just-bash':
+        specifier: 1.0.64
+        version: 1.0.64(ws@8.21.3)(zod@4.4.3)
+      '@ai-sdk/sandbox-vercel':
+        specifier: 1.0.64
+        version: 1.0.64(ws@8.21.3)(zod@4.4.3)
       '@calcom/embed-react':
         specifier: ^1.5.3
         version: 1.5.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -44,6 +59,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react@19.2.17)(react@19.2.3)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -51,17 +69,20 @@ importers:
         specifier: ^2.0.13
         version: 2.0.14
       ai:
-        specifier: ^6.0.116
-        version: 6.0.208(zod@4.4.3)
+        specifier: ^7.0.58
+        version: 7.0.58(zod@4.4.3)
       better-auth:
         specifier: 1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)))
+        version: 1.6.11(@opentelemetry/api@1.9.0)(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       cobe:
         specifier: ^0.6.3
         version: 0.6.5
@@ -70,16 +91,16 @@ importers:
         version: 5.2.1
       fumadocs-core:
         specifier: 16.11.1
-        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 15.1.0
-        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       fumadocs-openapi:
         specifier: 11.1.1
-        version: 11.1.1(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1))(json-schema-typed@8.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 11.1.1(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1))(json-schema-typed@8.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       fumadocs-ui:
         specifier: 16.11.1
-        version: 16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1)
+        version: 16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1)
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6
@@ -94,13 +115,16 @@ importers:
         version: 2.4.0
       mcp-handler:
         specifier: ^1.1.0
-        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       motion:
         specifier: ^12.38.0
         version: 12.40.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      nanoid:
+        specifier: ^6.0.1
+        version: 6.0.1
       next:
         specifier: 16.2.6
-        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -146,6 +170,9 @@ importers:
       shiki:
         specifier: ^4.0.1
         version: 4.2.0
+      streamdown:
+        specifier: ^2.5.0
+        version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       svg-dotted-map:
         specifier: ^2.1.0
         version: 2.1.0
@@ -155,6 +182,9 @@ importers:
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
+      use-stick-to-bottom:
+        specifier: ^1.1.6
+        version: 1.1.6(react@19.2.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -182,37 +212,73 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
 
 packages:
 
-  '@ai-sdk/gateway@3.0.133':
-    resolution: {integrity: sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.46':
+    resolution: {integrity: sha512-LIAO6kAG8fpXQb9L0iwPk1FIbXftvqnyC56v5NEAzeWTeL8fUsy/Hx86VPBTWEDFdwbVprjWifJOAqS6AOj3mA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@2.0.51':
-    resolution: {integrity: sha512-A6qfyaVs4lxmRxRux6U3ViOa8mMbsSd0OaHghpei2MpiBT6791J4zFH5MN7kaW1tLfQ246rSC2DVTMOavsycjQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/harness-acp@1.0.1':
+    resolution: {integrity: sha512-tTqp/c7MeQuC1igHUw78c/w3Zmj8EW0x6RefN8bYLGLu2rJ2piZ5lC2+q2fX0HzzaxaFBPcYOg0vDweL9sdnmA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.30':
-    resolution: {integrity: sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/harness-pi@1.0.64':
+    resolution: {integrity: sha512-HRaRHIs3uaaLmNij3zMJ9vigKvHylYN4GBPsxCtz+Fg784g6Ib4RI0Ls8gJP09yWedFJar/ArXeCYWNwW4jHgQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.10':
-    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/harness@1.0.64':
+    resolution: {integrity: sha512-kN9Mt8uNnJK11FhaFg0Kkb/2PWzFl3MEEUHl9s4d/r69A7/iRBEpAjEHnJ4SLWzF/udvdBYriVGA3FgZTuMyww==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      ws: ^8.21.0
+      zod: ^3.25.76 || ^4.1.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
 
-  '@ai-sdk/react@3.0.210':
-    resolution: {integrity: sha512-VprBlyc8yvwlpIdcIICL307vRncXrLlmcRTY/7JR5ND9+LvUcxJU16yW6prClFahqEWVza8Vr8P4Bgk5ZBtp4A==}
-    engines: {node: '>=18'}
+  '@ai-sdk/mcp@2.0.29':
+    resolution: {integrity: sha512-cK8mYpjKGp7/gmsTYtq/dkdmNlBeWQrwcfsah/W9hN6Vr1yNzunLnAZAqL5tMzumLDBueSz6y+vrb5z8DJ8TMg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@3.0.27':
+    resolution: {integrity: sha512-icGSoBDbFKZotUwehg7h/JjtD7arweeKfeDcsT9UsPY+YdwiT94JciD59bqAOAdNA3wlS+klW2vsaVLxTUUhbA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.25':
+    resolution: {integrity: sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/react@4.0.61':
+    resolution: {integrity: sha512-iY59f4092oD3Px2xL5qCmfG5gC0ySHCw5d2Hzq5ReCvig/DIgwUQ6SZG49XIgc8Yg7leTQ4y41CXXY8nQ1eWrA==}
+    engines: {node: '>=22'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+
+  '@ai-sdk/sandbox-just-bash@1.0.64':
+    resolution: {integrity: sha512-xy4pHXQvArzApctBTy6z7cCmmrFsbfdpD/NMWc8uTczaZyxGk1L6fg5vhTY27yjGZBZsW3/8vj0WRNDM0bDUtw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/sandbox-vercel@1.0.64':
+    resolution: {integrity: sha512-bSDvfA7KMl0j5u51tPQqgtqPe7P45C0vZ9UMX/BD6eVTzdgc1MByYFSuEsk35a63+wTnitP9AVUEOJ1qzUP4JA==}
+    engines: {node: '>=22'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -255,6 +321,112 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.6':
+    resolution: {integrity: sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.67':
+    resolution: {integrity: sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.69':
+    resolution: {integrity: sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.12':
+    resolution: {integrity: sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.74':
+    resolution: {integrity: sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.78':
+    resolution: {integrity: sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.67':
+    resolution: {integrity: sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.11':
+    resolution: {integrity: sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.73':
+    resolution: {integrity: sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.31':
+    resolution: {integrity: sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.26':
+    resolution: {integrity: sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.49':
+    resolution: {integrity: sha512-wGYJvu1/stdWuzGcNyh44u8aY7ArU8XFrMesBlzIYn70HWVCRBNEngQexDuPIMu0NEgsKGKmTc0uvnS/bF7KWw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.41':
+    resolution: {integrity: sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1103.0':
+    resolution: {integrity: sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -434,6 +606,9 @@ packages:
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
@@ -479,6 +654,24 @@ packages:
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@earendil-works/pi-agent-core@0.80.10':
+    resolution: {integrity: sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.80.10':
+    resolution: {integrity: sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.80.10':
+    resolution: {integrity: sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.80.10':
+    resolution: {integrity: sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==}
+    engines: {node: '>=22.19.0'}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
@@ -936,6 +1129,15 @@ packages:
       react: ^16 || ^17 || ^18 || ^19
       react-dom: ^16 || ^17 || ^18 || ^19
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hackernoon/pixel-icon-library@1.1.0':
     resolution: {integrity: sha512-VEdDskTYRc37quKh3LFt65nMtriJlxuov/ifOmlomAyfK2hty4IPdL6IIXNvATOaQwZYjlfyxJTCGO+JgWbgIw==}
 
@@ -1088,6 +1290,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jitl/quickjs-ffi-types@0.32.0':
+    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1137,6 +1354,69 @@ packages:
       react: ^19.0.0
       react-dom: ^19.0.0
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
+    engines: {node: '>= 10'}
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
@@ -1149,6 +1429,17 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -1158,6 +1449,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@mongodb-js/zstd@7.0.0':
+    resolution: {integrity: sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==}
+    engines: {node: '>= 20.19.0'}
 
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
@@ -1217,6 +1512,9 @@ packages:
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
+
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@octokit/app@16.1.2':
     resolution: {integrity: sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ==}
@@ -1325,8 +1623,8 @@ packages:
     resolution: {integrity: sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==}
     engines: {node: '>= 20'}
 
-  '@opentelemetry/api@1.9.1':
-    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/semantic-conventions@1.41.1':
@@ -1356,6 +1654,33 @@ packages:
   '@primer/octicons@19.28.1':
     resolution: {integrity: sha512-pwSilXmgNrbVF2bChkh4zZtUyb4Vr4niYhA9PhUdtjVz86A2iwA/YjjopHS0suT+I7niUZJEepEpmSC7kARKNQ==}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
 
@@ -1364,6 +1689,9 @@ packages:
 
   '@radix-ui/primitive@1.1.5':
     resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
+
+  '@radix-ui/primitive@1.1.7':
+    resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
 
   '@radix-ui/react-accessible-icon@1.1.10':
     resolution: {integrity: sha512-TraSwZUqTcVbiDV2/RXzAXC7aeVVXchq0daPFZE7zAxYFaMzjOUggLOfQH9KFLgRizuwVKZO/crveV1eeO3/ZQ==}
@@ -2187,8 +2515,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.6':
+    resolution: {integrity: sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.3':
     resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.5':
+    resolution: {integrity: sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2216,6 +2562,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.2':
     resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.4':
+    resolution: {integrity: sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2834,6 +3189,49 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@splinetool/runtime@0.9.526':
     resolution: {integrity: sha512-qznHbXA5aKwDbCgESAothCNm1IeEZcmNWG145p5aXj4w5uoqR1TZ9qkTHTKLTsUbHeitCwdhzmRqan1kxboLgQ==}
 
@@ -2952,6 +3350,13 @@ packages:
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
   '@types/aws-lambda@8.10.162':
     resolution: {integrity: sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==}
@@ -3102,6 +3507,9 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -3132,6 +3540,9 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
+  '@vercel/sandbox@2.9.2':
+    resolution: {integrity: sha512-tnPtCNL6MZKM9eRYvmyL0geA2Nifq+PSxVXBNhk/lQNeCWgMp/EYzCDOotKEWR/VH+c0Yv9HG4qk0w2I65xnLA==}
+
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
@@ -3161,6 +3572,12 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -3175,15 +3592,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ahooks@3.9.7:
     resolution: {integrity: sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  ai@6.0.208:
-    resolution: {integrity: sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ==}
-    engines: {node: '>=18'}
+  ai@7.0.58:
+    resolution: {integrity: sha512-GfgO90CQQ0yYuoxJAUOeQ6tviyYw1BUIDygSZ1q3Ce6kSc93tYmB5eltKY/NxC0YOouAax7JvDqVnYxvIAr04Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -3210,6 +3631,9 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -3232,6 +3656,9 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   attr-accept@2.2.5:
     resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
     engines: {node: '>=4'}
@@ -3239,12 +3666,35 @@ packages:
   autolinker@3.16.2:
     resolution: {integrity: sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.10.38:
     resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
@@ -3324,12 +3774,31 @@ packages:
       zod:
         optional: true
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -3377,6 +3846,9 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   chroma-js@3.2.0:
     resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
 
@@ -3397,6 +3869,12 @@ packages:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+
   cnfast@0.0.8:
     resolution: {integrity: sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q==}
     hasBin: true
@@ -3416,6 +3894,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -3634,6 +4116,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
@@ -3655,6 +4141,14 @@ packages:
   decode-uri-component@0.4.1:
     resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
     engines: {node: '>=14.16'}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -3684,12 +4178,19 @@ packages:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   dompurify@3.4.11:
     resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3703,6 +4204,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -3799,6 +4303,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -3806,6 +4313,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -3835,8 +4346,18 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-xml-builder@1.3.0:
+    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
+
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
+    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3851,12 +4372,20 @@ packages:
     resolution: {integrity: sha512-jTynzYPWs9ALjro0GW8j7sv9y7cJBeOdD4Y88kVqYy/eyusIX3g+499JiTDIlD9Ge/unebx57T4Uzo6vpYvMtA==}
     engines: {node: '>=20', pnpm: '>=10'}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-selector@0.5.0:
     resolution: {integrity: sha512-s8KNnmIDTBoD0p9uJ9uD0XY38SCeBOtj0UMXyQSLg1Ypfrfj8+dAvwsLjYQkQ2GjhVtp2HrnF5cJzMhBjfD8HA==}
     engines: {node: '>= 10'}
+
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
 
   filter-obj@5.1.0:
     resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
@@ -3872,6 +4401,10 @@ packages:
   for-in@1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
     engines: {node: '>=0.10.0'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3908,6 +4441,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4051,6 +4587,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@7.3.0:
+    resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   generic-pool@3.9.0:
     resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
     engines: {node: '>= 4'}
@@ -4078,8 +4622,23 @@ packages:
   giscus@1.6.0:
     resolution: {integrity: sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -4123,6 +4682,9 @@ packages:
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
@@ -4147,12 +4709,19 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
   hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
+
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -4164,6 +4733,14 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -4171,6 +4748,13 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
 
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
@@ -4187,6 +4771,13 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -4251,6 +4842,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -4284,8 +4878,15 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -4301,6 +4902,19 @@ packages:
 
   json2mq@0.2.0:
     resolution: {integrity: sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==}
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
+
+  just-bash@2.14.5:
+    resolution: {integrity: sha512-MCBGnRlDeZ/MM7mcw+ZuSGFMBsggajrmKz6e/hrOAN7syvVZkjiY+Vh2wyCwN/CdcnAX5SxbiQB51n5nrQuX+g==}
+    hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
@@ -4413,12 +5027,19 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
 
   lru_map@0.4.1:
     resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
@@ -4464,6 +5085,11 @@ packages:
 
   marked@17.0.6:
     resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -4694,9 +5320,35 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  modern-tar@0.7.7:
+    resolution: {integrity: sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==}
+    engines: {node: '>=18.0.0'}
 
   motion-dom@12.40.0:
     resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
@@ -4743,9 +5395,17 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
+    hasBin: true
+
   nanostores@1.3.0:
     resolution: {integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -4777,6 +5437,32 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-abi@3.94.0:
+    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
+    engines: {node: '>=10'}
+
+  node-addon-api@8.9.1:
+    resolution: {integrity: sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==}
+    engines: {node: ^18 || ^20 || >= 21}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  node-liblzma@2.2.0:
+    resolution: {integrity: sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
 
   numeral@2.0.6:
     resolution: {integrity: sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==}
@@ -4814,8 +5500,31 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  papaparse@5.5.4:
+    resolution: {integrity: sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4835,8 +5544,15 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4844,6 +5560,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -4906,15 +5626,31 @@ packages:
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -4926,6 +5662,13 @@ packages:
   query-string@9.4.0:
     resolution: {integrity: sha512-ivvWyHqU9K1Log4hJFhqVIIMoEi0nzmlRhvk2pPcTuQH/Y0K5iTTMxEx7R0PRHD2Z1hMVbWnjfsEWbIKIK+3IA==}
     engines: {node: '>=18'}
+
+  quickjs-emscripten-core@0.32.0:
+    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
+
+  quickjs-emscripten@0.32.0:
+    resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
+    engines: {node: '>=16.0.0'}
 
   radix-ui@1.6.0:
     resolution: {integrity: sha512-EUEC70O03EgxWMP5aoqfBZ6iLC5bczFagGy7zhSYRt8o5DP7IWNiP3ywetse3L9b8843ExB0OGWZvgbYVJuNeg==}
@@ -5014,11 +5757,18 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   re-resizable@6.11.2:
     resolution: {integrity: sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==}
     peerDependencies:
       react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  re2js@1.3.3:
+    resolution: {integrity: sha512-s/I5zEAo79SUK0Qw4dpZKpiMwbQ6Gz0KU2NRr7eaO4x/p2g7Vvmn3hdeXDg8VsaUjfj/ora+e9oi27LX/C9+mw==}
 
   react-avatar-editor@15.1.0:
     resolution: {integrity: sha512-Zto7u9l6Wd5LPPtjeFJ+7uwoT4bs01OSgkN2kxD18lWl8IiZ0GY3nWCbKPx4qIU7Au1vENsMJm19rfVWHHayaQ==}
@@ -5148,6 +5898,10 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -5197,6 +5951,9 @@ packages:
   rehype-github-alerts@4.2.0:
     resolution: {integrity: sha512-6di6kEu9WUHKLKrkKG2xX6AOuaCMGghg0Wq7MEuM/jBYUPVIq6PJpMe00dxMfU+/YSBtDXhffpDimgDi+BObIQ==}
 
+  rehype-harden@1.1.8:
+    resolution: {integrity: sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==}
+
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
 
@@ -5205,6 +5962,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
@@ -5276,6 +6036,14 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
@@ -5297,6 +6065,9 @@ packages:
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -5314,8 +6085,17 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  seek-bzip@2.0.0:
+    resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
+    hasBin: true
+
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -5397,6 +6177,19 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  smol-toml@1.7.1:
+    resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -5423,6 +6216,12 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  sql.js@1.14.1:
+    resolution: {integrity: sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -5433,11 +6232,34 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  streamdown@2.5.0:
+    resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   string-convert@0.2.1:
     resolution: {integrity: sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -5490,6 +6312,19 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
   throttle-debounce@5.0.2:
     resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
     engines: {node: '>=12.22'}
@@ -5527,11 +6362,18 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-dedent@2.3.0:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
@@ -5547,17 +6389,42 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  turndown@7.2.4:
+    resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
+    engines: {node: '>=18', npm: '>=9'}
+
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
+
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+
+  typebox@1.3.11:
+    resolution: {integrity: sha512-tZGKIS02Opbh4EYMmAEVuXl+y3EQJ9ZlkitLZ1CmFCY4ZOqr/xWR9dDSCFmIjNDICGMWkOqMh6WxGTyRXqcSGQ==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -5625,10 +6492,18 @@ packages:
       '@types/react':
         optional: true
 
+  use-stick-to-bottom@1.1.6:
+    resolution: {integrity: sha512-z3Up8jYQGTkUCsGBnwg6/wj70KgXoW5Kz1AAc1j8MtQuYMBo6ZsdhrIXoegxa7gaMMilgQYyTohTrt3p94jHog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@13.0.2:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
@@ -5757,6 +6632,10 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
@@ -5773,9 +6652,33 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
     hasBin: true
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -5783,6 +6686,11 @@ packages:
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -5806,38 +6714,103 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.133(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.46(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@2.0.51(zod@4.4.3)':
+  '@ai-sdk/harness-acp@1.0.1(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/harness': 1.0.64(ws@8.21.3)(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      ws: 8.21.3
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@ai-sdk/harness-pi@1.0.64(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/harness': 1.0.64(ws@8.21.3)(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      '@earendil-works/pi-coding-agent': 0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      typebox: 1.3.11
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
+  '@ai-sdk/harness@1.0.64(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      ai: 7.0.58(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      ws: 8.21.3
+
+  '@ai-sdk/mcp@2.0.29(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.30(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@3.0.27(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.25(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
+      undici: 7.29.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.10':
+  '@ai-sdk/provider@4.0.7':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.210(react@19.2.3)(zod@4.4.3)':
+  '@ai-sdk/react@4.0.61(react@19.2.3)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
-      ai: 6.0.208(zod@4.4.3)
+      '@ai-sdk/mcp': 2.0.29(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      ai: 7.0.58(zod@4.4.3)
       react: 19.2.3
       swr: 2.4.1(react@19.2.3)
       throttleit: 2.1.0
     transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/sandbox-just-bash@1.0.64(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/harness': 1.0.64(ws@8.21.3)(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      just-bash: 2.14.5
+    transitivePeerDependencies:
+      - supports-color
+      - ws
+      - zod
+
+  '@ai-sdk/sandbox-vercel@1.0.64(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/harness': 1.0.64(ws@8.21.3)(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      '@vercel/sandbox': 2.9.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - ws
       - zod
 
   '@alloc/quick-lru@5.2.0': {}
@@ -5892,6 +6865,226 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.2
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/credential-provider-node': 3.972.78
+      '@aws-sdk/eventstream-handler-node': 3.972.31
+      '@aws-sdk/middleware-eventstream': 3.972.26
+      '@aws-sdk/middleware-websocket': 3.972.49
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.6':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.12':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/credential-provider-env': 3.972.67
+      '@aws-sdk/credential-provider-http': 3.972.69
+      '@aws-sdk/credential-provider-login': 3.972.74
+      '@aws-sdk/credential-provider-process': 3.972.67
+      '@aws-sdk/credential-provider-sso': 3.973.11
+      '@aws-sdk/credential-provider-web-identity': 3.972.73
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.74':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.78':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.67
+      '@aws-sdk/credential-provider-http': 3.972.69
+      '@aws-sdk/credential-provider-ini': 3.973.12
+      '@aws-sdk/credential-provider-process': 3.972.67
+      '@aws-sdk/credential-provider-sso': 3.973.11
+      '@aws-sdk/credential-provider-web-identity': 3.972.73
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.11':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/token-providers': 3.1103.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.73':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.31':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.26':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.41':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1103.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -5995,7 +7188,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
+  '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
@@ -6007,38 +7200,38 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
@@ -6047,6 +7240,8 @@ snapshots:
       '@noble/hashes': 2.2.0
 
   '@better-fetch/fetch@1.1.21': {}
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -6096,6 +7291,76 @@ snapshots:
     dependencies:
       react: 19.2.3
       tslib: 2.8.1
+
+  '@earendil-works/pi-agent-core@0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.3)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.10
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-tui@0.80.10':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
 
   '@emnapi/runtime@1.11.1':
     dependencies:
@@ -6379,15 +7644,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@fumadocs/api-docs@0.1.0(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1))(json-schema-typed@8.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@fumadocs/api-docs@0.1.0(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1))(json-schema-typed@8.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@fumari/stf': 1.1.0(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority: 0.7.1
       cnfast: 0.0.8
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
-      fumadocs-ui: 16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+      fumadocs-ui: 16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1)
       github-slugger: 2.0.0
       js-yaml: 5.2.1
       lucide-react: 1.23.0(react@19.2.3)
@@ -6424,6 +7689,19 @@ snapshots:
       giscus: 1.6.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+    dependencies:
+      google-auth-library: 10.9.1
+      p-retry: 4.6.2
+      protobufjs: 7.6.5
+      ws: 8.21.3
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@hackernoon/pixel-icon-library@1.1.0': {}
 
@@ -6535,6 +7813,24 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@jitl/quickjs-ffi-types@0.32.0': {}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6685,6 +7981,50 @@ snapshots:
       - svelte
       - vue
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.9':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
+    optional: true
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.9
@@ -6725,6 +8065,20 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
+      ws: 8.21.3
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@mixmark-io/domino@2.2.0': {}
+
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
@@ -6746,6 +8100,12 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@mongodb-js/zstd@7.0.0':
+    dependencies:
+      node-addon-api: 8.9.1
+      prebuild-install: 7.1.3
+    optional: true
 
   '@next/env@16.2.6': {}
 
@@ -6776,6 +8136,8 @@ snapshots:
   '@noble/ciphers@2.2.0': {}
 
   '@noble/hashes@2.2.0': {}
+
+  '@nodable/entities@3.0.0': {}
 
   '@octokit/app@16.1.2':
     dependencies:
@@ -6925,7 +8287,7 @@ snapshots:
       '@octokit/request-error': 7.1.0
       '@octokit/webhooks-methods': 6.0.0
 
-  '@opentelemetry/api@1.9.1': {}
+  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
@@ -6954,11 +8316,33 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
   '@radix-ui/number@1.1.2': {}
 
   '@radix-ui/primitive@1.1.4': {}
 
   '@radix-ui/primitive@1.1.5': {}
+
+  '@radix-ui/primitive@1.1.7': {}
 
   '@radix-ui/react-accessible-icon@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -7892,9 +9276,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-use-controllable-state@1.2.6(@types/react@19.2.17)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.17)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-effect-event@0.0.5(@types/react@19.2.17)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.3)
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.17
@@ -7913,6 +9313,12 @@ snapshots:
       '@types/react': 19.2.17
 
   '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-layout-effect@1.1.4(@types/react@19.2.17)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:
@@ -8552,6 +9958,61 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@splinetool/runtime@0.9.526':
     dependencies:
       on-change: 4.0.2
@@ -8649,6 +10110,15 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   '@tanstack/table-core@8.21.3': {}
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
 
   '@types/aws-lambda@8.10.162': {}
 
@@ -8820,6 +10290,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
@@ -8844,6 +10316,23 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
+  '@vercel/sandbox@2.9.2':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.29.0
+      xdg-app-paths: 5.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -8853,13 +10342,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -8885,6 +10374,10 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@workflow/serde@4.1.0': {}
+
+  '@workflow/serde@4.1.0-beta.2': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -8895,6 +10388,8 @@ snapshots:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  agent-base@7.1.4: {}
 
   ahooks@3.9.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -8911,12 +10406,11 @@ snapshots:
       screenfull: 5.2.0
       tslib: 2.8.1
 
-  ai@6.0.208(zod@4.4.3):
+  ai@7.0.58(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.133(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.46(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -9003,6 +10497,8 @@ snapshots:
       - luxon
       - moment
 
+  anynum@1.0.1: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -9019,11 +10515,17 @@ snapshots:
 
   astring@1.9.0: {}
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   attr-accept@2.2.5: {}
 
   autolinker@3.16.2:
     dependencies:
       tslib: 2.8.1
+
+  b4a@1.8.1: {}
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -9033,19 +10535,25 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
+
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.38: {}
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0))):
+  better-auth@1.6.11(@opentelemetry/api@1.9.0)(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))):
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0
@@ -9057,10 +10565,10 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -9073,6 +10581,15 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.4.3
+
+  bignumber.js@9.3.1: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    optional: true
 
   body-parser@2.3.0:
     dependencies:
@@ -9089,6 +10606,20 @@ snapshots:
       - supports-color
 
   bottleneck@2.19.5: {}
+
+  bowser@2.14.1: {}
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    optional: true
 
   bytes@3.1.2: {}
 
@@ -9124,6 +10655,9 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  chownr@1.1.4:
+    optional: true
+
   chroma-js@3.2.0: {}
 
   class-variance-authority@0.7.1:
@@ -9138,6 +10672,18 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
   cnfast@0.0.8: {}
 
   cobe@0.6.5:
@@ -9151,6 +10697,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
+
+  commander@6.2.1: {}
 
   commander@7.2.0: {}
 
@@ -9387,6 +10935,8 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-uri-to-buffer@4.0.1: {}
+
   dayjs@1.11.21: {}
 
   debug@4.4.3:
@@ -9400,6 +10950,14 @@ snapshots:
       character-entities: 2.0.2
 
   decode-uri-component@0.4.1: {}
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+    optional: true
+
+  deep-extend@0.6.0:
+    optional: true
 
   defu@6.1.7: {}
 
@@ -9421,6 +10979,8 @@ snapshots:
 
   diff@8.0.3: {}
 
+  diff@8.0.4: {}
+
   dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -9431,6 +10991,10 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   ee-first@1.1.1: {}
 
   emoji-mart@5.6.0: {}
@@ -9438,6 +11002,11 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+    optional: true
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -9585,11 +11154,20 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.1.0
+
+  expand-template@2.0.3:
+    optional: true
 
   expect-type@1.3.0: {}
 
@@ -9644,7 +11222,23 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-uri@3.1.2: {}
+
+  fast-xml-builder@1.3.0:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.10.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.0
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.1
+      xml-naming: 0.3.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -9658,11 +11252,25 @@ snapshots:
     dependencies:
       xml-js: 1.6.11
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fflate@0.4.8: {}
 
   file-selector@0.5.0:
     dependencies:
       tslib: 2.8.1
+
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   filter-obj@5.1.0: {}
 
@@ -9680,6 +11288,10 @@ snapshots:
   find-root@1.1.0: {}
 
   for-in@1.0.2: {}
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -9705,10 +11317,13 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3):
+  fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -9734,21 +11349,21 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       lucide-react: 0.563.0(react@19.2.3)
-      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)):
+  fumadocs-mdx@15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
       github-slugger: 2.0.0
       js-yaml: 5.2.1
       mdast-util-mdx: 3.0.0
@@ -9765,23 +11380,23 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
-      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
-      vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-openapi@11.1.1(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1))(json-schema-typed@8.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  fumadocs-openapi@11.1.1(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1))(json-schema-typed@8.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@fumadocs/api-docs': 0.1.0(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1))(json-schema-typed@8.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@fumadocs/api-docs': 0.1.0(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1))(json-schema-typed@8.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@fumari/json-schema-ts': 0.0.2(json-schema-typed@8.0.2)
       '@fumari/stf': 1.1.0(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       chokidar: 5.0.0
       class-variance-authority: 0.7.1
       cnfast: 0.0.8
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
-      fumadocs-ui: 16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+      fumadocs-ui: 16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1)
       github-slugger: 2.0.0
       hast-util-to-jsx-runtime: 2.3.6
       js-yaml: 5.2.1
@@ -9800,7 +11415,7 @@ snapshots:
       - date-fns
       - supports-color
 
-  fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1):
+  fumadocs-ui@16.11.1(@emotion/is-prop-valid@1.4.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.1):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@fumadocs/tailwind': 0.1.0(tailwindcss@4.3.1)
@@ -9816,7 +11431,7 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority: 0.7.1
       cnfast: 0.0.8
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.563.0(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
       lucide-react: 1.23.0(react@19.2.3)
       motion: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -9830,13 +11445,29 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
-      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react-dom'
       - tailwindcss
 
   function-bind@1.1.2: {}
+
+  gaxios@7.3.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.3.0
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generic-pool@3.9.0: {}
 
@@ -9868,7 +11499,29 @@ snapshots:
     dependencies:
       lit: 3.3.3
 
+  github-from-package@0.0.0:
+    optional: true
+
   github-slugger@2.0.0: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.0
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -9942,6 +11595,12 @@ snapshots:
       vfile: 6.0.3
       web-namespaces: 2.0.1
       zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.1
+      unist-util-position: 5.0.0
 
   hast-util-to-estree@3.1.3:
     dependencies:
@@ -10031,11 +11690,17 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  highlight.js@10.7.3: {}
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
 
   hono@4.12.27: {}
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.5.2
 
   html-url-attributes@3.0.1: {}
 
@@ -10049,6 +11714,20 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -10056,6 +11735,10 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  ignore@7.0.5: {}
 
   immer@10.2.0: {}
 
@@ -10069,6 +11752,11 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8:
+    optional: true
+
+  ini@6.0.0: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -10115,6 +11803,8 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-unsafe@2.0.0: {}
+
   isexe@2.0.0: {}
 
   isobject@3.0.1: {}
@@ -10137,7 +11827,16 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -10150,6 +11849,42 @@ snapshots:
   json2mq@0.2.0:
     dependencies:
       string-convert: 0.2.1
+
+  jsonlines@0.1.1: {}
+
+  just-bash@2.14.5:
+    dependencies:
+      diff: 8.0.3
+      fast-xml-parser: 5.10.1
+      file-type: 21.3.4
+      ini: 6.0.0
+      minimatch: 10.2.6
+      modern-tar: 0.7.7
+      papaparse: 5.5.4
+      quickjs-emscripten: 0.32.0
+      re2js: 1.3.3
+      seek-bzip: 2.0.0
+      smol-toml: 1.7.1
+      sprintf-js: 1.1.3
+      sql.js: 1.14.1
+      turndown: 7.2.4
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mongodb-js/zstd': 7.0.0
+      node-liblzma: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   katex@0.16.47:
     dependencies:
@@ -10253,11 +11988,15 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@11.5.2: {}
 
   lru_map@0.4.1: {}
 
@@ -10293,16 +12032,18 @@ snapshots:
 
   marked@17.0.6: {}
 
+  marked@18.0.5: {}
+
   math-intrinsics@1.1.0: {}
 
-  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1
     optionalDependencies:
-      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -10828,10 +12569,31 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mimic-response@3.1.0:
+    optional: true
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimist@1.2.8:
+    optional: true
+
+  minipass@7.1.3: {}
+
   mixin-deep@1.3.2:
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
+
+  mkdirp-classic@0.5.3:
+    optional: true
+
+  modern-tar@0.7.7: {}
 
   motion-dom@12.40.0:
     dependencies:
@@ -10865,7 +12627,12 @@ snapshots:
 
   nanoid@3.3.15: {}
 
+  nanoid@6.0.1: {}
+
   nanostores@1.3.0: {}
+
+  napi-build-utils@2.0.0:
+    optional: true
 
   negotiator@1.0.0: {}
 
@@ -10874,7 +12641,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -10893,11 +12660,36 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
-      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-abi@3.94.0:
+    dependencies:
+      semver: 7.8.5
+    optional: true
+
+  node-addon-api@8.9.1:
+    optional: true
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  node-gyp-build@4.8.4:
+    optional: true
+
+  node-liblzma@2.2.0:
+    dependencies:
+      node-addon-api: 8.9.1
+      node-gyp-build: 4.8.4
+    optional: true
 
   numeral@2.0.6: {}
 
@@ -10939,7 +12731,21 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  openai@6.26.0(ws@8.21.3)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.3
+      zod: 4.4.3
+
+  os-paths@4.4.0: {}
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   package-manager-detector@1.6.0: {}
+
+  papaparse@5.5.4: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -10968,11 +12774,20 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  partial-json@0.1.7: {}
+
   path-data-parser@0.1.0: {}
+
+  path-expression-matcher@1.6.2: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 
@@ -11030,18 +12845,60 @@ snapshots:
 
   preact@10.29.2: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.94.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
+    optional: true
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   property-information@7.2.0: {}
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 20.19.43
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+    optional: true
 
   qs@6.15.3:
     dependencies:
@@ -11055,6 +12912,18 @@ snapshots:
       decode-uri-component: 0.4.1
       filter-obj: 5.1.0
       split-on-first: 3.0.0
+
+  quickjs-emscripten-core@0.32.0:
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  quickjs-emscripten@0.32.0:
+    dependencies:
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.32.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.32.0
+      quickjs-emscripten-core: 0.32.0
 
   radix-ui@1.6.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -11227,10 +13096,20 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-is: 18.3.1
 
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+    optional: true
+
   re-resizable@6.11.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+
+  re2js@1.3.3: {}
 
   react-avatar-editor@15.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -11357,6 +13236,13 @@ snapshots:
 
   react@19.2.3: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    optional: true
+
   readdirp@5.0.0: {}
 
   recharts@3.8.1(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)(redux@5.0.1):
@@ -11440,6 +13326,10 @@ snapshots:
       hast-util-is-element: 3.0.0
       unist-util-visit: 5.1.0
 
+  rehype-harden@1.1.8:
+    dependencies:
+      unist-util-visit: 5.1.0
+
   rehype-katex@7.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -11463,6 +13353,11 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   rehype-slug@6.0.0:
     dependencies:
@@ -11581,6 +13476,10 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
+
   robust-predicates@3.0.3: {}
 
   rollup@4.62.2:
@@ -11635,6 +13534,8 @@ snapshots:
 
   rw@1.3.3: {}
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
@@ -11647,7 +13548,13 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
+  seek-bzip@2.0.0:
+    dependencies:
+      commander: 6.2.1
+
   semver-compare@1.0.0: {}
+
+  semver@7.8.0: {}
 
   semver@7.8.5:
     optional: true
@@ -11795,6 +13702,20 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
+  simple-concat@1.0.1:
+    optional: true
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+    optional: true
+
+  smol-toml@1.7.1: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.5.7: {}
@@ -11811,18 +13732,70 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sprintf-js@1.1.3: {}
+
+  sql.js@1.14.1: {}
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
+  streamdown@2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      clsx: 2.1.1
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      marked: 17.0.6
+      mermaid: 11.15.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      rehype-harden: 1.1.8
+      rehype-raw: 7.0.0
+      rehype-sanitize: 6.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remend: 1.3.0
+      tailwind-merge: 3.6.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-convert@0.2.1: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-json-comments@2.0.1:
+    optional: true
+
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
 
   style-to-js@1.1.21:
     dependencies:
@@ -11859,6 +13832,38 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+    optional: true
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    optional: true
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
   throttle-debounce@5.0.2: {}
 
   throttleit@2.1.0: {}
@@ -11884,9 +13889,17 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-dedent@2.3.0: {}
 
@@ -11896,15 +13909,34 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
+  turndown@7.2.4:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
+
   type-is@2.1.0:
     dependencies:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typebox@1.1.38: {}
+
+  typebox@1.3.11: {}
+
   typescript@5.9.3: {}
 
+  uint8array-extras@1.5.0: {}
+
   undici-types@6.21.0: {}
+
+  undici@7.29.0: {}
+
+  undici@8.5.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -11980,9 +14012,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  use-stick-to-bottom@1.1.6(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  util-deprecate@1.0.2:
+    optional: true
 
   uuid@13.0.2: {}
 
@@ -12027,7 +14066,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0):
+  vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.5)
@@ -12040,11 +14079,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
+      yaml: 2.9.0
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@20.19.43)(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -12061,15 +14101,17 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.43
     transitivePeerDependencies:
       - msw
 
   web-namespaces@2.0.1: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   web-vitals@5.3.0: {}
 
@@ -12084,13 +14126,27 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.21.3: {}
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xml-js@1.6.11:
     dependencies:
       sax: 1.6.0
 
+  xml-naming@0.3.0: {}
+
   yallist@4.0.0: {}
 
   yaml@1.10.3: {}
+
+  yaml@2.9.0: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/test/server-only-stub.ts
+++ b/test/server-only-stub.ts
@@ -1,0 +1,10 @@
+/**
+ * Stands in for the `server-only` marker module under vitest.
+ *
+ * `server-only` is not an npm dependency here — Next resolves it at build time,
+ * where it exists to make a client component that imports a server module fail
+ * loudly. Vitest has no such resolution, so importing a `server-only` module in
+ * a test throws before the test runs. Aliasing it to this empty file keeps the
+ * marker meaningful in the build and inert in the test run.
+ */
+export {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,19 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 // Pure-logic tests only (lib/**/*.test.{ts,mjs}, components/**/*.test.{ts,mjs}).
 // Relative imports, no path aliases.
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Not a path alias for app code — `server-only` is a Next build-time
+      // marker with no npm package behind it, so it is unresolvable here.
+      // See test/server-only-stub.ts.
+      "server-only": fileURLToPath(
+        new URL("./test/server-only-stub.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     include: ["lib/**/*.test.{ts,mjs}", "components/**/*.test.{ts,mjs}"],
     environment: "node",


### PR DESCRIPTION
**Draft — not ready to merge.** See *Before this ships* below.

Adds `/chat`: one playground where both axes are chosen per turn — the model BitRouter routes to, and the harness driving the agent loop. Replaces the earlier split between `/chat` and `/chat/harness`.

## The harness axis

A flat registry ([`lib/harnesses.ts`](lib/harnesses.ts)) rendered as one picker. Entries that cannot run stay **visible with the reason** rather than being hidden — the picker is the clearest statement of what the product is, so an unconfigured option should still show.

| Entry | What it is |
|---|---|
| `ai-sdk` | `streamText` loop + docs tools, no server session |
| `pi` | in-process runtime on `@ai-sdk/sandbox-just-bash` |
| `bitrouter-claude-acp` / `-codex-acp` / `-gemini-cli` / `-pi-acp` | BitRouter's own catalog over ACP, in a sandbox VM |
| `claude-code` / `codex` / `opencode` | listed; run against the vendor's own API |

The BitRouter entries are the point. `@ai-sdk/harness-acp` is the AI SDK's *generic* adapter — `@ai-sdk/harness-grok-build` is nothing but a `createACP()` call — and `bitrouter acp serve` speaks vanilla ACP over stdio. So one `createACP()` per catalog id turns BitRouter's agents into AI SDK harnesses whose traffic is **routed** rather than going direct to a vendor. `BitRouter · Claude Code` and `Claude Code` sit side by side deliberately: same runtime, different endpoint.

## Notable design points

- **Shared session pool** ([`lib/harness-sessions.ts`](lib/harness-sessions.ts)) — process-local and evictable by design, which one long-lived `next start` on Railway supports. Documented as such rather than pretending to durability.
- **Changing either axis rebuilds the runtime**, so the client starts a fresh chat instead of showing a transcript the agent has no memory of (`resetsHistory`).
- **Sandbox behind one module** ([`lib/harness-sandbox.server.ts`](lib/harness-sandbox.server.ts)) so the intended Railway swap is a single edit.

## Verified

Typecheck clean, 129 tests, build compiling, picker checked in-browser. End-to-end against **real Vercel Sandboxes**, stages 1–3 (plan §8):

```
1 provision          PASS  Amazon Linux 2023, node 24.14.1, glibc 2.34
2 install bitrouter  PASS  1.0.0-alpha.27 runs (~24s)
3 ACP handshake      PASS  protocolVersion 1, agentInfo "Claude Code" 0.16.2
```

Two findings from that run are baked into the code:

- **`xz` is missing from the sandbox image.** glibc 2.34 < 2.35 means bitrouter falls back to its musl `.tar.xz`, which tar cannot unpack. Fixable in `onBootstrap` — which runs *after* the adapter's bootstrap — only because pnpm 10 ignores bitrouter's build script, so the binary is fetched lazily on first spawn. Verified in production order.
- **`@vercel/sandbox` never reads `VERCEL_TOKEN`/`PROJECT_ID`/`TEAM_ID`.** They appear only in its README as values a caller passes explicitly. They are now threaded through, and the local OIDC path is recognised.

## Before this ships

- [ ] **No full harness turn has run.** Stage 3 used `--direct`, so the routed path (`--base-url` + key), whether `--model` accepts a raw `CHAT_MODELS` id, and the bridge's WebSocket dial are all unexercised.
- [ ] **Auth and billing.** `/api/chat/playground` is unauthenticated and spends the shared key; the BitRouter entries are a **VM per chat session**. Keep the sandbox credentials unset until this is addressed.
- [ ] **Decide plan §4.4** — whether BitRouter grows `session/resume`. The playground does not need it; recommendation is no, plus a two-line masking fix in `bitrouter`.

## Known issues (deliberate)

- `bitrouter-gemini-cli` is listed but permanently unavailable: it sends a non-Bearer key the router rejects, and is deprecated upstream. Encoded as `knownIssue` rather than shipped broken.
- Pre-existing typecheck errors in `components/ai/search.tsx` (`buttonVariants({ color })`) and `components/markdown.tsx` are untouched.

Plan and full findings: [`docs/bitrouter-acp-harness-plan.md`](docs/bitrouter-acp-harness-plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
