### PR TITLE
feat(changelog): make releases legible to agents

### DIFF
--- a/app/api/docs/llms-full.txt/route.ts
+++ b/app/api/docs/llms-full.txt/route.ts
@@ -1,16 +1,23 @@
 import { getLLMText, source } from "@/lib/source";
 import { LLMS_PRODUCT_SUMMARY } from "@/lib/llms-shared";
+import { buildChangelogMarkdown } from "@/lib/changelog-markdown";
 
 export const revalidate = false;
 
 export async function GET() {
   const scan = source.getPages().map(getLLMText);
-  const scanned = await Promise.all(scan);
+  const [scanned, changelog] = await Promise.all([
+    Promise.all(scan),
+    // The docs say what BitRouter does; only the changelog says what it does
+    // *now*. A bundle without it answers version questions from whenever the
+    // docs were last rewritten.
+    buildChangelogMarkdown(),
+  ]);
 
   // Lead with the product summary (value prop, key facts, comparison) so the
   // full-text ingestion bundle carries the landing-page positioning the docs
   // tree alone doesn't, then append every doc page.
   const header = `# BitRouter\n\n${LLMS_PRODUCT_SUMMARY}`;
 
-  return new Response([header, ...scanned].join("\n\n"));
+  return new Response([header, ...scanned, changelog].join("\n\n"));
 }

--- a/app/changelog.md/route.ts
+++ b/app/changelog.md/route.ts
@@ -1,0 +1,13 @@
+import { buildChangelogMarkdown } from "@/lib/changelog-markdown";
+
+export const dynamic = "force-static";
+export const revalidate = false;
+
+export async function GET() {
+  return new Response(await buildChangelogMarkdown(), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/app/changelog/(posts)/[slug]/page.tsx
+++ b/app/changelog/(posts)/[slug]/page.tsx
@@ -8,6 +8,38 @@ import type { Metadata } from "next";
 
 type Props = { params: Promise<{ slug: string }> };
 
+const SITE = "https://bitrouter.ai";
+
+/**
+ * A release entry is a version fact, not just an article: schema.org models it
+ * as the application at a version, with `softwareVersion` and `releaseNotes`.
+ * Answer engines use that to bind "which version added X" to an entity instead
+ * of inferring it from prose.
+ *
+ * Carries an `@id` of its own and states only version facts. The root layout
+ * already publishes the canonical BitRouter `SoftwareApplication`; without a
+ * distinct id these would merge into one node, and app-level properties
+ * restated here would contradict the ones stated there.
+ */
+function releaseJsonLd(page: ReturnType<typeof changelogSource.getPage>) {
+  if (!page) return null;
+  const url = `${SITE}${page.url}`;
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "@id": `${url}#release`,
+    name: "BitRouter",
+    applicationCategory: "DeveloperApplication",
+    url,
+    // JSON.stringify drops undefined members, so an entry with no version or
+    // description simply omits them rather than emitting nulls.
+    softwareVersion: page.data.version,
+    datePublished: page.data.date,
+    releaseNotes: url,
+    description: page.data.description,
+  };
+}
+
 export default async function ChangelogEntryPage({ params }: Props) {
   const { slug } = await params;
 
@@ -15,6 +47,7 @@ export default async function ChangelogEntryPage({ params }: Props) {
   if (!page) notFound();
 
   const MDX = page.data.body;
+  const jsonLd = releaseJsonLd(page);
   const date = new Date(page.data.date).toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
@@ -24,6 +57,12 @@ export default async function ChangelogEntryPage({ params }: Props) {
 
   return (
     <div className="zed-bg">
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
       <section style={{ position: "relative" }}>
         <div
           style={{
@@ -88,12 +127,29 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // Keep the version in the <title> — it's what people search for — but don't
   // repeat it when the headline already is the version string.
   const headline = headlineOf(page.data);
+  const title =
+    page.data.version && headline !== page.data.version
+      ? `${page.data.version} — ${headline}`
+      : headline;
+  const url = `${SITE}${page.url}`;
   return {
-    title:
-      page.data.version && headline !== page.data.version
-        ? `${page.data.version} — ${headline}`
-        : headline,
+    title,
     description: page.data.description,
-    alternates: { canonical: `https://bitrouter.ai${page.url}` },
+    alternates: { canonical: url },
+    // Release entries are dated articles. Without `type: article` and
+    // `publishedTime` a shared link carries no date, and the whole point of a
+    // changelog entry is when it happened.
+    openGraph: {
+      type: "article",
+      url,
+      title,
+      description: page.data.description,
+      publishedTime: new Date(page.data.date).toISOString(),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: page.data.description,
+    },
   };
 }

--- a/lib/changelog-markdown.ts
+++ b/lib/changelog-markdown.ts
@@ -1,0 +1,40 @@
+/**
+ * The whole release history as one plain-Markdown document, served at
+ * /changelog.md and appended to /api/docs/llms-full.txt.
+ *
+ * RSS and Atom already exist, but assistants and coding agents fetch Markdown,
+ * not feeds — and a feed carries only the descriptions, never the notes. One
+ * file, chronological, an `##` per release, is the shape that survives every
+ * retrieval pipeline intact and stays readable to a human who curls it.
+ *
+ * Formatting lives in lib/changelog.ts, which is pure and unit-tested; this
+ * module is only the read of the entry bodies.
+ */
+import { changelogSource, getChangelogItems } from "./source";
+import { releaseSection, sortReleasesDesc } from "./changelog";
+
+const SITE = "https://bitrouter.ai";
+
+const HEADER = [
+  "# BitRouter Changelog",
+  "Every BitRouter release, newest first.",
+  [
+    `Web: ${SITE}/changelog`,
+    `Feeds: ${SITE}/changelog/rss.xml · ${SITE}/changelog/atom.xml`,
+    "Source: https://github.com/bitrouter/bitrouter",
+  ].join("  \n"),
+].join("\n\n");
+
+export async function buildChangelogMarkdown(): Promise<string> {
+  const pages = new Map(changelogSource.getPages().map((page) => [page.url, page]));
+
+  const sections = await Promise.all(
+    sortReleasesDesc(getChangelogItems()).map(async (item) => {
+      const page = pages.get(item.url);
+      const notes = page ? await page.data.getText("processed") : "";
+      return releaseSection(item, notes);
+    }),
+  );
+
+  return `${[HEADER, ...sections].join("\n\n---\n\n")}\n`;
+}

--- a/lib/changelog.test.ts
+++ b/lib/changelog.test.ts
@@ -5,6 +5,9 @@ import {
   groupFeed,
   allTags,
   headlineOf,
+  releaseHeading,
+  releaseSection,
+  stripMdxComments,
   type ChangelogItem,
   type FeedRollup,
 } from "./changelog";
@@ -158,5 +161,43 @@ describe("headlineOf", () => {
   it("falls back to the title when there is no description", () => {
     expect(headlineOf({ title: "v1.0.0-alpha.18" })).toBe("v1.0.0-alpha.18");
     expect(headlineOf({ title: "t", description: "  " })).toBe("t");
+  });
+});
+
+describe("Markdown surface", () => {
+  const item = {
+    url: "/changelog/v1-0-0-alpha-28",
+    title: "v1.0.0-alpha.28",
+    description: "Skills are served over MCP.",
+    date: "2026-08-15",
+    version: "v1.0.0-alpha.28",
+    tags: [],
+    breaking: true,
+  };
+
+  it("drops the sync's provenance comment from the notes", () => {
+    const notes = "{/* Auto-generated from bitrouter/bitrouter release v1. */}\n\n### Added\n\nProse.";
+    expect(stripMdxComments(notes)).toBe("### Added\n\nProse.");
+  });
+
+  it("titles a release with its version and headline, no trailing period", () => {
+    expect(releaseHeading(item)).toBe("## v1.0.0-alpha.28 — Skills are served over MCP");
+  });
+
+  it("does not repeat the version when it is also the headline", () => {
+    expect(releaseHeading({ ...item, description: undefined })).toBe("## v1.0.0-alpha.28");
+  });
+
+  it("carries the date, permalink and breaking flag above the notes", () => {
+    const section = releaseSection(item, "{/* banner */}\n\n### Added\n\nProse.");
+    expect(section).toContain("Released: 2026-08-15");
+    expect(section).toContain("Permalink: https://bitrouter.ai/changelog/v1-0-0-alpha-28");
+    expect(section).toContain("Breaking: yes");
+    expect(section).not.toContain("banner");
+    expect(section.endsWith("### Added\n\nProse.")).toBe(true);
+  });
+
+  it("omits the breaking line for an ordinary release", () => {
+    expect(releaseSection({ ...item, breaking: false }, "Prose.")).not.toContain("Breaking:");
   });
 });

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -130,3 +130,41 @@ export function headlineOf(item: {
 }): string {
   return item.description?.trim() || item.title;
 }
+
+const SITE = "https://bitrouter.ai";
+
+/**
+ * Entry bodies carry an MDX provenance comment telling a maintainer whether the
+ * sync will overwrite the file. It is build bookkeeping, invisible on the
+ * rendered page — and it must stay invisible on the Markdown surfaces too,
+ * where it would otherwise be the first thing an agent reads about a release.
+ */
+export function stripMdxComments(text: string): string {
+  return text.replace(/\{\/\*[\s\S]*?\*\/\}/g, "").trim();
+}
+
+/** `## v1.0.0-alpha.28 — What shipped`, with no trailing sentence period. */
+export function releaseHeading(item: ChangelogItem): string {
+  const headline = headlineOf(item).replace(/\.$/, "");
+  return item.version && headline !== item.version
+    ? `## ${item.version} — ${headline}`
+    : `## ${headline}`;
+}
+
+/**
+ * One release as a Markdown section: heading, the facts a reader needs to place
+ * it in time, then the notes. Used for /changelog.md and the changelog tail of
+ * llms-full.txt.
+ */
+export function releaseSection(item: ChangelogItem, notes: string): string {
+  const meta = [
+    `Released: ${item.date}`,
+    `Permalink: ${SITE}${item.url}`,
+    item.breaking ? "Breaking: yes" : null,
+  ]
+    .filter(Boolean)
+    .join("  \n");
+  return [releaseHeading(item), meta, stripMdxComments(notes)]
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/lib/llms-txt.test.ts
+++ b/lib/llms-txt.test.ts
@@ -6,4 +6,12 @@ describe("LLMS_TXT", () => {
     expect(LLMS_TXT.trim().startsWith("# BitRouter")).toBe(true);
     expect(LLMS_TXT.length).toBeGreaterThan(200);
   });
+
+  // An agent asked "what's new" or "is X supported yet" can only answer from
+  // the changelog, and it only finds the changelog if this index names it.
+  it("routes to the changelog and its Markdown surface", () => {
+    expect(LLMS_TXT).toContain("## Changelog");
+    expect(LLMS_TXT).toContain("https://bitrouter.ai/changelog.md");
+    expect(LLMS_TXT).toContain("https://bitrouter.ai/changelog)");
+  });
 });

--- a/lib/llms-txt.ts
+++ b/lib/llms-txt.ts
@@ -101,8 +101,14 @@ References:
 - [Hermes](${BASE_URL}/docs/integrations/hermes): Nous Research's self-improving agent
 - [OpenClaw](${BASE_URL}/docs/integrations/openclaw): Route the OpenClaw multi-channel agent
 
+## Changelog
+
+- [Changelog](${BASE_URL}/changelog): Every release, newest first — what shipped, what broke, and how to migrate
+- [changelog.md](${BASE_URL}/changelog.md): The complete release history as one plain-Markdown file; fetch this to answer "what's new", "is X supported yet", or "what changed between versions"
+- [RSS](${BASE_URL}/changelog/rss.xml) / [Atom](${BASE_URL}/changelog/atom.xml): Release feeds
+
 ## Optional
 
-- [llms-full.txt](${BASE_URL}/api/docs/llms-full.txt): Complete documentation as plain text for ingestion
+- [llms-full.txt](${BASE_URL}/api/docs/llms-full.txt): Complete documentation as plain text for ingestion, with the full changelog appended
 - [Blog: Introducing BitRouter](${BASE_URL}/blog/introducing-bitrouter): Long-form launch post
 `;

--- a/lib/release-notes.mjs
+++ b/lib/release-notes.mjs
@@ -1,0 +1,110 @@
+/**
+ * Reading a GitHub release body from bitrouter/bitrouter.
+ *
+ * Two shapes arrive here. Releases up to v1.0.0-alpha.27 are raw git-cliff:
+ * emoji group headings over one bullet per commit. From v1.0.0-alpha.28 the
+ * source repo folds per-PR change files in first (bitrouter/bitrouter#820), so
+ * the body leads with curated Keep a Changelog sections — `### Breaking
+ * changes`, `### Added`, … — each holding an `#### <title>` and prose, and the
+ * generated bullets move into a collapsed "All commits" block at the end.
+ *
+ * Both shapes have to keep working: the old ones are already published, and a
+ * release whose PRs were all labelled `no-changelog` still arrives bullets-only.
+ *
+ * Script-side only, extracted from scripts/sync-changelog.mjs so the parsing
+ * can be unit-tested against both shapes.
+ */
+import { escapeMdxText } from "./mdx-escape.mjs";
+
+/**
+ * Drop the collapsed commit list. It is the same information the git history
+ * already carries, and left in it would be the bulk of the page's text — the
+ * exact noise folding the change files upstream was meant to remove. Anchored
+ * on the summary so a hand-written <details> in a curated entry survives.
+ */
+export function stripCommitList(body) {
+  return String(body ?? "").replace(
+    /\n*<details>\s*(?:\n\s*)?<summary>\s*All commits\s*<\/summary>[\s\S]*?<\/details>[^\S\n]*/gi,
+    "",
+  );
+}
+
+/**
+ * The body as it goes into the MDX entry: no commit list, no trailing commit
+ * hashes (the PR link is the useful half), no triple blank lines, MDX-safe.
+ */
+export function cleanReleaseBody(body) {
+  return escapeMdxText(
+    stripCommitList(body)
+      // strip the trailing " - ([hash](url))" without crossing line boundaries
+      .replace(/[^\S\n]*-[^\S\n]*\(\[[0-9a-f]{7,}\]\([^)]+\)\)[^\S\n]*$/gim, "")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim(),
+  );
+}
+
+/**
+ * The one line that becomes the entry's `description` — the headline on the
+ * index, the `<meta name="description">`, and the RSS summary.
+ *
+ * A curated `#### ` title is written for a reader upgrading, so it wins over
+ * the first commit subject whenever one exists. Only a release with no change
+ * files falls back to the bullet.
+ */
+export function headlineFor(body) {
+  const text = stripCommitList(body);
+  const curated = text.match(/^####\s+(.+?)\s*$/m);
+  if (curated) return tidyHeadline(curated[1]);
+
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("- ")) {
+      return tidyHeadline(line.replace(/^- /, "").replace(/\*\(([^)]+)\)\*\s*/, ""));
+    }
+  }
+  return null;
+}
+
+/**
+ * `description` is rendered as plain text, not Markdown, so link tails and code
+ * fences would show up literally. git-cliff's inline breaking marker belongs in
+ * the `breaking` flag rather than the headline.
+ */
+function tidyHeadline(text) {
+  return text
+    .replace(/\[\*\*breaking\*\*\]\s*/i, "")
+    .replace(/\s*\(\[#\d+\][^)]*\)\s*.*$/, "") // drop PR/commit refs + tail
+    .replace(/`/g, "")
+    .trim();
+}
+
+/**
+ * Read tags off the *raw* body, so a curated entry is still tagged from the
+ * commit groups in its collapsed list. Both heading vocabularies count.
+ */
+export function deriveTags(body) {
+  const text = String(body ?? "");
+  const tags = [];
+  const has = (re) => re.test(text);
+  if (has(/###.*Features/i) || has(/^###\s+Added\b/im)) tags.push("features");
+  if (has(/###.*(Bug Fixes|Fixes)/i) || has(/^###\s+Fixed\b/im)) tags.push("fixes");
+  if (has(/###.*(Performance|Perf)/i)) tags.push("performance");
+  if (has(/###.*(Documentation|Docs)/i)) tags.push("docs");
+  if (has(/^###\s+Security\b/im)) tags.push("security");
+  return tags;
+}
+
+/**
+ * Also read from the raw body: a curated `### Breaking changes` section and
+ * git-cliff's inline `[**breaking**]` marker are independent signals, and a
+ * release can carry the second without the first.
+ */
+export function isBreaking(body) {
+  const text = String(body ?? "");
+  return (
+    /breaking change/i.test(text) ||
+    /^#+.*!:/m.test(text) ||
+    /\bfeat!|\bfix!/i.test(text) ||
+    /\[\*\*breaking\*\*\]/i.test(text)
+  );
+}

--- a/lib/release-notes.test.mjs
+++ b/lib/release-notes.test.mjs
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import {
+  cleanReleaseBody,
+  deriveTags,
+  headlineFor,
+  isBreaking,
+  stripCommitList,
+} from "./release-notes.mjs";
+
+// The shape every release up to v1.0.0-alpha.27 arrives in.
+const GIT_CLIFF = `### ⛰️ Features
+
+- *(sdk)* Clarify request timing metrics ([#738](https://github.com/bitrouter/bitrouter/pull/738)) - ([a5b0730](https://github.com/bitrouter/bitrouter/commit/a5b0730))
+- *(tui)* Composite manager ([#715](https://github.com/bitrouter/bitrouter/pull/715)) - ([7a72dff](https://github.com/bitrouter/bitrouter/commit/7a72dff))
+
+### 🐛 Bug Fixes
+
+- *(fleet)* Non-blocking spawn/prompt ([#737](https://github.com/bitrouter/bitrouter/pull/737)) - ([84c1e99](https://github.com/bitrouter/bitrouter/commit/84c1e99))`;
+
+// The shape from v1.0.0-alpha.28 on, after bitrouter/bitrouter#820 folds the
+// per-PR change files into the release section.
+const FOLDED = `### Breaking changes
+
+#### The \`bitrouter skills\` installer subcommands are removed ([#770](https://github.com/bitrouter/bitrouter/pull/770))
+
+\`bitrouter skills add\`, \`remove\`, \`find\`, and \`update\` are removed. Install
+skills with \`npx skills add\` instead.
+
+### Added
+
+#### Agent Skills are served and proxied over MCP (SEP-2640) ([#770](https://github.com/bitrouter/bitrouter/pull/770))
+
+BitRouter now serves Agent Skills as an MCP server.
+
+<details>
+<summary>All commits</summary>
+
+### ⛰️ Features
+
+- *(skills)* [**breaking**] Serve over MCP ([#770](https://github.com/bitrouter/bitrouter/pull/770)) - ([afeb3ab](https://github.com/bitrouter/bitrouter/commit/afeb3ab))
+
+### 🐛 Bug Fixes
+
+- *(responses)* Harden continuation publication - ([c3c35b3](https://github.com/bitrouter/bitrouter/commit/c3c35b3))
+
+</details>`;
+
+describe("stripCommitList", () => {
+  it("drops the collapsed All commits block", () => {
+    const stripped = stripCommitList(FOLDED);
+    expect(stripped).not.toContain("<details>");
+    expect(stripped).not.toContain("Harden continuation publication");
+    expect(stripped).toContain("Agent Skills are served");
+  });
+
+  it("leaves a git-cliff body alone", () => {
+    expect(stripCommitList(GIT_CLIFF)).toBe(GIT_CLIFF);
+  });
+
+  it("keeps a <details> that is not the commit list", () => {
+    const body = "### Added\n\n<details>\n<summary>Config example</summary>\n\nyaml\n</details>";
+    expect(stripCommitList(body)).toBe(body);
+  });
+});
+
+describe("headlineFor", () => {
+  it("prefers a curated title over the first commit subject", () => {
+    expect(headlineFor(FOLDED)).toBe(
+      "The bitrouter skills installer subcommands are removed",
+    );
+  });
+
+  it("falls back to the first bullet when no change file was written", () => {
+    expect(headlineFor(GIT_CLIFF)).toBe("Clarify request timing metrics");
+  });
+
+  it("never reaches into the collapsed commit list for a fallback", () => {
+    const curatedOnly = FOLDED.replace(/### Breaking changes[\s\S]*?### Added/, "### Added");
+    expect(headlineFor(curatedOnly)).toBe(
+      "Agent Skills are served and proxied over MCP (SEP-2640)",
+    );
+  });
+
+  it("strips the inline breaking marker, which belongs in the flag", () => {
+    const body = "- *(cli)* [**breaking**] Drop the legacy flag ([#1](https://x.invalid))";
+    expect(headlineFor(body)).toBe("Drop the legacy flag");
+  });
+
+  it("returns null when there is nothing to lead with", () => {
+    expect(headlineFor("")).toBeNull();
+  });
+});
+
+describe("deriveTags", () => {
+  it("reads Keep a Changelog headings", () => {
+    expect(deriveTags("### Added\n\n### Fixed\n\n### Security")).toEqual([
+      "features",
+      "fixes",
+      "security",
+    ]);
+  });
+
+  it("still reads git-cliff headings", () => {
+    expect(deriveTags(GIT_CLIFF)).toEqual(["features", "fixes"]);
+  });
+
+  it("reads a curated release through its collapsed commit list", () => {
+    expect(deriveTags(FOLDED)).toContain("fixes");
+  });
+});
+
+describe("isBreaking", () => {
+  it("detects a curated Breaking changes section", () => {
+    expect(isBreaking("### Breaking changes\n\n#### Something went")).toBe(true);
+  });
+
+  it("detects git-cliff's inline marker even with no curated section", () => {
+    expect(isBreaking(GIT_CLIFF.replace("*(sdk)*", "*(sdk)* [**breaking**]"))).toBe(true);
+  });
+
+  it("is false for an ordinary release", () => {
+    expect(isBreaking(GIT_CLIFF)).toBe(false);
+  });
+});
+
+describe("cleanReleaseBody", () => {
+  it("keeps the PR link and drops the commit-hash tail", () => {
+    const cleaned = cleanReleaseBody(GIT_CLIFF);
+    expect(cleaned).toContain("([#738](https://github.com/bitrouter/bitrouter/pull/738))");
+    expect(cleaned).not.toContain("a5b0730");
+  });
+
+  it("reduces a folded release to its curated prose", () => {
+    const cleaned = cleanReleaseBody(FOLDED);
+    expect(cleaned).toContain("### Breaking changes");
+    expect(cleaned).not.toContain("All commits");
+    expect(cleaned).not.toContain("c3c35b3");
+  });
+});

--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -5,6 +5,11 @@
  * content/changelog/. It never overwrites an existing entry, so once an entry is
  * hand-edited and merged it is frozen.
  *
+ * Release bodies come in two shapes and lib/release-notes.mjs reads both — see
+ * its header. From v1.0.0-alpha.28 the source repo folds per-PR change files in
+ * before publishing, so the body leads with curated prose and the generated
+ * bullets arrive in a collapsed block that is dropped here.
+ *
  * Entries are tiered by `significance` (see lib/release-version.mjs), and the
  * tier decides how much human attention the entry needs:
  *   routine (prereleases, patches) → published as-is; no curation expected
@@ -31,7 +36,12 @@
 import { readdir, writeFile, appendFile } from "node:fs/promises";
 import { join } from "node:path";
 import { significanceFor, compareVersionsAsc } from "../lib/release-version.mjs";
-import { escapeMdxText } from "../lib/mdx-escape.mjs";
+import {
+  cleanReleaseBody,
+  deriveTags,
+  headlineFor,
+  isBreaking,
+} from "../lib/release-notes.mjs";
 
 const SOURCE_REPO = process.env.SOURCE_REPO ?? "bitrouter/bitrouter";
 const ONLY_TAG = process.env.CHANGELOG_TAG?.trim() || null;
@@ -70,57 +80,6 @@ function slugForTag(tag) {
   return tag.replace(/[^\w.-]/g, "").replace(/\./g, "-").toLowerCase();
 }
 
-// git-cliff release notes group bullets under "### ⛰️ Features" etc. and end
-// each line with " - ([hash](url))". Strip the commit-hash tail (keeping the PR
-// link) so the draft reads less like a raw commit log.
-function cleanBody(body) {
-  return escapeMdxText(
-    (body ?? "")
-      // strip the trailing " - ([hash](url))" without crossing line boundaries
-      .replace(/[^\S\n]*-[^\S\n]*\(\[[0-9a-f]{7,}\]\([^)]+\)\)[^\S\n]*$/gim, "")
-      .replace(/\n{3,}/g, "\n\n")
-      .trim(),
-  );
-}
-
-function firstFeatureLine(body) {
-  for (const raw of (body ?? "").split("\n")) {
-    const line = raw.trim();
-    if (line.startsWith("- ")) {
-      return line
-        .replace(/^- /, "")
-        .replace(/\*\(([^)]+)\)\*\s*/, "") // drop the *(scope)* prefix
-        // git-cliff marks breaking commits inline. That belongs in the
-        // `breaking` frontmatter flag (see isBreaking), not in the prose —
-        // left in, it rendered as literal "[**breaking**]" in the headline.
-        .replace(/\[\*\*breaking\*\*\]\s*/i, "")
-        .replace(/\s*\(\[#\d+\][^)]*\)\s*.*$/, "") // drop PR/commit refs + tail
-        .trim();
-    }
-  }
-  return null;
-}
-
-function deriveTags(body) {
-  const tags = [];
-  if (/###.*Features/i.test(body)) tags.push("features");
-  if (/###.*(Bug Fixes|Fixes)/i.test(body)) tags.push("fixes");
-  if (/###.*(Performance|Perf)/i.test(body)) tags.push("performance");
-  if (/###.*(Documentation|Docs)/i.test(body)) tags.push("docs");
-  return tags;
-}
-
-function isBreaking(body) {
-  return (
-    /breaking change/i.test(body) ||
-    /^#+.*!:/m.test(body) ||
-    /\bfeat!|\bfix!/i.test(body) ||
-    // git-cliff's own inline marker — the form actually used in these releases,
-    // and the one the original three patterns all missed.
-    /\[\*\*breaking\*\*\]/i.test(body)
-  );
-}
-
 function yaml(v) {
   return JSON.stringify(v); // JSON scalars/arrays are valid YAML flow syntax
 }
@@ -128,14 +87,21 @@ function yaml(v) {
 function buildMdx(release) {
   const tag = release.tag_name;
   const date = (release.published_at ?? release.created_at ?? "").slice(0, 10);
-  const cleaned = cleanBody(release.body);
-  const lead = firstFeatureLine(release.body);
-  const tags = deriveTags(cleaned);
-  const breaking = isBreaking(cleaned);
+  // Tags and the breaking flag read the raw body — a curated release still
+  // carries its commit groups and any inline `[**breaking**]` marker inside the
+  // collapsed list, and that is signal the cleaned prose no longer has.
+  const cleaned = cleanReleaseBody(release.body);
+  const lead = headlineFor(release.body);
+  const tags = deriveTags(release.body);
+  const breaking = isBreaking(release.body);
 
   const significance = significanceFor(tag);
   const title = release.name?.trim() || tag;
-  const description = lead ? `${lead}.` : `BitRouter ${tag} release.`;
+  const description = lead
+    ? /[.!?]$/.test(lead)
+      ? lead
+      : `${lead}.`
+    : `BitRouter ${tag} release.`;
   const body = cleaned || "_No release notes._";
 
   const fm = [

--- a/source.config.ts
+++ b/source.config.ts
@@ -55,6 +55,12 @@ export const changelog = defineDocs({
       // to promote a release the version shape would otherwise call routine.
       significance: z.enum(["highlight", "notable", "routine"]).optional(),
     }),
+    // Release notes are served as plain Markdown too (/changelog.md, and the
+    // tail of /api/docs/llms-full.txt), so the processed body has to survive
+    // alongside the compiled MDX.
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
   },
   meta: {
     schema: metaSchema,


### PR DESCRIPTION
Four gaps, all on the surfaces agents actually read. The plumbing here is already good — `robots.ts` names GPTBot, ClaudeBot, OAI-SearchBot, PerplexityBot and Google-Extended by hand, there's llms.txt, llms-full.txt, a git-dated sitemap, RSS and Atom. The changelog just wasn't wired into any of it.

## 1. llms.txt never mentioned the changelog

The index that tells an assistant what exists listed docs, API reference and recipes. `llms-full.txt` bundled `source.getPages()` — docs only. So an agent asked *"what's new"*, *"is X supported yet"*, or *"what changed between versions"* had no route to an answer.

Adds a `## Changelog` section, and appends the release history to the ingestion bundle. The docs say what BitRouter does; only the changelog says what it does *now*.

## 2. `/changelog.md`

RSS and Atom are the developer channel. Assistants fetch Markdown — and a feed carries only the descriptions, never the notes. This serves the whole history as one file, newest first, an `##` per release with its date, permalink and breaking flag.

Formatting lives in `lib/changelog.ts` beside the other pure presentation logic so it's unit-tested; bodies come from fumadocs, which needed `includeProcessedMarkdown` on the changelog collection. The sync's provenance comment (`{/* Auto-generated… Edit freely */}`) is stripped — build bookkeeping, invisible on the rendered page, and otherwise the first thing an agent would read about a release.

## 3. Structured data and article metadata on entries

Entry pages had title, description and canonical, and nothing else. No `openGraph`, so a shared release link carried no date and no article type. No JSON-LD, on a site that emits it for the organization, the docs and every FAQ.

Adds both. The release node states only version facts (`softwareVersion`, `datePublished`, `releaseNotes`) and carries its own `@id` — the root layout already publishes the canonical BitRouter `SoftwareApplication`, and without a distinct id the two merge into one node with contradictory app-level properties. "Which version added X" is a question structured data answers deterministically and prose does not.

## 4. Teach the sync the folded release format — the time-sensitive one

From v1.0.0-alpha.28 the source repo folds per-PR change files into the release body ([bitrouter/bitrouter#820](https://github.com/bitrouter/bitrouter/pull/820)): it leads with `### Breaking changes` / `### Added` sections holding `#### <title>` and prose, and the generated bullets move into a collapsed **All commits** block.

Left alone, the old parser would have **regressed on the better input**:

- `firstFeatureLine` took the first `- ` bullet, which now lives inside the collapsed block — so `description` (the index headline, the `<meta>` description, and the RSS summary) would have become a random commit subject while the curated title was ignored.
- `deriveTags` matched `Fixes`, which does not match `Fixed`. Tags would have gone empty.

Parsing moves to `lib/release-notes.mjs`, tested against both shapes. Releases whose PRs were all labelled `no-changelog` still arrive bullets-only and still work. Tags and the breaking flag now read the *raw* body, so a curated entry is still tagged from the commit groups in its collapsed list and git-cliff's inline `[**breaking**]` marker isn't lost with them.

Verified against the exact body #820 will publish:

```
description : "Active policy_table routing only accepts key_strategy: agent_trace."
tags        : ["features","fixes"]
breaking    : true
body        : curated prose only, no commit list
```

## Verification

`pnpm build` passes (`/changelog.md` prerenders static, 25 releases, ~22KB), 148 tests pass (21 new), `lint:docs` and `lint:changelog` clean. Built HTML confirmed to carry `og:type=article`, `article:published_time`, and the release JSON-LD. Pre-existing `tsc` errors in `components/ai/search.tsx` and `components/markdown.tsx` are untouched by this branch.

## Not done

- Per-entry OG images — every changelog link still shares the root social card.
- The `[#anchor]` suffixes fumadocs appends to headings in processed Markdown show up in `/changelog.md`, exactly as they already do throughout `llms-full.txt`. Fixing that would change the docs bundle too, so it's left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)