### PR TITLE
Rebuild the hero TUI demo as a macOS terminal

### DIFF
--- a/components/landing/zed/data.ts
+++ b/components/landing/zed/data.ts
@@ -33,214 +33,363 @@ export const BYO: ByoGroup[] = [
   },
 ];
 
-// ── TUI demo sessions ───────────────────────────────────────────────────────
-export type TraceKind =
-  | "model" | "tool" | "skill" | "agent" | "cache" | "watch" | "score" | "write";
+// ── Hero TUI demo — five harnesses in one macOS terminal ────────────────────
+/**
+ * One id — `bitrouter/auto` — is configured once per harness. Inside the session
+ * BitRouter moves between five tiers (low → max), which resolve to a different
+ * model and/or reasoning effort. The user presses nothing: every row below is
+ * the harness's own output, and the only non-native chrome in the window is the
+ * BitRouter statusline along the bottom.
+ *
+ * The chrome for claude-code, codex, opencode and pi is transcribed from real
+ * screenshots. deepseek-harness has no screenshot — see the note on that entry.
+ *
+ * Identifiers are checked, not illustrative: model ids come from the registry
+ * snapshot (`.models-snapshot.json`) and the per-harness setup from
+ * `content/docs/(guide)/integrations/*.mdx`.
+ */
 
-export const TRACE_KIND: Record<TraceKind, { tag: string; color: string }> = {
-  model: { tag: "MODEL", color: "var(--z-blue)" },
-  tool: { tag: "TOOL ", color: "var(--z-cost)" },
-  skill: { tag: "SKILL", color: "var(--z-green)" },
-  agent: { tag: "AGENT", color: "var(--z-purple)" },
-  cache: { tag: "CACHE", color: "var(--z-ink-5)" },
-  watch: { tag: "WATCH", color: "var(--z-blue)" },
-  score: { tag: "SCORE", color: "var(--z-cost)" },
-  write: { tag: "WRITE", color: "var(--z-green)" },
+/** Terminal palette — real terminal colours, deliberately not the `--z-*` set. */
+export const TERM = {
+  bright: "#e6e6e6",
+  body: "#c9c9c9",
+  dim: "#8f8f8f",
+  faint: "#6e6e6e",
+  ghost: "#4a4a4a",
+  claude: "#c9764f",
+  cyan: "#56b6c2",
+  amber: "#d19a3f",
+  blue: "#5aa9f8",
+  ok: "#8bbf78",
+  white: "#ffffff",
+} as const;
+
+export type Tier = "low" | "medium" | "high" | "extra" | "max";
+export const TIERS: Tier[] = ["low", "medium", "high", "extra", "max"];
+export const TIER_COLOR: Record<Tier, string> = {
+  low: "var(--z-green)",
+  medium: "var(--z-blue)",
+  high: "var(--z-cost)",
+  extra: "var(--z-amber)",
+  max: "var(--z-purple)",
 };
 
-export type TraceRow = { kind: TraceKind; action: string; target: string; meta: string; esc?: boolean };
-export type Ledger = { label: string; value: string };
-export type Session = {
-  name: string;
-  sub: string;
-  dot: string;
-  cost: string;
-  costColor: string;
-  objTag: string;
-  calls: string;
-  goal: string;
-  trace: TraceRow[];
-  result: string;
-  ledger: Ledger[];
-  policyVer: string;
-  policy: string[];
-  summary: string;
-  beforeLabel: string;
-  beforeW: string;
-  afterLabel: string;
-  afterW: string;
+/** A run of styled text inside one terminal line. */
+export type Seg = { t: string; c: string; b?: boolean; i?: boolean };
+
+/** One line of harness output. `tier`/`model`/`effort` drive the statusline. */
+export type Row = {
+  bullet: string;
+  label?: string;
+  text: string;
+  meta?: string;
+  sub?: string;
+  /** The user's own turn — starts hard left, no label column. */
+  user?: boolean;
+  /** A reasoning line — italic, amber bullet. */
+  think?: boolean;
+  ok?: boolean;
+  tier: Tier;
+  model: string;
+  effort: string;
 };
 
-export const SESSIONS: Session[] = [
-  {
-    name: "bitrouter",
-    sub: "pi-agent · acp",
-    dot: "var(--z-blue)",
-    cost: "live",
-    costColor: "var(--z-blue)",
-    objTag: "optimize · self-tune",
-    calls: "3 sessions",
-    goal: "watch traces across every session → rewrite the shared policy",
-    trace: [
-      { kind: "watch", action: "ingest traces", target: "3 sessions", meta: "2,480 calls" },
-      { kind: "score", action: "complexity + quality", target: "per call", meta: "floor 0.92" },
-      { kind: "model", action: "demote routine", target: "open pool", meta: "2,200 calls" },
-      { kind: "tool", action: "prune", target: "semantic-search", meta: "used 0/5" },
-      { kind: "agent", action: "bias harness", target: "opencode", meta: "+12%" },
-      { kind: "write", action: "commit policy", target: "policy.yaml", meta: "→ v0.7" },
-    ],
-    result: "✓ policy v0.7 · −78% cost avg · quality held 0.96",
-    ledger: [
-      { label: "MODELS", value: "12 registered · 3 in rotation" },
-      { label: "MCP", value: "6 servers · 1 pruned this lap" },
-      { label: "SKILLS", value: "9 registered · 5 active" },
-      { label: "HARNESS", value: "opencode · hermes-agent · openclaw · acp" },
-    ],
-    policyVer: "v0.7",
-    policy: [
-      "policy:",
-      "  scope: global",
-      "  objective: per_session",
-      "tune:",
-      "  every: run   # closed loop",
-      "  fold_traces: true",
-      "  prune_unused_tools: true",
-      "──────────────────────",
-      "controls 3 sessions · 2,480 calls",
-    ],
-    summary: "−78% cost avg · quality held 0.96",
-    beforeLabel: "all-frontier · $3.60 avg",
-    beforeW: "100%",
-    afterLabel: "BitRouter · $0.79 avg",
-    afterW: "22%",
-  },
-  {
-    name: "coding-agent",
-    sub: "opencode · acp",
-    dot: "var(--z-green)",
-    cost: "$0.43",
-    costColor: "var(--z-cost)",
-    objTag: "optimize · cost",
-    calls: "2,400 calls",
-    goal: "200-file refactor — route routine edits to open models",
-    trace: [
-      { kind: "model", action: "fix auth.py test", target: "qwen/qwen-3.7", meta: "$0.002 · 82ms" },
-      { kind: "tool", action: "grep repo", target: "github-mcp", meta: "$0.000 · 14ms" },
-      { kind: "skill", action: "apply-diff", target: "invoked", meta: "8ms" },
-      { kind: "model", action: "design migration", target: "claude-opus-4.8", meta: "$0.021 · 140ms", esc: true },
-      { kind: "agent", action: "refactor task", target: "opencode", meta: "ok · 2 hops" },
-      { kind: "model", action: "format edits", target: "minimax/m3", meta: "$0.001 · 61ms" },
-    ],
-    result: "✓ $0.43/run · −80% vs all-frontier · tests green",
-    ledger: [
-      { label: "MODELS", value: "qwen-3.7 78% · minimax 15% · opus 7%↑" },
-      { label: "MCP", value: "github 412 · filesystem 1.2k" },
-      { label: "SKILLS", value: "apply-diff · run-tests" },
-      { label: "HARNESS", value: "opencode · acp" },
-    ],
-    policyVer: "v0.7",
-    policy: [
-      "route:",
-      "  optimize: cost   # objective",
-      "  quality_floor: 0.92",
-      "open_pool:",
-      "  - qwen/qwen-3.7",
-      "  - minimax/m3",
-      "escalate_when: cx > 0.55",
-      "──────────────────────",
-      "$0.43/run · p50 88ms · q 0.96",
-    ],
-    summary: "$0.43/run · p50 88ms · quality 0.96",
-    beforeLabel: "all-frontier · $2.10",
-    beforeW: "100%",
-    afterLabel: "BitRouter · $0.43",
-    afterW: "20%",
-  },
-  {
-    name: "research-agent",
-    sub: "hermes-agent · acp",
-    dot: "var(--z-blue)",
-    cost: "$0.18",
-    costColor: "var(--z-cost)",
-    objTag: "optimize · quality",
-    calls: "320 calls",
-    goal: "read 40 filings → reason → answer, hold the 0.92 floor",
-    trace: [
-      { kind: "tool", action: "fetch 10-K", target: "postgres-mcp", meta: "$0.000 · 22ms" },
-      { kind: "skill", action: "pdf-extract", target: "invoked", meta: "210ms" },
-      { kind: "model", action: "extract tables", target: "qwen/qwen-3.7", meta: "$0.003 · 96ms" },
-      { kind: "model", action: "reason: guidance", target: "claude-opus-4.8", meta: "$0.024 · 180ms", esc: true },
-      { kind: "skill", action: "cite-check", target: "invoked", meta: "12ms" },
-      { kind: "model", action: "verify answer", target: "deepseek-v4", meta: "$0.002 · 88ms" },
-    ],
-    result: "✓ 99% correct · +11 pts vs all-open · floor held",
-    ledger: [
-      { label: "MODELS", value: "qwen-3.7 68% · opus 24%↑ · deepseek 8%" },
-      { label: "MCP", value: "postgres 88 · fetch 40" },
-      { label: "SKILLS", value: "pdf-extract · cite-check" },
-      { label: "HARNESS", value: "hermes-agent · acp" },
-    ],
-    policyVer: "v0.4",
-    policy: [
-      "route:",
-      "  optimize: quality  # objective",
-      "  quality_floor: 0.92",
-      "verify: true",
-      "escalate_when: judgment",
-      "keep_open: read · extract",
-      "──────────────────────",
-      "99% correct · p50 120ms · q 0.94",
-    ],
-    summary: "99% correct · +11 pts vs all-open",
-    beforeLabel: "all-open · 88% correct",
-    beforeW: "89%",
-    afterLabel: "BitRouter · 99% correct",
-    afterW: "100%",
-  },
-  {
-    name: "support-bot",
-    sub: "openclaw · acp",
-    dot: "var(--z-amber)",
-    cost: "$0.04",
-    costColor: "var(--z-cost)",
-    objTag: "optimize · latency",
-    calls: "40 calls/session",
-    goal: "live chat + tools — fastest model that still clears the bar",
-    trace: [
-      { kind: "cache", action: "hot-path hit", target: "cache", meta: "3ms" },
-      { kind: "model", action: "reply", target: "gemini-3.5-flash", meta: "$0.001 · 48ms" },
-      { kind: "tool", action: "lookup order", target: "postgres-mcp", meta: "$0.000 · 19ms" },
-      { kind: "skill", action: "refund-policy", target: "invoked", meta: "9ms" },
-      { kind: "model", action: "tricky refund", target: "claude-opus-4.8", meta: "$0.018 · 160ms", esc: true },
-      { kind: "model", action: "reply", target: "qwen-3.7-turbo", meta: "$0.001 · 44ms" },
-    ],
-    result: "✓ p50 61ms · −92% vs all-frontier · floor held",
-    ledger: [
-      { label: "MODELS", value: "gemini-flash 65% · qwen-turbo 28% · opus 7%↑" },
-      { label: "MCP", value: "postgres 30 · stripe 6" },
-      { label: "SKILLS", value: "refund-policy · order-lookup" },
-      { label: "HARNESS", value: "openclaw · acp" },
-    ],
-    policyVer: "v0.9",
-    policy: [
-      "route:",
-      "  optimize: latency  # objective",
-      "  max_latency_p95: 200ms",
-      "  quality_floor: 0.92",
-      "cache: hot_path",
-      "fallback: qwen-3.7-turbo",
-      "──────────────────────",
-      "p50 61ms · −92% · q 0.94",
-    ],
-    summary: "p50 61ms · −92% latency · quality 0.94",
-    beforeLabel: "all-frontier · 720ms",
-    beforeW: "100%",
-    afterLabel: "BitRouter · 61ms",
-    afterW: "9%",
-  },
+export type InputWidget = {
+  /** A hairline rule above the input (claude, pi, dsh). */
+  rule?: boolean;
+  ruleBelow?: boolean;
+  /** A filled input row (codex, opencode) rather than a bare prompt line. */
+  boxed?: boolean;
+  boxBg?: string;
+  /** opencode's blue left bar. */
+  bar?: string;
+  glyph: string;
+  hint: string;
+};
+
+export type Harness = {
+  id: string;
+  /** Binary name, shown in the tab. */
+  tab: string;
+  cwd: string;
+  /** macOS Terminal window title. */
+  title: string;
+  bg: string;
+  accent: string;
+  mascot?: boolean;
+  boxedHeader?: boolean;
+  /** Shell lines typed before the harness starts. */
+  boot: string[];
+  header: Seg[][];
+  notes: Seg[][];
+  /** Width of the label column, 0 for harnesses that don't have one. */
+  labelW: number;
+  working: string;
+  rows: Row[];
+  input: InputWidget;
+  after: Seg[][];
+  afterRight?: Seg[][];
+  /** codex prints the serving model under its input… */
+  afterLive?: boolean;
+  /** …pi prints it bottom-right, where it normally prints `unknown`. */
+  afterLiveRight?: boolean;
+  ladder: { name: Tier; value: string }[];
+  workflow: string;
+  tierShape: string;
+};
+
+/** Claude Code's pixel mascot: 7×7, salmon face, two eyes, three feet. */
+export const MASCOT = [
+  "0111110",
+  "1111111",
+  "1011101",
+  "1111111",
+  "1111111",
+  "0000000",
+  "1010100",
 ];
 
-export const FOOTER_STAT = "4 sessions · −78% cost avg · q 0.96";
+export const SHELL_PROMPT = "[dev@mbp ~ %";
+
+export const HARNESSES: Harness[] = [
+  {
+    id: "claude-code",
+    tab: "claude",
+    cwd: "~/work/api",
+    title: "dev — api — node ~/.local/bin/claude — 100×31",
+    bg: "#1c1c1c",
+    accent: TERM.claude,
+    mascot: true,
+    boot: ["export ANTHROPIC_MODEL=bitrouter/auto", "claude"],
+    header: [
+      [{ t: "Claude Code ", c: TERM.white, b: true }, { t: "v2.1.175", c: TERM.dim }],
+      [
+        { t: "bitrouter/auto ", c: TERM.body },
+        { t: "(5 tiers)", c: TERM.dim },
+        { t: " · ~/work/api", c: TERM.body },
+      ],
+      [{ t: "1 working · 0 awaiting input · 0 completed", c: TERM.dim }],
+    ],
+    notes: [],
+    labelW: 62,
+    working: "Investigating…",
+    rows: [
+      { bullet: "❯", text: "the auth test is flaky — find out why", user: true, tier: "low", model: "claude-opus-4.8", effort: "think off" },
+      { bullet: "·", label: "read", text: "tests/test_auth.py", meta: "84 lines", tier: "low", model: "claude-opus-4.8", effort: "think off" },
+      { bullet: "·", label: "search", text: "verify_jwt", meta: "12 files", tier: "low", model: "claude-opus-4.8", effort: "think off" },
+      { bullet: "·", label: "read", text: "auth/jwt.py", meta: "210 lines", tier: "medium", model: "claude-opus-4.8", effort: "think 4k" },
+      { bullet: "✳", label: "reason", text: "clock skew on token refresh", think: true, tier: "high", model: "claude-opus-4.8", effort: "think 12k" },
+      { bullet: "✳", label: "reason", text: "tracing the async refresh path", think: true, tier: "max", model: "claude-opus-4.8", effort: "think 64k" },
+      { bullet: "·", label: "edit", text: "auth/jwt.py", meta: "+1 −1", tier: "medium", model: "claude-opus-4.8", effort: "think 4k" },
+      { bullet: "·", label: "bash", text: "pytest tests/test_auth.py -q", meta: "14 passed", ok: true, tier: "low", model: "claude-opus-4.8", effort: "think off" },
+    ],
+    input: { rule: true, glyph: "❯", hint: "describe a task for a new session" },
+    after: [[{ t: "? for shortcuts", c: TERM.faint }], []],
+    ladder: [
+      { name: "low", value: "claude-opus-4.8 · think off" },
+      { name: "medium", value: "claude-opus-4.8 · think 4k" },
+      { name: "high", value: "claude-opus-4.8 · think 12k" },
+      { name: "extra", value: "claude-opus-4.8 · think 32k" },
+      { name: "max", value: "claude-opus-4.8 · think 64k" },
+    ],
+    workflow: "Debugging",
+    tierShape: "one model, five efforts",
+  },
+  {
+    id: "codex",
+    tab: "codex",
+    cwd: "~/work/payments",
+    title: "dev — payments — node ~/.local/bin/codex — 111×37",
+    bg: "#0d0d0d",
+    accent: TERM.cyan,
+    boxedHeader: true,
+    boot: ["codex"],
+    header: [
+      [
+        { t: ">_ ", c: TERM.dim },
+        { t: "OpenAI Codex ", c: TERM.white, b: true },
+        { t: "(v0.147.0)", c: TERM.dim },
+      ],
+      [],
+      [
+        { t: "model:     ", c: TERM.dim },
+        { t: "bitrouter/auto auto", c: TERM.bright },
+        { t: "     /model", c: TERM.cyan },
+        { t: " to change", c: TERM.dim },
+      ],
+      [{ t: "directory: ", c: TERM.dim }, { t: "~/work/payments", c: TERM.bright }],
+    ],
+    notes: [
+      [
+        { t: "  Tip: ", c: TERM.bright, b: true },
+        { t: "New ", c: TERM.body, i: true },
+        { t: "Use ", c: TERM.body },
+        { t: "/fast", c: TERM.bright, b: true },
+        { t: " to enable our fastest inference with increased plan usage.", c: TERM.body },
+      ],
+    ],
+    labelW: 0,
+    working: "Working…",
+    rows: [
+      { bullet: "›", text: "scaffold the payments module from interfaces.ts", user: true, tier: "low", model: "openai/gpt-5.4", effort: "—" },
+      { bullet: "•", text: "Read interfaces.ts", sub: "  └ 3 exported interfaces", tier: "low", model: "openai/gpt-5.4", effort: "—" },
+      { bullet: "•", text: "Generated types and stubs", tier: "medium", model: "openai/gpt-5.4", effort: "—" },
+      { bullet: "•", text: "Thought about retry semantics", think: true, tier: "high", model: "openai/gpt-5.5", effort: "medium" },
+      { bullet: "•", text: "Reasoned about idempotent refunds", think: true, tier: "max", model: "openai/gpt-5.5", effort: "high" },
+      { bullet: "•", text: "Wrote handlers/ · 6 files", sub: "  └ +412 −0", tier: "medium", model: "openai/gpt-5.4", effort: "—" },
+      { bullet: "•", text: "Ran pnpm lint --fix", sub: "  └ clean", ok: true, tier: "low", model: "openai/gpt-5.4", effort: "—" },
+    ],
+    input: { boxed: true, boxBg: "#2b2b2b", glyph: "›", hint: "find and fix a bug in @filename" },
+    after: [],
+    afterLive: true,
+    ladder: [
+      { name: "low", value: "openai/gpt-5.4" },
+      { name: "medium", value: "openai/gpt-5.4" },
+      { name: "high", value: "openai/gpt-5.5 · medium" },
+      { name: "extra", value: "openai/gpt-5.5 · high" },
+      { name: "max", value: "openai/gpt-5.5 · high" },
+    ],
+    workflow: "Code generation",
+    tierShape: "two models on one ladder",
+  },
+  {
+    id: "opencode",
+    tab: "opencode",
+    cwd: "~/work/monorepo",
+    title: "dev — OpenCode — opencode — 111×37",
+    bg: "#0a0a0a",
+    accent: TERM.blue,
+    boot: ["opencode"],
+    header: [
+      [{ t: "opencode", c: TERM.white, b: true }, { t: "   ~/work/monorepo   ⑂ main", c: TERM.faint }],
+    ],
+    notes: [
+      [
+        { t: "  ● ", c: "#e5a05a" },
+        { t: "Tip ", c: "#e5a05a", b: true },
+        { t: "Press ", c: TERM.body },
+        { t: "ctrl+c", c: TERM.bright, b: true },
+        { t: " when typing to clear the input field", c: TERM.body },
+      ],
+    ],
+    labelW: 0,
+    working: "Scanning…",
+    rows: [
+      { bullet: "▍", text: "find every call site of the legacy client", user: true, tier: "low", model: "qwen/qwen3.6-flash", effort: "—" },
+      { bullet: " ", text: "glob **/*.ts", meta: "1,800 files", tier: "low", model: "qwen/qwen3.6-flash", effort: "—" },
+      { bullet: " ", text: "classify imports", meta: "212 candidates", tier: "low", model: "qwen/qwen3.6-flash", effort: "—" },
+      { bullet: " ", text: "read 40 candidates", tier: "medium", model: "qwen/qwen3.7-plus", effort: "—" },
+      { bullet: " ", text: "rank true call sites", meta: "61 confirmed", tier: "high", model: "minimax/minimax-m3", effort: "—" },
+      { bullet: " ", text: "resolve dynamic dispatch", tier: "extra", model: "deepseek/deepseek-v4-pro", effort: "—" },
+      { bullet: " ", text: "write migration plan", meta: "MIGRATION.md", ok: true, tier: "max", model: "claude-opus-4.8", effort: "—" },
+    ],
+    input: {
+      boxed: true,
+      boxBg: "#1a1a1a",
+      bar: "#3b82f6",
+      glyph: "",
+      hint: 'Ask anything...  "What is the tech stack of this project?"',
+    },
+    after: [
+      [
+        { t: "tab", c: TERM.bright, b: true },
+        { t: " agents   ", c: TERM.faint },
+        { t: "ctrl+p", c: TERM.bright, b: true },
+        { t: " commands", c: TERM.faint },
+      ],
+      [{ t: "~", c: TERM.faint }],
+    ],
+    afterRight: [[], [{ t: "1.18.3", c: TERM.faint }]],
+    ladder: [
+      { name: "low", value: "qwen/qwen3.6-flash" },
+      { name: "medium", value: "qwen/qwen3.7-plus" },
+      { name: "high", value: "minimax/minimax-m3" },
+      { name: "extra", value: "deepseek/deepseek-v4-pro" },
+      { name: "max", value: "anthropic/claude-opus-4.8" },
+    ],
+    workflow: "Repo scanning",
+    tierShape: "a different model per rung",
+  },
+  {
+    id: "pi",
+    tab: "pi",
+    cwd: "~/work/analytics",
+    title: "dev — π - pi — 111×37",
+    bg: "#000000",
+    accent: TERM.cyan,
+    boot: ["pi"],
+    header: [
+      [{ t: "  pi ", c: TERM.cyan, b: true }, { t: "v0.80.10", c: TERM.dim }],
+      [{ t: "  escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more", c: TERM.faint }],
+    ],
+    notes: [
+      [{ t: "  [Skills]", c: TERM.amber }],
+      [{ t: "    bitrouter, find-skills, twitter", c: TERM.dim }],
+    ],
+    labelW: 0,
+    working: "thinking",
+    rows: [
+      { bullet: "❯", text: "this report query takes 40s — fix it", user: true, tier: "low", model: "kimi-k2.7-code", effort: "—" },
+      { bullet: "·", text: "describe schema", meta: "11 tables", tier: "low", model: "kimi-k2.7-code", effort: "—" },
+      { bullet: "·", text: "read EXPLAIN output", tier: "medium", model: "kimi-k2.7-code", effort: "—" },
+      { bullet: "·", text: "rewrite the join", tier: "high", model: "openai/gpt-5.5", effort: "medium" },
+      { bullet: "·", text: "cost the index tradeoff", tier: "extra", model: "openai/gpt-5.5", effort: "high" },
+      { bullet: "·", text: "write the migration", meta: "0004_report_idx.sql", tier: "max", model: "claude-opus-4.8", effort: "—" },
+      { bullet: "·", text: "generate rollback", meta: "40s → 1.1s", ok: true, tier: "low", model: "kimi-k2.7-code", effort: "—" },
+    ],
+    input: { rule: true, ruleBelow: true, glyph: "", hint: "" },
+    after: [[{ t: "~", c: TERM.faint }], [{ t: "0.0%/0 (auto)", c: TERM.dim }]],
+    afterLiveRight: true,
+    ladder: [
+      { name: "low", value: "moonshotai/kimi-k2.7-code" },
+      { name: "medium", value: "moonshotai/kimi-k2.7-code" },
+      { name: "high", value: "openai/gpt-5.5 · medium" },
+      { name: "extra", value: "openai/gpt-5.5 · high" },
+      { name: "max", value: "anthropic/claude-opus-4.8" },
+    ],
+    workflow: "SQL & database",
+    tierShape: "three models, five rungs",
+  },
+  {
+    // UNVERIFIED CHROME. No screenshot of dsh exists, unlike the four above, so
+    // the header, prefixes and input widget here are a plain best guess rather
+    // than a transcription. Replace once someone has run it.
+    id: "deepseek-harness",
+    tab: "dsh",
+    cwd: "~/work/console",
+    title: "dev — console — dsh — 111×37",
+    bg: "#0d0d0d",
+    accent: TERM.blue,
+    boot: ["dsh"],
+    header: [
+      [{ t: "[dsh] ", c: TERM.blue, b: true }, { t: "deepseek-harness · developer preview", c: TERM.body }],
+      [{ t: "  plugins: llm · tools · log     provider: bitrouter", c: TERM.faint }],
+    ],
+    notes: [],
+    labelW: 0,
+    working: "running",
+    rows: [
+      { bullet: "›", text: "rebuild the settings panel", user: true, tier: "low", model: "deepseek-v4-pro", effort: "off" },
+      { bullet: "·", text: "[llm] read design tokens", tier: "low", model: "deepseek-v4-pro", effort: "off" },
+      { bullet: "·", text: "[llm] lay out the form grid", tier: "low", model: "deepseek-v4-pro", effort: "off" },
+      { bullet: "·", text: "[tools] write SettingsPanel.tsx", meta: "+186 −40", tier: "medium", model: "deepseek-v4-pro", effort: "low" },
+      { bullet: "·", text: "[llm] validation state machine", think: true, tier: "high", model: "deepseek-v4-pro", effort: "medium" },
+      { bullet: "·", text: "[llm] optimistic save and revert", think: true, tier: "extra", model: "deepseek-v4-pro", effort: "high" },
+      { bullet: "·", text: "[log] done · 4 files changed", ok: true, tier: "low", model: "deepseek-v4-pro", effort: "off" },
+    ],
+    input: { rule: true, glyph: "›", hint: "message" },
+    after: [[{ t: "⌃D exit", c: TERM.faint }], []],
+    ladder: [
+      { name: "low", value: "deepseek-v4-pro · off" },
+      { name: "medium", value: "deepseek-v4-pro · low" },
+      { name: "high", value: "deepseek-v4-pro · medium" },
+      { name: "extra", value: "deepseek-v4-pro · high" },
+      { name: "max", value: "deepseek-v4-pro · high" },
+    ],
+    workflow: "Frontend & UI",
+    tierShape: "declared efforts, routed per step",
+  },
+];
 
 // ── Trusted / metrics ───────────────────────────────────────────────────────
 export const TRUSTED = ["Anthropic", "Vercel", "Ramp", "Linear", "Sourcegraph", "Retool"];

--- a/components/landing/zed/tui-demo.tsx
+++ b/components/landing/zed/tui-demo.tsx
@@ -1,257 +1,675 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { SESSIONS, TRACE_KIND, FOOTER_STAT } from "./data";
-import { Cursor, highlightYamlLine } from "./primitives";
+import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from "react";
+import {
+  HARNESSES,
+  MASCOT,
+  SHELL_PROMPT,
+  TERM,
+  TIER_COLOR,
+  type Harness,
+  type Seg,
+  type Tier,
+} from "./data";
 
-const REVEAL_MS = 360;
+/* ============================================================================
+ * Hero TUI demo — one macOS terminal, five native harnesses.
+ *
+ * The section makes a single claim: `bitrouter/auto` is configured once, and
+ * inside the session BitRouter moves between five tiers that resolve to a
+ * different model and/or reasoning effort. Nothing in a transcript is a user
+ * action, and no transcript carries a tier badge — the BitRouter statusline
+ * along the bottom is the only non-native element in the window.
+ *
+ * Everything inside the window uses real terminal colours (`TERM` in data.ts);
+ * everything outside it stays on the `--z-*` tokens.
+ * ========================================================================== */
 
-export function TuiDemo() {
-  const [sel, setSel] = useState(0);
-  const [reveal, setReveal] = useState(0);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-  const cur = SESSIONS[sel];
-  const traceLen = cur.trace.length;
+/** Poll rate. Position comes from elapsed `Date.now()` deltas, never from tick
+ *  count, so a throttled background tab doesn't stretch the prologue. */
+const TICK_MS = 34;
+/** Shell prologue, typed a character at a time. */
+const CHAR_MS = 34;
+/** Between the two shell lines, and before the harness's TUI appears. */
+const LINE_HOLD_MS = 320;
+const BOOT_HOLD_MS = 460;
+/** One transcript row. */
+const REVEAL_MS = 620;
+/** Hold on the finished session before advancing. */
+const DWELL_MS = 2600;
+
+const SPIN = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const SPIN_MS = 90;
+
+/**
+ * Below this the interior reflows to a phone-width layout — see `.zed-tui-*` in
+ * zed.css, which owns every size that changes. Kept in sync with the media query
+ * there; this copy exists because autoplay is a behaviour, not a style.
+ */
+const NARROW_MAX = 699;
+
+/** `useLayoutEffect` has no server counterpart and warns if called during SSR. */
+const useIsoLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+function useMediaQuery(query: string): boolean {
+  const [match, setMatch] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia(query);
+    const apply = () => setMatch(mq.matches);
+    apply();
+    mq.addEventListener("change", apply);
+    // `change` is the right event, but it is not always delivered when the
+    // viewport is driven programmatically rather than by the user. Re-reading
+    // on resize costs nothing and keeps JS in step with the CSS breakpoint —
+    // without it the two disagree and the layout is sized for the wrong one.
+    window.addEventListener("resize", apply);
+    return () => {
+      mq.removeEventListener("change", apply);
+      window.removeEventListener("resize", apply);
+    };
+  }, [query]);
+  return match;
+}
+
+/**
+ * Shrink the window to whatever width it actually has. The layout box keeps its
+ * natural size under a transform, so the wrapper is given the scaled box to
+ * occupy — otherwise it would reserve full-size space and leave a gap.
+ */
+function useFitToWidth(deps: unknown[]) {
+  const outer = useRef<HTMLDivElement>(null);
+  const inner = useRef<HTMLDivElement>(null);
+  const [fit, setFit] = useState<{ s: number; w: number; h: number } | null>(null);
+
+  useIsoLayoutEffect(() => {
+    const o = outer.current;
+    const el = inner.current;
+    if (!o || !el) return;
+    const measure = () => {
+      // offsetWidth/Height are the untransformed layout size.
+      const natW = el.offsetWidth;
+      const natH = el.offsetHeight;
+      if (!natW) return;
+      const s = Math.min(1, o.clientWidth / natW);
+      setFit(s < 1 ? { s, w: natW * s, h: natH * s } : null);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(o);
+    ro.observe(el);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return { outer, inner, fit };
+}
+
+function segStyle(s: Seg): React.CSSProperties {
+  return { color: s.c, fontWeight: s.b ? 600 : 400, fontStyle: s.i ? "italic" : "normal" };
+}
+
+function Line({ segs }: { segs: Seg[] }) {
+  return (
+    <div className="zed-tui-line" style={{ whiteSpace: "pre" }}>
+      {segs.length === 0 ? (
+        " "
+      ) : (
+        segs.map((s, i) => (
+          <span key={i} style={segStyle(s)}>
+            {s.t}
+          </span>
+        ))
+      )}
+    </div>
+  );
+}
+
+/* ── the clock ───────────────────────────────────────────────────────────── */
+
+type Phase = "boot" | "tui";
+type Frame = {
+  /** Shell lines already committed, plus how much of the current one is typed. */
+  bootIdx: number;
+  typedLen: number;
+  committed: number;
+  phase: Phase;
+  reveal: number;
+};
+
+const START: Frame = { bootIdx: 0, typedLen: 0, committed: 0, phase: "boot", reveal: 0 };
+
+/**
+ * Resolve the frame for a harness purely from elapsed milliseconds. Keeping this
+ * a pure function of time (rather than accumulating per tick) is what makes a
+ * backgrounded tab resume in the right place instead of replaying the prologue.
+ */
+function frameAt(h: Harness, elapsed: number): Frame & { done: boolean } {
+  let t = elapsed;
+  for (let i = 0; i < h.boot.length; i++) {
+    const typing = h.boot[i].length * CHAR_MS;
+    const hold = i + 1 < h.boot.length ? LINE_HOLD_MS : BOOT_HOLD_MS;
+    if (t < typing) {
+      return { ...START, bootIdx: i, committed: i, typedLen: Math.floor(t / CHAR_MS), done: false };
+    }
+    if (t < typing + hold) {
+      // Line fully typed, still sitting at the prompt.
+      return { ...START, bootIdx: i, committed: i, typedLen: h.boot[i].length, done: false };
+    }
+    t -= typing + hold;
+  }
+  const committed = h.boot.length;
+  const reveal = Math.floor(t / REVEAL_MS);
+  const n = h.rows.length;
+  if (reveal < n) return { bootIdx: 0, typedLen: 0, committed, phase: "tui", reveal, done: false };
+  return {
+    bootIdx: 0,
+    typedLen: 0,
+    committed,
+    phase: "tui",
+    reveal: n,
+    done: t >= n * REVEAL_MS + DWELL_MS,
+  };
+}
+
+/** The spinner index, or -1 when nothing is streaming. */
+function spinAt(cur: Harness, f: Frame): number {
+  const streaming = f.phase === "tui" && f.reveal > 0 && f.reveal < cur.rows.length;
+  return streaming ? Math.floor(Date.now() / SPIN_MS) % SPIN.length : -1;
+}
+
+function useTerminal() {
+  const [h, setH] = useState(0);
+  const [, bump] = useReducer((x: number) => x + 1, 0);
+  const reduced = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const narrow = useMediaQuery(`(max-width: ${NARROW_MAX}px)`);
+  /**
+   * On a phone the window is small enough that a transcript advancing every
+   * 620ms is noise, so the loop doesn't run: the section rests on a finished
+   * session and a tab tap plays that harness once. `playing` is that latch.
+   */
+  const [playing, setPlaying] = useState(false);
+  // Anchored on first render rather than in the effect, so the server and the
+  // hydrating client both compute elapsed ≈ 0 and agree on an empty prompt —
+  // instead of the server rendering a finished session that then snaps to boot.
+  const startedAt = useRef(0);
+  if (startedAt.current === 0) startedAt.current = Date.now();
+  const hRef = useRef(0);
+  hRef.current = h;
+  /** Last frame pushed to React, so a tick that changes nothing doesn't re-render. */
+  const lastKey = useRef("");
+
+  /** Clicking a tab switches immediately and cancels the queued advance. On a
+   *  phone it also starts that harness, since nothing is playing by default. */
+  const select = useCallback(
+    (i: number) => {
+      startedAt.current = Date.now();
+      lastKey.current = "";
+      setH(i);
+      if (narrow && !reduced) setPlaying(true);
+    },
+    [narrow, reduced],
+  );
+
+  const running = !reduced && (!narrow || playing);
 
   useEffect(() => {
-    setReveal(0);
-    if (timer.current) clearInterval(timer.current);
-    timer.current = setInterval(() => {
-      setReveal((r) => {
-        if (r > traceLen) {
-          if (timer.current) clearInterval(timer.current);
-          return r;
+    if (!running) return;
+    startedAt.current = Date.now();
+    lastKey.current = "";
+    const id = setInterval(() => {
+      const cur = HARNESSES[hRef.current];
+      const f = frameAt(cur, Date.now() - startedAt.current);
+      if (f.done) {
+        lastKey.current = "";
+        // A phone plays the harness the reader asked for, once, and stops.
+        if (narrow) setPlaying(false);
+        else {
+          startedAt.current = Date.now();
+          setH((i) => (i + 1) % HARNESSES.length);
         }
-        return r + 1;
-      });
-    }, REVEAL_MS);
-    return () => {
-      if (timer.current) clearInterval(timer.current);
-    };
-  }, [sel, traceLen]);
+        return;
+      }
+      // The tick runs at typing resolution, but most ticks land on the frame
+      // already on screen — only push the ones that actually change something.
+      const key = `${f.phase}|${f.committed}|${f.bootIdx}|${f.typedLen}|${f.reveal}|${spinAt(cur, f)}`;
+      if (key !== lastKey.current) {
+        lastKey.current = key;
+        bump();
+      }
+    }, TICK_MS);
+    return () => clearInterval(id);
+  }, [running, narrow]);
 
-  const shown = cur.trace.slice(0, Math.min(reveal, traceLen));
-  const streaming = reveal <= traceLen;
-  const showResult = reveal > traceLen;
+  const cur = HARNESSES[h];
+  // At rest — reduced motion, or a phone between taps — the window holds a
+  // finished session. That is the frame worth showing statically: the whole
+  // transcript, and a statusline that has actually switched.
+  const frame: Frame = running
+    ? frameAt(cur, Date.now() - startedAt.current)
+    : { bootIdx: 0, typedLen: 0, committed: cur.boot.length, phase: "tui", reveal: cur.rows.length };
+
+  return { h, cur, frame, narrow, select };
+}
+
+/* ── the section ─────────────────────────────────────────────────────────── */
+
+export function TuiDemo() {
+  const { h, cur, frame, narrow, select } = useTerminal();
+
+  const inTui = frame.phase === "tui";
+  const rows = cur.rows.slice(0, frame.reveal);
+  const last = rows.length ? rows[rows.length - 1] : null;
+  const streaming = inTui && frame.reveal > 0 && frame.reveal < cur.rows.length;
+
+  let switches = 0;
+  for (let i = 1; i < rows.length; i++) if (rows[i].tier !== rows[i - 1].tier) switches++;
+
+  const activeTier: Tier | null = last ? last.tier : null;
+  const spin = SPIN[Math.max(0, spinAt(cur, frame))];
+  // Re-measure when the harness changes: `dsh` and `claude` are different widths.
+  const { outer, inner, fit } = useFitToWidth([h, narrow]);
+
+  // codex prints the serving model under its input; pi prints it bottom-right,
+  // where it otherwise prints `unknown`.
+  const after: Seg[][] = cur.after.map((l) => [...l]);
+  const afterRight: Seg[][] = (cur.afterRight ?? []).map((l) => [...l]);
+  if (cur.afterLive) {
+    // `—` is the statusline's placeholder for "this harness has no effort knob";
+    // inline in the harness's own output it would just read as a stray dash.
+    const live = last ? [last.model, last.effort === "—" ? "" : last.effort].join(" ").trim() : "bitrouter/auto";
+    after.push([{ t: `  ${live} · ${cur.cwd}`, c: TERM.dim }]);
+    afterRight.push([]);
+  }
+  if (cur.afterLiveRight) {
+    afterRight[1] = [{ t: last ? last.model : "unknown", c: TERM.dim }];
+  }
 
   return (
     <section className="zed-section">
-      <div className="zed-wrap" style={{ padding: "48px 34px 40px" }}>
-        <div style={{ overflowX: "auto" }}>
-          <div className="zed-term" style={{ minWidth: 780, fontFamily: "var(--font-mono)" }}>
-            {/* titlebar */}
+      {/* Vertical only — `.zed-wrap` owns the horizontal padding, and drops it
+          to 20px under 900px. Hard-coding 34px here cost the terminal 28px of
+          width on a phone, which is 28px it does not have. */}
+      <div className="zed-wrap" style={{ paddingTop: 44, paddingBottom: 44 }}>
+        <div ref={outer} style={{ overflowX: "auto" }}>
+          {/* Occupies the scaled box so the transform doesn't leave a gap. */}
+          <div style={fit ? { width: fit.w, height: fit.h, margin: "0 auto" } : undefined}>
+            <div
+              ref={inner}
+              className="zed-tui-fit"
+              style={
+                fit
+                  ? { transform: `scale(${fit.s})`, transformOrigin: "top left" }
+                  : { margin: "0 auto" }
+              }
+            >
             <div
               style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 12,
-                padding: "9px 14px",
-                background: "var(--z-panel-header)",
-                borderBottom: "1px solid var(--z-rule)",
-                fontSize: 12,
-                color: "var(--z-ink-5)",
+                borderRadius: 10,
+                overflow: "hidden",
+                boxShadow: "0 34px 80px -34px rgba(0,0,0,0.85)",
               }}
             >
-              <span
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: 15,
-                  height: 15,
-                  border: "1px solid var(--z-blue)",
-                  borderRadius: 4,
-                  color: "var(--z-blue)",
-                  fontSize: 9,
-                }}
-              >
-                ≋
-              </span>
-              <span style={{ color: "var(--z-ink-2)" }}>bitrouter</span>
-              <span style={{ color: "var(--z-ink-7)" }}>v0.7</span>
-              <span style={{ color: "var(--z-ink-7)" }}>⑂ main</span>
-              <span
-                style={{
-                  marginLeft: "auto",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 14,
-                  color: "var(--z-ink-6)",
-                }}
-              >
-                <span>{cur.objTag}</span>
-                <span style={{ display: "inline-flex", alignItems: "center", gap: 6, color: "var(--z-green)" }}>
-                  <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--z-green-dot)" }} />
-                  live
-                </span>
-              </span>
-            </div>
-
-            {/* body */}
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "222px minmax(0,1.02fr) minmax(0,1.05fr)",
-                minHeight: 474,
-              }}
-            >
-              {/* sessions rail */}
+              {/* ── macOS titlebar ────────────────────────────────────── */}
               <div
                 style={{
-                  background: "var(--z-panel-header)",
-                  borderRight: "1px solid var(--z-rule)",
                   display: "flex",
-                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: 9,
+                  height: 38,
+                  padding: "0 13px",
+                  background: "#333336",
+                  borderBottom: "1px solid #262628",
                 }}
               >
-                <div
+                <span style={{ width: 12, height: 12, borderRadius: "50%", background: "#ff5f57" }} />
+                <span style={{ width: 12, height: 12, borderRadius: "50%", background: "#febc2e" }} />
+                <span style={{ width: 12, height: 12, borderRadius: "50%", background: "#28c840" }} />
+                {/* Finder proxy icon */}
+                <span
                   style={{
-                    fontSize: 9.5,
-                    letterSpacing: "0.18em",
-                    textTransform: "uppercase",
-                    color: "var(--z-ink-7)",
-                    padding: "12px 14px 10px",
-                    display: "flex",
-                    alignItems: "center",
+                    display: "inline-block",
+                    width: 13,
+                    height: 11,
+                    borderRadius: 2,
+                    background: "#5aa9f8",
+                    marginLeft: 14,
+                    flex: "0 0 auto",
+                  }}
+                />
+                <span
+                  style={{
+                    fontFamily: "var(--font-sans)",
+                    fontSize: 12.5,
+                    fontWeight: 600,
+                    color: "#d8d8d8",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
                   }}
                 >
-                  sessions <span style={{ marginLeft: "auto", color: "var(--z-ink-8)" }}>{SESSIONS.length}</span>
-                </div>
-                {SESSIONS.map((s, i) => (
-                  <button
-                    key={s.name}
-                    onClick={() => setSel(i)}
-                    style={{
-                      textAlign: "left",
-                      border: "none",
-                      cursor: "pointer",
-                      padding: "8px 14px",
-                      background: i === sel ? "var(--z-panel-sel)" : "transparent",
-                      boxShadow: i === sel ? "inset 2px 0 0 var(--z-blue)" : "none",
-                    }}
-                  >
-                    <div style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 12, color: i === sel ? "#eef1f4" : "#a7adb8" }}>
-                      <span style={{ width: 6, height: 6, borderRadius: "50%", background: s.dot, flex: "0 0 auto" }} />
-                      <span style={{ flex: "1 1 auto" }}>{s.name}</span>
-                      <span style={{ fontSize: 10, color: s.costColor }}>{s.cost}</span>
-                    </div>
-                    <div style={{ fontSize: 10, color: "var(--z-ink-7)", marginTop: 3, paddingLeft: 13 }}>{s.sub}</div>
-                  </button>
-                ))}
-                <div
-                  style={{
-                    marginTop: "auto",
-                    padding: "11px 14px",
-                    borderTop: "1px solid var(--z-rule)",
-                    fontSize: 10,
-                    color: "var(--z-ink-7)",
-                  }}
-                >
-                  registry <span style={{ color: "var(--z-ink-6)" }}>12 models · 6 mcp · 9 skills</span>
-                </div>
+                  {cur.title}
+                </span>
               </div>
 
-              {/* routed trace */}
-              <div style={{ borderRight: "1px solid var(--z-rule)", display: "flex", flexDirection: "column" }}>
-                <div style={{ padding: "11px 15px", borderBottom: "1px solid var(--z-rule-faint)", display: "flex", alignItems: "center", gap: 10 }}>
-                  <span style={{ fontSize: 11, color: "var(--z-ink-2)" }}>{cur.name}</span>
-                  <span style={{ fontSize: 10, color: "var(--z-blue)", border: "1px solid #2d3a55", borderRadius: 4, padding: "2px 7px" }}>{cur.objTag}</span>
-                  <span style={{ marginLeft: "auto", fontSize: 10, color: "var(--z-ink-6)" }}>{cur.calls}</span>
-                </div>
-                <div style={{ padding: "12px 15px 4px", fontSize: 11.5, color: "var(--z-ink-5)" }}>{cur.goal}</div>
+              {/* ── tab bar ───────────────────────────────────────────── */}
+              <div style={{ display: "flex", background: "#232326", borderBottom: "1px solid #17171a" }}>
+                {HARNESSES.map((x, i) => {
+                  const on = i === h;
+                  return (
+                    <button
+                      key={x.id}
+                      onClick={() => select(i)}
+                      aria-current={on}
+                      title={`${x.tab} — ${x.cwd}`}
+                      className="zed-tui-tab"
+                      style={{
+                        flex: "1 1 0",
+                        minWidth: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 7,
+                        padding: "7px 12px",
+                        cursor: "pointer",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 11.5,
+                        textAlign: "left",
+                        border: "none",
+                        borderRight: i === HARNESSES.length - 1 ? "none" : "1px solid #17171a",
+                        background: on ? x.bg : "transparent",
+                        color: on ? TERM.body : "#6e6e6e",
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: 5,
+                          height: 5,
+                          borderRadius: "50%",
+                          flex: "0 0 auto",
+                          background: on ? "#28c840" : "#3a3a3a",
+                        }}
+                      />
+                      <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {x.tab}
+                        <span className="zed-tui-cwd"> — {x.cwd}</span>
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
 
-                <div style={{ padding: "8px 15px", fontSize: 12, lineHeight: 1.9, flex: 1 }}>
-                  <div style={{ fontSize: 9.5, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--z-ink-7)", marginBottom: 9 }}>
-                    routed trace
-                  </div>
-                  {shown.map((t, i) => {
-                    const k = TRACE_KIND[t.kind];
-                    return (
-                      <div key={i} style={{ display: "flex", alignItems: "baseline", gap: 8, whiteSpace: "nowrap" }}>
-                        <span style={{ color: k.color, fontSize: 10, letterSpacing: "0.04em", flex: "0 0 auto" }}>{k.tag}</span>
-                        <span style={{ color: "var(--z-ink-5)", flex: "1 1 auto", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>{t.action}</span>
-                        <span style={{ color: "var(--z-ink-7)", flex: "0 0 auto" }}>→</span>
-                        <span style={{ color: t.esc ? "var(--z-amber)" : "var(--z-ink-2)", flex: "0 0 auto" }}>{t.target}</span>
-                        <span style={{ color: "var(--z-ink-7)", fontSize: 11, flex: "0 0 auto", marginLeft: 6 }}>
-                          {t.esc ? "↑ " : ""}
-                          {t.meta}
-                        </span>
-                      </div>
-                    );
-                  })}
-                  {streaming && (
-                    <div>
-                      <Cursor style={{ transform: "translateY(0.12em)" }} />
-                    </div>
-                  )}
-                  {showResult && <div style={{ color: "var(--z-green)", marginTop: 7 }}>{cur.result}</div>}
-                </div>
-
-                <div style={{ borderTop: "1px solid var(--z-rule-faint)", padding: "12px 15px 14px" }}>
-                  <div style={{ fontSize: 9.5, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--z-ink-7)", marginBottom: 10 }}>
-                    resources · this run
-                  </div>
-                  {cur.ledger.map((r) => (
-                    <div key={r.label} style={{ display: "flex", gap: 12, alignItems: "baseline", marginBottom: 8, fontSize: 11 }}>
-                      <span style={{ width: 58, flex: "0 0 auto", color: "var(--z-blue)", fontSize: 10, letterSpacing: "0.06em" }}>{r.label}</span>
-                      <span style={{ color: "var(--z-ink-4)" }}>{r.value}</span>
+              {/* ── terminal body ─────────────────────────────────────── */}
+              <div
+                className="zed-tui-body"
+                style={{
+                  background: cur.bg,
+                  display: "flex",
+                  flexDirection: "column",
+                  padding: "12px 16px 10px",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 12.5,
+                  lineHeight: 1.62,
+                  overflow: "hidden",
+                }}
+              >
+                {/* Clips rather than colliding with the input widget below if a
+                    harness ever outgrows the body. */}
+                <div style={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+                  {/* shell prologue */}
+                  {cur.boot.slice(0, frame.committed).map((t, i) => (
+                    <div key={i} className="zed-tui-line" style={{ whiteSpace: "pre" }}>
+                      <span style={{ color: TERM.bright, fontWeight: 600 }}>{SHELL_PROMPT}</span>
+                      <span style={{ color: TERM.bright }}> {t}</span>
                     </div>
                   ))}
-                </div>
-              </div>
+                  {!inTui && (
+                    <div className="zed-tui-line" style={{ whiteSpace: "pre" }}>
+                      <span style={{ color: TERM.bright, fontWeight: 600 }}>{SHELL_PROMPT}</span>
+                      <span style={{ color: TERM.bright }}>
+                        {" "}
+                        {(cur.boot[frame.bootIdx] ?? "").slice(0, frame.typedLen)}
+                      </span>
+                      <span className="zed-tui-caret" style={{ background: "#d4d4d4" }} />
+                    </div>
+                  )}
 
-              {/* policy pane */}
-              <div style={{ display: "flex", flexDirection: "column", fontSize: 12.5, lineHeight: 1.9 }}>
-                <div style={{ padding: "11px 16px", fontSize: 11, color: "var(--z-ink-6)", borderBottom: "1px solid var(--z-rule-faint)", display: "flex", alignItems: "center" }}>
-                  policy.yaml <span style={{ marginLeft: "auto", color: "var(--z-ink-7)" }}>{cur.policyVer}</span>
+                  {inTui && (
+                    <div>
+                      {/* harness header */}
+                      <div
+                        style={
+                          cur.boxedHeader
+                            ? {
+                                display: "flex",
+                                alignItems: "flex-start",
+                                marginTop: 10,
+                                padding: "10px 14px",
+                                border: "1px solid #5a5a5a",
+                                borderRadius: 6,
+                                alignSelf: "flex-start",
+                              }
+                            : { display: "flex", alignItems: "flex-start", marginTop: 10 }
+                        }
+                      >
+                        {cur.mascot && (
+                          <div
+                            aria-hidden
+                            style={{
+                              display: "grid",
+                              gridTemplateColumns: "repeat(7, 6px)",
+                              gridAutoRows: 6,
+                              gap: 1,
+                              flex: "0 0 auto",
+                              marginRight: 14,
+                              marginTop: 2,
+                            }}
+                          >
+                            {MASCOT.join("")
+                              .split("")
+                              .map((c, i) => (
+                                <span
+                                  key={i}
+                                  style={{ width: 6, height: 6, background: c === "1" ? TERM.claude : "transparent" }}
+                                />
+                              ))}
+                          </div>
+                        )}
+                        <div style={{ minWidth: 0 }}>
+                          {cur.header.map((l, i) => (
+                            <Line key={i} segs={l} />
+                          ))}
+                        </div>
+                      </div>
+
+                      {cur.notes.map((l, i) => (
+                        <div key={i} style={{ marginTop: 6 }}>
+                          <Line segs={l} />
+                        </div>
+                      ))}
+
+                      <div style={{ height: 10 }} />
+
+                      {/* transcript */}
+                      {rows.map((r, i) => (
+                        <div key={i}>
+                          <div style={{ display: "flex", gap: 8, alignItems: "baseline", whiteSpace: "pre" }}>
+                            <span
+                              style={{
+                                flex: "0 0 auto",
+                                width: 10,
+                                color: r.user
+                                  ? cur.accent
+                                  : r.think
+                                    ? TERM.amber
+                                    : r.ok
+                                      ? TERM.ok
+                                      : TERM.faint,
+                              }}
+                            >
+                              {r.bullet}
+                            </span>
+                            {/* The user's own row starts hard left — no label column. */}
+                            {cur.labelW > 0 && !r.user && (
+                              <span className="zed-tui-label" style={{ flex: "0 0 auto", width: cur.labelW, color: TERM.dim }}>
+                                {r.label ?? ""}
+                              </span>
+                            )}
+                            <span
+                              style={{
+                                flex: "1 1 auto",
+                                minWidth: 0,
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                color: r.user ? TERM.bright : TERM.body,
+                                fontStyle: r.think ? "italic" : "normal",
+                              }}
+                            >
+                              {r.text}
+                            </span>
+                            <span style={{ flex: "0 0 auto", color: r.ok ? TERM.ok : TERM.faint }}>{r.meta ?? ""}</span>
+                          </div>
+                          {r.sub && (
+                            <div style={{ whiteSpace: "pre", paddingLeft: 18, color: TERM.faint }}>{r.sub}</div>
+                          )}
+                        </div>
+                      ))}
+
+                      {streaming && (
+                        <div style={{ display: "flex", gap: 8, alignItems: "baseline", whiteSpace: "pre" }}>
+                          <span style={{ color: cur.accent, flex: "0 0 auto", width: 10 }}>{spin}</span>
+                          <span style={{ color: TERM.faint, fontStyle: "italic" }}>{cur.working}</span>
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
-                <div style={{ display: "grid", gridTemplateColumns: "30px 1fr", padding: "10px 0 6px", flex: 1 }}>
-                  <div style={{ textAlign: "right", paddingRight: 10, color: "var(--z-ink-8)", userSelect: "none" }}>
-                    {cur.policy.map((_, i) => (
-                      <div key={i}>{i + 1}</div>
+
+                {/* the harness's own input widget, pinned to the bottom */}
+                {inTui && (
+                  <div>
+                    {cur.input.rule && <div style={{ height: 1, background: "#4a4a4a", margin: "8px 0" }} />}
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        padding: cur.input.boxed ? "9px 12px" : "2px 0",
+                        background: cur.input.boxed ? cur.input.boxBg : "transparent",
+                        borderLeft: cur.input.bar ? `3px solid ${cur.input.bar}` : "none",
+                        marginTop: cur.input.boxed ? 8 : 0,
+                      }}
+                    >
+                      {cur.input.glyph && <span style={{ color: TERM.dim, flex: "0 0 auto" }}>{cur.input.glyph}</span>}
+                      <span className="zed-tui-caret" style={{ background: "#8a8a8a", flex: "0 0 auto" }} />
+                      <span
+                        style={{
+                          color: "#6e6e6e",
+                          flex: "1 1 auto",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {cur.input.hint}
+                      </span>
+                    </div>
+                    {cur.input.ruleBelow && <div style={{ height: 1, background: "#4a4a4a", margin: "8px 0" }} />}
+                    {after.map((l, i) => (
+                      <div
+                        key={i}
+                        style={{ display: "flex", justifyContent: "space-between", gap: 16, marginTop: 4, fontSize: 12 }}
+                      >
+                        <span style={{ whiteSpace: "pre" }}>
+                          {l.map((s, j) => (
+                            <span key={j} style={segStyle(s)}>
+                              {s.t}
+                            </span>
+                          ))}
+                        </span>
+                        <span style={{ whiteSpace: "pre" }}>
+                          {(afterRight[i] ?? []).map((s, j) => (
+                            <span key={j} style={segStyle(s)}>
+                              {s.t}
+                            </span>
+                          ))}
+                        </span>
+                      </div>
                     ))}
                   </div>
-                  <div style={{ paddingRight: 16 }}>{cur.policy.map((l, i) => highlightYamlLine(l, i))}</div>
-                </div>
-                <div style={{ borderTop: "1px solid var(--z-rule-faint)", padding: "12px 16px 14px" }}>
-                  <div style={{ color: "var(--z-ink-bright)", fontSize: 12, marginBottom: 10 }}>{cur.summary}</div>
-                  <div style={{ fontSize: 10, color: "var(--z-ink-6)", marginBottom: 5 }}>{cur.beforeLabel}</div>
-                  <div style={{ height: 5, background: "var(--z-rule-faint)" }}>
-                    <i style={{ display: "block", height: "100%", width: cur.beforeW, background: "#5b626d" }} />
-                  </div>
-                  <div style={{ fontSize: 10, color: "var(--z-ink-2)", margin: "9px 0 5px" }}>{cur.afterLabel}</div>
-                  <div style={{ height: 5, background: "var(--z-rule-faint)" }}>
-                    <i style={{ display: "block", height: "100%", width: cur.afterW, background: "var(--z-blue)" }} />
-                  </div>
-                </div>
+                )}
+              </div>
+
+              {/* ── BitRouter statusline — the only non-native element ── */}
+              <div
+                className="zed-tui-status"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "0 14px",
+                  background: "var(--z-blue-chip-bg)",
+                  borderTop: "1px solid var(--z-blue-chip-border)",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 11.5,
+                  color: "var(--z-ink-6)",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                <span className="zed-tui-id" style={{ color: "var(--z-blue)" }}>
+                  bitrouter/auto
+                </span>
+                <span className="zed-tui-sep" style={{ color: "var(--z-blue-chip-border)" }}>
+                  │
+                </span>
+                <span className="zed-tui-rungs" style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                  {cur.ladder.map((r) => {
+                    const on = r.name === activeTier;
+                    return (
+                      <span
+                        key={r.name}
+                        style={{
+                          padding: "1px 6px",
+                          borderRadius: 3,
+                          letterSpacing: "0.04em",
+                          color: on ? TIER_COLOR[r.name] : "var(--z-ink-7)",
+                          background: on ? "rgba(255,255,255,.06)" : "transparent",
+                          transition: "color .2s ease, background .2s ease",
+                        }}
+                      >
+                        {r.name}
+                      </span>
+                    );
+                  })}
+                </span>
+                <span className="zed-tui-sep" style={{ color: "var(--z-blue-chip-border)" }}>
+                  │
+                </span>
+                <span className="zed-tui-model" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <span style={{ color: "var(--z-ink-2)" }}>{last ? last.model : "waiting for the session"}</span>
+                  <span style={{ color: "var(--z-ink-7)" }}>·</span>
+                  <span>{last ? last.effort : "—"}</span>
+                </span>
+                <span className="zed-tui-switches" style={{ marginLeft: "auto", color: "var(--z-ink-7)" }}>
+                  {switches ? `switched ${switches}× this session` : last ? "no switch yet" : ""}
+                </span>
               </div>
             </div>
 
-            {/* footer keybinds */}
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 16,
-                background: "var(--z-panel-header)",
-                borderTop: "1px solid var(--z-rule)",
-                padding: "7px 14px",
-                fontSize: 11,
-                color: "var(--z-ink-6)",
-                flexWrap: "wrap",
-              }}
-            >
-              <span><span style={{ color: "var(--z-ink-4)" }}>↑↓</span> session</span>
-              <span><span style={{ color: "var(--z-ink-4)" }}>enter</span> inspect</span>
-              <span><span style={{ color: "var(--z-ink-4)" }}>tab</span> pane</span>
-              <span><span style={{ color: "var(--z-ink-4)" }}>o</span> objective</span>
-              <span><span style={{ color: "var(--z-ink-4)" }}>/</span> filter</span>
-              <span style={{ marginLeft: "auto", color: "var(--z-ink-7)" }}>{FOOTER_STAT}</span>
+            <div style={{ textAlign: "center", marginTop: 18 }}>
+              <div style={{ fontSize: 12.5, color: "var(--z-ink-4)" }}>
+                Five tiers, set once in <span style={{ color: "var(--z-ink-2)" }}>bitrouter.yaml</span> — every harness
+                only ever sees the id <span style={{ color: "var(--z-blue)" }}>bitrouter/auto</span>.
+              </div>
+              <div style={{ fontSize: 11.5, color: "var(--z-ink-7)", marginTop: 7 }}>
+                {cur.id} · {cur.workflow} · {cur.tierShape}
+              </div>
+              {narrow && (
+                <div style={{ fontSize: 11.5, color: "var(--z-ink-6)", marginTop: 9 }}>
+                  tap a tab to run that session
+                </div>
+              )}
+            </div>
             </div>
           </div>
-        </div>
-        <div style={{ textAlign: "center", fontFamily: "var(--font-mono)", fontSize: 11.5, color: "var(--z-ink-7)", marginTop: 14 }}>
-          ↑ click a session — watch how BitRouter routed models, MCP tools, skills &amp; harness for that workflow
         </div>
       </div>
     </section>

--- a/components/landing/zed/zed.css
+++ b/components/landing/zed/zed.css
@@ -279,6 +279,78 @@
   animation: zed-blink 1.05s steps(1) infinite;
 }
 
+/* ── Hero terminal (tui-demo) ──
+   Two layouts. At full size the window is a faithful 920px macOS terminal. The
+   interior's real floor is ~410px (the widest transcript row) — everything
+   above that is chrome, so below `--tui-narrow` the chrome reflows instead of
+   the window shrinking: tabs drop their cwd, the statusline stacks, and the
+   decorative harness output (pi's keybind line, codex's tip) truncates.
+   tui-demo.tsx then scales whatever is left to fit its scroller. */
+.zed-tui-fit {
+  min-width: 920px;
+  max-width: 1000px;
+}
+.zed-tui-body {
+  height: 452px;
+}
+.zed-tui-status {
+  height: 28px;
+}
+@media (max-width: 699px) {
+  .zed-tui-fit {
+    min-width: 380px;
+    max-width: 560px;
+  }
+  /* No height override here: the reflow is horizontal only, so the transcript
+     still needs the full 452px. Shrinking it collides the last rows with the
+     harness's input widget. */
+  .zed-tui-cwd {
+    display: none;
+  }
+  /* Size tabs to their binary name instead of five equal shares, which is too
+     narrow for `opencode`; they still grow to fill the bar. */
+  .zed-tui-tab {
+    flex: 1 1 auto !important;
+    padding-left: 9px !important;
+    padding-right: 9px !important;
+  }
+  .zed-tui-line {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  /* Wide enough for `search`, the longest label. */
+  .zed-tui-label {
+    width: 48px !important;
+  }
+  /* Three explicit rows rather than free wrapping, which stranded the `│`
+     separators at the end of a line: id + switch count, then the rungs, then
+     the serving model. */
+  .zed-tui-status {
+    height: auto;
+    flex-wrap: wrap;
+    padding-top: 6px;
+    padding-bottom: 7px;
+    row-gap: 2px;
+  }
+  .zed-tui-sep {
+    display: none;
+  }
+  .zed-tui-id {
+    order: 0;
+  }
+  .zed-tui-switches {
+    order: 0;
+  }
+  .zed-tui-rungs {
+    order: 1;
+    flex-basis: 100%;
+  }
+  .zed-tui-model {
+    order: 2;
+    flex-basis: 100%;
+  }
+}
+
 /* ── Blinking cursor ── */
 .zed-ck {
   display: inline-block;
@@ -286,6 +358,15 @@
   height: 1.05em;
   transform: translateY(0.16em);
   background: var(--z-blue);
+  animation: zed-blink 1.05s steps(1) infinite;
+}
+/* Block caret inside the hero terminal. Colour is set per call site, because
+   the shell caret and a harness's input caret are different greys. */
+.zed-tui-caret {
+  display: inline-block;
+  width: 0.6em;
+  height: 1.02em;
+  transform: translateY(0.16em);
   animation: zed-blink 1.05s steps(1) infinite;
 }
 @keyframes zed-blink {
@@ -342,7 +423,8 @@
   .zed-marq-track {
     animation: none;
   }
-  .zed-ck {
+  .zed-ck,
+  .zed-tui-caret {
     animation: none;
   }
 }


### PR DESCRIPTION
Replaces the three-pane session/policy panel on the landing page with a single macOS terminal window showing BitRouter switching effort tier and model **inside** a coding session, across five native harnesses. Implements the `Landing Hero TUI (mac terminal)` design.

## What it says

One id — `bitrouter/auto` — is configured once per harness. Inside the session the router moves between five tiers (`low` `medium` `high` `extra` `max`) which resolve to a different model and/or reasoning effort. The user presses nothing: every row is the harness's own output, and the BitRouter statusline along the bottom is the only non-native element in the window.

| harness | workflow | tier shape |
| --- | --- | --- |
| claude-code | Debugging | 1 model, 5 reasoning efforts |
| codex | Code generation | 2 models on one ladder |
| opencode | Repo scanning | 4 models, one per rung |
| pi | SQL & database | 3 models |
| deepseek-harness | Frontend & UI | 1 model, `reasoningEfforts` |

## Scope

- `components/landing/zed/tui-demo.tsx` — rewritten.
- `components/landing/zed/data.ts` — `SESSIONS`/`TRACE_KIND`/`FOOTER_STAT` replaced with `HARNESSES`, `TERM`, `TIERS`/`TIER_COLOR`, `MASCOT`, `SHELL_PROMPT`. `HERO`, `BYO`, `METRICS`, `BENCH_*`, `CAPABILITIES`, `STEPS`, `FAQS` untouched.
- `components/landing/zed/zed.css` — terminal sizing, the narrow-viewport rules, and a caret class.

`hero.tsx` and `hero-quickstart.tsx` are not touched: the hero in the mock is identical to what already ships. Everything stays on the `--z-*` tokens except the terminal interior, which uses real terminal colours.

## Corrections to the mock

The design's identifiers were illustrative. These are checked against the shipped docs and the registry snapshot:

- **`bitrouter/code` → `bitrouter/auto`.** `bitrouter/code` does not exist; the docs are explicit that the virtual id is `bitrouter/auto` and resolves against a policy. This appears in the statusline, the caption, and every harness's setup.
- **Model ids swapped for real registry ids:** `gpt-5-codex`→`openai/gpt-5.4`, `qwen-3.7-turbo`→`qwen/qwen3.6-flash`, `qwen-3.7`→`qwen/qwen3.7-plus`, `minimax/m3`→`minimax/minimax-m3`, `deepseek-v4`→`deepseek/deepseek-v4-pro`. `claude-opus-4.8`, `openai/gpt-5.5` and `moonshotai/kimi-k2.7-code` were already real.
- **pi's prologue** typed `/model bitrouter/code` at the *shell* prompt — a TUI command in the wrong place. Dropped; pi's bottom-right live model carries the routing instead.
- **claude's window title** said `claude ▸ claude.exe`, not a macOS path. Uses the `node ~/.local/bin/claude` form the codex title already used.

`deepseek-harness` has no screenshot, unlike the other four, and carries an explicit `UNVERIFIED CHROME` comment in the data.

## Animation

Driven off elapsed `Date.now()` deltas rather than tick counts, so a throttled background tab resumes on the right frame instead of stretching the prologue — confirmed working under a tab where `setInterval` was clamped to ~1s. Ticks that do not change the frame do not re-render. The clock is anchored on first render so SSR and hydration agree on an empty prompt (no snap from a finished session to boot). `prefers-reduced-motion` holds a finished session with no loop.

## Mobile

Below 700px the interior reflows rather than the window shrinking — the transcript's real floor is ~410px, so everything above that is chrome: tabs drop their cwd and size to content, the statusline stacks to three explicit rows, and decorative harness output (pi's keybind line, codex's tip) truncates. A `ResizeObserver` then scales whatever is left to fit, in both bands — 0.90 at 900px, 0.88 at 375px (~11px effective text). Autoplay is paused below the breakpoint: the section rests on a finished session and a tab tap plays that harness once.

## Verification

Checked in the browser at 375 / 820 / 900 / 1280px:

- All five harnesses render their real chrome; window height is constant at 550px with zero content overflow, and the loop advances unattended.
- Tab selection switches immediately and cancels the queued advance.
- On mobile the page does not scroll horizontally, no tab label truncates, and tap-to-play runs once without advancing.
- `tsc --noEmit` clean for these files; no hydration warnings.

**Not verified:** live window resizing across the 700px breakpoint. `resize_window` in this environment changes `innerWidth` but fires neither `resize` nor `matchMedia change` (instrumented: zero of both), so each band was verified by reloading at that width, which exercises the real mount path. A `resize` fallback is in place alongside the `change` listener; dragging a real window across 700px is worth one manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
