### PR TITLE
docs: hide Guardrails & Tool Calling, reorder Usage, add the Agent page

### DIFF
--- a/content/docs/(guide)/meta.json
+++ b/content/docs/(guide)/meta.json
@@ -6,8 +6,8 @@
   "pages": [
     "overview",
     "usage",
-    "integrations",
     "models-and-routing",
-    "evals-and-observability"
+    "evals-and-observability",
+    "integrations"
   ]
 }

--- a/content/docs/(guide)/models-and-routing/meta.json
+++ b/content/docs/(guide)/models-and-routing/meta.json
@@ -9,8 +9,6 @@
     "model-variants",
     "bring-your-own-model",
     "bring-your-own-provider",
-    "structured-outputs",
-    "guardrails",
-    "tool-calling"
+    "structured-outputs"
   ]
 }

--- a/content/docs/(guide)/usage/agent.mdx
+++ b/content/docs/(guide)/usage/agent.mdx
@@ -1,0 +1,100 @@
+---
+title: Agent
+description: bitrouter-agent — a CLI wizard that reads your agentic codebase and writes an MVP bitrouter.yaml, a cost audit, and a machine-readable analysis, then upgrades the estimate to observed spend once the router has metered real traffic.
+---
+
+**[bitrouter-agent](https://github.com/bitrouter/bitrouter-agent)** is a CLI wizard that answers the question you have *before* you adopt BitRouter: what is this codebase actually spending on LLM calls, and what would a routing policy save? It reads your code **read-only** and writes three artifacts:
+
+| Artifact | What it is |
+|----------|------------|
+| `bitrouter.yaml` | An MVP routing policy to try — see [Config (YAML)](/docs/usage/configuration) |
+| `bitrouter-audit.md` | An audit of your LLM usage, with a savings estimate |
+| `.bitrouter/analysis.json` | The same analysis, machine-readable |
+
+It never modifies your source. The only files it creates are the ones above.
+
+<Callout type="warn">
+  bitrouter-agent is **in development**. Commands and artifact shapes can still change between releases.
+</Callout>
+
+## Run it
+
+```bash
+npx @bitrouter/agent            # analyze + generate all three artifacts
+npx @bitrouter/agent audit      # audit + estimate only (no policy file)
+npx @bitrouter/agent estimate   # estimate only (.bitrouter/analysis.json)
+npx @bitrouter/agent optimize   # tighten the policy from real metered traffic
+```
+
+Flags: `--out-dir <dir>`, `--model <id>`, `--target <local|cloud>`, `--offline`, `--yes`, `--debug`, plus the observed-mode flags `--db <path|url>`, `--since <days>`, and `--min-requests <n>`.
+
+### Targets
+
+The agent routes its own LLM calls through BitRouter, so it needs a router to talk to:
+
+- **`local`** *(default)* — a BitRouter daemon at `http://127.0.0.1:4356`. Run [`bitrouter start`](/docs/usage/cli) first.
+- **`cloud`** — BitRouter Cloud. Run `bitrouter auth login` first.
+
+### Offline analysis
+
+By default the analysis is done by a [pi](https://pi.dev) agent routed through BitRouter, with a **consent prompt before any code is sent**. Pass `--offline` to run a fully local static analysis instead — nothing leaves your machine, and no LLM is required. If the router is unreachable, the tool falls back to that path on its own.
+
+## Cold start vs. observed
+
+A first run has no traffic to look at, so its numbers are a **rate-card scenario, not a bill**. Once BitRouter is your gateway it meters every request into a local `bitrouter.db`, and `optimize` reads that database (read-only) to replace the estimate with **observed spend**:
+
+```bash
+npx @bitrouter/agent optimize            # read bitrouter.db, propose a tighter policy
+npx @bitrouter/agent optimize --since 7  # use only the last 7 days of traffic
+```
+
+That run adds:
+
+- **`bitrouter-optimizer.md`** — real dollars spent per model and provider, the rate you actually paid ($/Mtok), error rates, and a projected monthly saving.
+- **`bitrouter.optimized.yaml`** — a **proposed** tightened policy, written to a *new* file. Your own `bitrouter.yaml` is never touched.
+- an `observed` block merged into `.bitrouter/analysis.json`.
+
+The model drafts the policy diff (through BitRouter, with a deterministic offline fallback), but the numbers are always computed locally. The first command also performs this upgrade silently when it finds a populated `bitrouter.db` — when there isn't enough traffic yet, both degrade to the cold-start rate card and tell you why.
+
+<Callout type="info">
+  Reading the metering database uses Node's built-in `node:sqlite`. It works out of the box on **Node ≥ 24**; on Node 22–23 run with `--experimental-sqlite`, or the optimizer cleanly falls back to the cold-start rate card.
+</Callout>
+
+## Interactive session
+
+The package also ships a **read-only chat session**, launched as `bitrouter` from the agent package rather than `pi`. It can inspect your codebase and run the `estimate` / `audit` / `optimize` tools and the `/bitrouter` command, but it **cannot edit files or run shell commands**. Its identity, tool set, and skills are locked to BitRouter, and its config lives under `~/.bitrouter/agent` rather than pi's `~/.pi`.
+
+<Callout type="warn">
+  This session shares its name with the router binary documented in [CLI](/docs/usage/cli). They are different programs from different packages — `@bitrouter/agent` is the npm wizard, and the router is the Rust binary. Check which one is first on your `PATH` before assuming which you launched.
+</Callout>
+
+### Which skills load
+
+By default the session loads **only BitRouter-family skills** — every skill whose front-matter `name` is `bitrouter` or `bitrouter-<thing>`, such as the bundled `bitrouter` analysis skill and the provider's `bitrouter-pi` setup skill. pi's usual skill auto-discovery (`~/.agents/skills`, ancestor `.agents/skills`, and so on) is otherwise disabled, so unrelated skills don't leak into the appliance. See [Skills](/docs/usage/skills) for the skills BitRouter itself publishes.
+
+Discovery is **by declared name, not directory name**, and de-duplicates by name — the bundled copy wins over a stray `~/.agents/skills` copy. Naming a skill `bitrouter-<thing>` is all it takes to have it auto-load.
+
+Skills outside the family can be opted in, per invocation:
+
+```bash
+bitrouter --skill ~/.agents/skills/paseo   # by path
+bitrouter --skill paseo                    # by name, searched in the skill roots
+```
+
+Or persistently, via a `skills` array under the `bitrouter` key in `~/.bitrouter/agent/settings.json` — each entry a name or a path:
+
+```json
+{ "bitrouter": { "skills": ["paseo", "/abs/path/to/team-skill"] } }
+```
+
+The list is namespaced under `bitrouter` on purpose: pi reads the top-level `skills` key as auto-discovery *patterns*, so the opt-in list needs its own home.
+
+## Where it fits
+
+bitrouter-agent is an **adoption and tuning** tool, not a runtime surface — it writes policy, it doesn't serve traffic. Once the generated `bitrouter.yaml` is in place, the router runs it like any other config:
+
+<Cards>
+  <Card title="Config (YAML)" href="/docs/usage/configuration" description="The bitrouter.yaml reference — every block the generated policy can contain." />
+  <Card title="CLI" href="/docs/usage/cli" description="Start the daemon the agent routes through, and validate the policy it wrote." />
+  <Card title="TUI" href="/docs/usage/tui" description="Watch the metered traffic that optimize later reads back." />
+</Cards>

--- a/content/docs/(guide)/usage/configuration.mdx
+++ b/content/docs/(guide)/usage/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configuration
+title: Config (YAML)
 description: bitrouter.yaml — the single file that holds your routing policy, providers, and gateways, with a JSON Schema for your editor and a validate command for CI.
 ---
 

--- a/content/docs/(guide)/usage/meta.json
+++ b/content/docs/(guide)/usage/meta.json
@@ -2,5 +2,5 @@
   "title": "Usage",
   "icon": "Terminal",
   "collapsible": false,
-  "pages": ["cli", "tui", "configuration", "mcp", "skills"]
+  "pages": ["configuration", "cli", "tui", "agent", "mcp", "skills"]
 }

--- a/content/docs/(guide)/usage/skills.mdx
+++ b/content/docs/(guide)/usage/skills.mdx
@@ -1,5 +1,5 @@
 ---
-title: Agent Skills
+title: Skills
 description: Drop-in Agent Skills that teach an AI agent to install, configure, and use BitRouter.
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,9 +66,21 @@ tab. Page order within a section is the `pages` list in that section's
 `meta.json`; the section order is the `pages` list in
 `content/docs/(guide)/meta.json`.
 
-`usage/` is how you drive BitRouter: `cli.mdx` (generated — don't hand-author
-it), `tui.mdx`, `configuration.mdx` (the `bitrouter.yaml` reference),
-`mcp.mdx`, and `skills.mdx`.
+`usage/` is how you drive BitRouter, in nav order: `configuration.mdx` (the
+`bitrouter.yaml` reference, titled "Config (YAML)"), `cli.mdx` (generated —
+don't hand-author it), `tui.mdx`, `agent.mdx` (the `@bitrouter/agent` adoption
+wizard), `mcp.mdx`, and `skills.mdx` (titled "Skills"; the page is still about
+the Agent Skills product, so body copy keeps that name).
+
+### Unlisted pages are hidden, not retired
+
+A page left out of its section's `pages` list still builds and still answers at
+its URL — it just doesn't appear in the sidebar. Three pages are hidden this
+way on purpose: `models-and-routing/acp-gateway.mdx`, `guardrails.mdx`, and the
+whole `tool-calling/` subfolder. They stay linked from feature pages, the
+migration guides, and `lib/llms-txt.ts`, so **don't delete them and don't add
+301s** — hiding a page changes the nav, not the URL history. Deleting one is a
+separate decision that does need a redirect.
 
 ## Authoring contract (import-free MDX)
 

--- a/lib/llms-txt.ts
+++ b/lib/llms-txt.ts
@@ -54,11 +54,12 @@ References:
 
 ## Usage
 
+- [Config (YAML)](${BASE_URL}/docs/usage/configuration): The \`bitrouter.yaml\` reference, including the policy table and the adaptive loop
 - [CLI](${BASE_URL}/docs/usage/cli): Every command of the binary — serve, route, models, policy, optimize, providers
 - [TUI](${BASE_URL}/docs/usage/tui): The terminal dashboard for live routing, spend, and traces
-- [Configuration](${BASE_URL}/docs/usage/configuration): The \`bitrouter.yaml\` reference, including the policy table and the adaptive loop
+- [Agent](${BASE_URL}/docs/usage/agent): \`npx @bitrouter/agent\` — reads an agentic codebase and writes an MVP policy, a cost audit, and an observed-spend optimization
 - [MCP](${BASE_URL}/docs/usage/mcp): Drive BitRouter itself as an MCP tool from inside an agent
-- [Agent Skills](${BASE_URL}/docs/usage/skills): Skills as governed, routable resources an agent loads on demand
+- [Skills](${BASE_URL}/docs/usage/skills): Skills as governed, routable resources an agent loads on demand
 
 ## Self-hosting
 


### PR DESCRIPTION
Four nav revisions to the Documentation tab, plus one new page.

## Models & Routing hides Guardrails and Tool Calling

Both come out of the section's `pages` list. **The files stay.** All seven URLs still resolve (verified 200 locally) and are linked from `usage/configuration.mdx`, `self-hosting/hardening`, the three migration guides, and `lib/llms-txt.ts` — so this is a nav change, not a retirement. No 301s are needed and nothing is deleted. `acp-gateway.mdx` has been hidden exactly this way since the Tool Calling subfolder was created, so the pattern is not new.

## Integrations moves below Evals & Observability

The tab now runs overview → usage → models-and-routing → evals-and-observability → integrations.

## Usage leads with the config reference

New order: **Config (YAML) → CLI → TUI → Agent → MCP → Skills**.

`configuration.mdx` is retitled "Config (YAML)" and `skills.mdx` is retitled "Skills" — frontmatter only, so the URLs are unchanged. `skills.mdx` keeps "Agent Skills" in its body copy: that is the product name at [bitrouter/agent-skills](https://github.com/bitrouter/agent-skills), not the nav label.

Agent is placed after TUI rather than appended last, grouping the three things you *run* ahead of the two agent-facing surfaces.

## New page: Usage → Agent

`content/docs/(guide)/usage/agent.mdx`, written from the [bitrouter-agent](https://github.com/bitrouter/bitrouter-agent) README — the three artifacts, the four commands and their flags, local vs cloud targets, `--offline` static analysis, and the cold-start → observed optimizer including the `node:sqlite` Node-version caveat.

Two things the page states rather than smooths over:

- the repo marks itself **in development**, so a `warn` callout says commands and artifact shapes can change;
- the package's interactive session launches as `bitrouter`, which **collides with the router binary** documented on the CLI page. The page names the collision instead of pretending the two commands are the same program.

The README's Smithers reward-optimizer mode is **left out**: its own linked experiment report records a rejected candidate (3/4 holdout, 27.6% cost-per-success regression) and a contract fix still sitting on a branch. Too unsettled to publish as reference docs — easy to add once it lands.

## Also

- `docs/CONTRIBUTING.md` gains an *"unlisted pages are hidden, not retired"* note, so a later pass doesn't garbage-collect the three hidden entries or add redirects they don't need.
- The Usage list in `lib/llms-txt.ts` is resynced with the new order and titles, and gains the Agent entry.

## Verification

- `pnpm lint:docs` — OK, 43 docs across 6 sections
- `pnpm test` — 126/126
- Sidebar order confirmed in the running dev server; the four hidden/renamed URLs all return 200
- The one console warning on docs pages (duplicate React key in `Sidebar`) reproduces on unmodified `main` — pre-existing, not from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)